### PR TITLE
feat: Chat widget only, dedicated chat page, reasoning and sources in UI

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -47,5 +47,8 @@ export async function POST(req: Request) {
     stopWhen: stepCountIs(5),
   });
 
-  return result.toUIMessageStreamResponse();
+  return result.toUIMessageStreamResponse({
+    sendReasoning: true,
+    sendSources: true,
+  });
 }

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,0 +1,9 @@
+import { ChatPageContent } from "@/components/chat/chat-page-content";
+
+export default function ChatPage() {
+  return (
+    <div className="flex flex-1 flex-col">
+      <ChatPageContent />
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,6 @@ import { Inter, JetBrains_Mono, Playfair_Display } from "next/font/google";
 import "./globals.css";
 import { ChatContextProvider } from "@/components/chat/chat-context-provider";
 import { ChatPanel } from "@/components/chat/chat-panel";
-import { CvUploadSidebar } from "@/components/cv-upload-sidebar";
 import { SidebarLayout } from "@/components/sidebar-layout";
 import { Providers } from "./providers";
 
@@ -40,7 +39,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <ChatContextProvider>
             <SidebarLayout>{children}</SidebarLayout>
             <ChatPanel />
-            <CvUploadSidebar />
           </ChatContextProvider>
         </Providers>
       </body>

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Activity, Briefcase, GalleryVerticalEnd, LayoutDashboard, Users, Zap } from "lucide-react";
+import {
+  Activity,
+  Briefcase,
+  GalleryVerticalEnd,
+  LayoutDashboard,
+  MessageSquare,
+  Users,
+  Zap,
+} from "lucide-react";
 import type * as React from "react";
 
 import { NavMain } from "@/components/nav-main";
@@ -81,6 +89,11 @@ const data = {
       title: "Scraper Analytics",
       url: "/scraper",
       icon: Activity,
+    },
+    {
+      title: "Chat",
+      url: "/chat",
+      icon: MessageSquare,
     },
   ],
 };

--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { getToolName, isToolUIPart, type UIMessage } from "ai";
-import { Bot } from "lucide-react";
+import { Bot, Brain, ExternalLink, FileText, Loader2 } from "lucide-react";
+import { useState } from "react";
 import {
   Conversation,
   ConversationContent,
@@ -26,6 +27,64 @@ const EXAMPLE_PROMPTS = [
   "Hoeveel pending matches zijn er?",
   "Start de Flextender scraper",
 ];
+
+function ReasoningBlock({ text, state }: { text: string; state?: "streaming" | "done" }) {
+  const hasContent = text.length > 0;
+  const [expanded, setExpanded] = useState(hasContent || state === "streaming");
+
+  if (!hasContent && state !== "streaming") return null;
+
+  return (
+    <div className="my-2 rounded-lg border border-border bg-muted/50">
+      <button
+        type="button"
+        onClick={() => setExpanded((e) => !e)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm font-medium text-muted-foreground hover:bg-muted/50"
+      >
+        <Brain className="h-4 w-4 shrink-0" />
+        <span>Redenering</span>
+        {state === "streaming" && <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin" />}
+        <span className="ml-auto text-xs">{expanded ? "Inklappen" : "Uitklappen"}</span>
+      </button>
+      {expanded && (
+        <div className="border-t border-border px-3 py-2">
+          <p className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">
+            {text}
+            {state === "streaming" && (
+              <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-primary align-middle" />
+            )}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SourceUrlBlock({ url, title }: { url: string; title: string }) {
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="my-1 flex items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+    >
+      <ExternalLink className="h-3.5 w-3.5 shrink-0" />
+      <span className="truncate">{title}</span>
+    </a>
+  );
+}
+
+function SourceDocumentBlock({ title, mediaType }: { title: string; mediaType: string }) {
+  return (
+    <div className="my-1 flex items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+      <FileText className="h-3.5 w-3.5 shrink-0" />
+      <span className="truncate">{title}</span>
+      {mediaType && (
+        <span className="rounded bg-background px-1.5 py-0.5 text-[10px]">{mediaType}</span>
+      )}
+    </div>
+  );
+}
 
 export function ChatMessages({ messages, status, onSuggestion }: Props) {
   if (messages.length === 0) {
@@ -69,6 +128,53 @@ export function ChatMessages({ messages, status, onSuggestion }: Props) {
                     );
                   }
                   return <MessageResponse key={partKey}>{part.text}</MessageResponse>;
+                }
+
+                if (part.type === "reasoning") {
+                  const reasoningPart = part as {
+                    type: "reasoning";
+                    text: string;
+                    state?: "streaming" | "done";
+                  };
+                  return (
+                    <ReasoningBlock
+                      key={partKey}
+                      text={reasoningPart.text}
+                      state={reasoningPart.state}
+                    />
+                  );
+                }
+
+                if (part.type === "source-url") {
+                  const sourcePart = part as {
+                    type: "source-url";
+                    sourceId: string;
+                    url: string;
+                    title?: string;
+                  };
+                  return (
+                    <SourceUrlBlock
+                      key={partKey}
+                      url={sourcePart.url}
+                      title={sourcePart.title ?? sourcePart.url}
+                    />
+                  );
+                }
+
+                if (part.type === "source-document") {
+                  const docPart = part as {
+                    type: "source-document";
+                    sourceId: string;
+                    mediaType: string;
+                    title: string;
+                  };
+                  return (
+                    <SourceDocumentBlock
+                      key={partKey}
+                      title={docPart.title}
+                      mediaType={docPart.mediaType}
+                    />
+                  );
                 }
 
                 if (isToolUIPart(part)) {

--- a/components/chat/chat-page-content.tsx
+++ b/components/chat/chat-page-content.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport } from "ai";
+import { useCallback } from "react";
+import {
+  PromptInput,
+  PromptInputFooter,
+  type PromptInputMessage,
+  PromptInputSubmit,
+  PromptInputTextarea,
+} from "@/src/components/ai-elements/prompt-input";
+import { useChatContext } from "./chat-context-provider";
+import { ChatMessages } from "./chat-messages";
+
+export function ChatPageContent() {
+  const ctx = useChatContext();
+
+  const { messages, sendMessage, status, stop } = useChat({
+    transport: new DefaultChatTransport({
+      api: "/api/chat",
+      body: {
+        context: {
+          route: ctx.route,
+          entityId: ctx.entityId,
+          entityType: ctx.entityType,
+        },
+      },
+    }),
+  });
+
+  const handleSubmit = useCallback(
+    (message: PromptInputMessage) => {
+      const text = message.text.trim();
+      if (!text) return;
+      sendMessage({ text });
+    },
+    [sendMessage],
+  );
+
+  return (
+    <div className="flex h-[calc(100vh-var(--sidebar-height,0px))] flex-col">
+      <header className="flex h-12 shrink-0 items-center border-b border-border px-4">
+        <span className="text-sm font-semibold text-foreground">Motian AI</span>
+      </header>
+
+      <ChatMessages
+        messages={messages}
+        status={status}
+        onSuggestion={(text) => sendMessage({ text })}
+      />
+
+      <div className="border-t border-border p-3">
+        <PromptInput onSubmit={handleSubmit}>
+          <PromptInputTextarea placeholder="Stel een vraag..." />
+          <PromptInputFooter>
+            <div />
+            <PromptInputSubmit status={status} onStop={stop} />
+          </PromptInputFooter>
+        </PromptInput>
+      </div>
+    </div>
+  );
+}

--- a/components/chat/chat-panel.tsx
+++ b/components/chat/chat-panel.tsx
@@ -3,6 +3,7 @@
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import { MessageSquare, X } from "lucide-react";
+import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import {
   PromptInput,
@@ -15,6 +16,7 @@ import { useChatContext } from "./chat-context-provider";
 import { ChatMessages } from "./chat-messages";
 
 export function ChatPanel() {
+  const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const ctx = useChatContext();
 
@@ -58,6 +60,8 @@ export function ChatPanel() {
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [handleKeyDown]);
+
+  if (pathname === "/chat") return null;
 
   return (
     <>


### PR DESCRIPTION
## Summary
- **Single global widget**: Removed CV upload sidebar from root layout; the only floating widget is the chat (MessageSquare FAB).
- **Dedicated chat page**: New `/chat` route with full-page chat; sidebar includes a "Chat" nav item.
- **No duplicate chat on /chat**: Floating chat panel is hidden when pathname is `/chat`.
- **AI Elements + reasoning/sources**: Chat API streams reasoning and sources; `ChatMessages` renders:
  - **Reasoning**: Collapsible "Redenering" block (Brain icon, streaming state).
  - **Sources**: `source-url` as links, `source-document` as document chips.
  - **Tools**: Unchanged; tool calls still shown via `ChatToolCall`.

## Files changed
- `app/layout.tsx` — remove `CvUploadSidebar`
- `app/chat/page.tsx` — new chat page
- `components/chat/chat-page-content.tsx` — full-page chat client component
- `components/chat/chat-panel.tsx` — hide on `/chat`
- `components/chat/chat-messages.tsx` — ReasoningBlock, SourceUrlBlock, SourceDocumentBlock
- `components/app-sidebar.tsx` — Chat nav item
- `app/api/chat/route.ts` — `sendReasoning: true`, `sendSources: true`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated chat page with an interactive messaging interface.
  * Messages now display reasoning, source URLs, and referenced documents.
  * Added Chat navigation option in the sidebar.
  * Chat API now returns reasoning and source information with responses.

* **Removed Features**
  * Removed the CV upload sidebar component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->