### PR TITLE
feat: expose API externally and add Scalar docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,13 @@ MOTIA_API_URL=http://localhost:3000
 
 # Next.js URL (voor cache revalidatie vanuit Motia steps)
 NEXT_URL=http://localhost:3001
+PUBLIC_API_BASE_URL=http://localhost:3001
+HOSTNAME=0.0.0.0
+PORT=3001
+
+# Externe API toegang
+ALLOWED_ORIGINS=http://localhost:3001,http://127.0.0.1:3001
+API_SECRET=vervang_dit_met_een_lang_geheim_token
 
 # Encryptie (genereer met: openssl rand -base64 32)
 ENCRYPTION_KEY=jouw_encryptie_sleutel_hier

--- a/Justfile
+++ b/Justfile
@@ -8,11 +8,11 @@ default:
 
 # Clean up ports
 cleanup-ports:
-	-npx -y kill-port 3001
+	-npx -y kill-port ${PORT:-3001}
 
 # Start the Next.js development server
 dev: cleanup-ports
-	pnpm next dev --port 3001
+	pnpm next dev --hostname ${HOSTNAME:-0.0.0.0} --port ${PORT:-3001}
 
 # ── Testing ──────────────────────────────────────
 

--- a/README.en.md
+++ b/README.en.md
@@ -785,6 +785,8 @@ X_AI_API_KEY=xai-...
 
 # Security
 ENCRYPTION_KEY=...   # openssl rand -base64 32
+API_SECRET=...       # Bearer token for external API clients
+ALLOWED_ORIGINS=http://localhost:3001,http://127.0.0.1:3001
 
 # Sentry (error tracking)
 SENTRY_DSN=https://xxx@xxx.ingest.sentry.io/xxx
@@ -800,6 +802,13 @@ SLACK_CHANNEL_ID=C0...
 LIVEKIT_URL=wss://your-project.livekit.cloud
 LIVEKIT_API_KEY=API...
 LIVEKIT_API_SECRET=...
+
+# Public API / docs base URL (optional, otherwise request origin)
+PUBLIC_API_BASE_URL=http://localhost:3001
+
+# External host binding for local dev/start
+HOSTNAME=0.0.0.0
+PORT=3001
 ```
 
 ### Database Setup
@@ -815,7 +824,7 @@ pnpm db:generate
 ### Development
 
 ```bash
-# Start dev server (port 3001)
+# Start dev server (port 3001, externally reachable via HOSTNAME)
 just dev
 # or
 pnpm dev
@@ -880,8 +889,14 @@ For a list of all Just tasks: `just --list`.
 
 All API routes use **Dutch path naming** convention.
 
+- OpenAPI JSON: `/api/openapi`
+- Interactive Scalar docs: `/api-docs`
+- External clients should send `Authorization: Bearer <API_SECRET>` for protected routes.
+- Cross-origin requests remain allowlist-based through `ALLOWED_ORIGINS`.
+
 | Endpoint                     | Method    | Description                            |
 | ---------------------------- | --------- | -------------------------------------- |
+| `/api/openapi`               | GET       | OpenAPI JSON document                  |
 | `/api/chat`                  | POST      | AI chat streaming (Vercel AI SDK)      |
 | `/api/opdrachten`            | GET/POST  | List/create vacancies                  |
 | `/api/opdrachten/[id]`       | GET/PATCH | Get/update vacancy                     |
@@ -906,6 +921,8 @@ All API routes use **Dutch path naming** convention.
 | `/api/cron/vacancy-expiry`   | GET       | Expire old vacancies                   |
 | `/api/cron/data-retention`   | GET       | GDPR data cleanup                      |
 | `/api/revalidate`            | POST      | Cache revalidation                     |
+
+Open `/api-docs` in the main app for interactive Scalar-based API documentation.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -781,6 +781,8 @@ STRIIVE_PASSWORD=...
 
 # Beveiliging
 ENCRYPTION_KEY=...   # openssl rand -base64 32
+API_SECRET=...       # Bearer token voor externe API clients
+ALLOWED_ORIGINS=http://localhost:3001,http://127.0.0.1:3001
 
 # Google AI (Gemini — CV parsing & verrijking)
 GOOGLE_GENERATIVE_AI_API_KEY=AIza...
@@ -802,6 +804,13 @@ SLACK_CHANNEL_ID=C0...
 LIVEKIT_URL=wss://your-project.livekit.cloud
 LIVEKIT_API_KEY=API...
 LIVEKIT_API_SECRET=...
+
+# Openbare API / docs base URL (optioneel, anders request-origin)
+PUBLIC_API_BASE_URL=http://localhost:3001
+
+# Externe host binding voor lokale dev/start
+HOSTNAME=0.0.0.0
+PORT=3001
 ```
 
 ### Database Opzet
@@ -817,7 +826,7 @@ pnpm db:generate
 ### Ontwikkeling
 
 ```bash
-# Dev server starten (poort 3001)
+# Dev server starten (poort 3001, extern bereikbaar via HOSTNAME)
 just dev
 # of
 pnpm dev
@@ -882,8 +891,14 @@ Voor een overzicht van alle Just-taken: `just --list`.
 
 Alle API routes gebruiken **Nederlandse padnamen**.
 
+- OpenAPI JSON: `/api/openapi`
+- Interactieve Scalar docs: `/api-docs`
+- Externe clients moeten een `Authorization: Bearer <API_SECRET>` header meesturen voor beschermde routes.
+- Cross-origin requests blijven allowlist-gebaseerd via `ALLOWED_ORIGINS`.
+
 | Endpoint                     | Methode   | Beschrijving                               |
 | ---------------------------- | --------- | ------------------------------------------ |
+| `/api/openapi`               | GET       | OpenAPI JSON documentatie                  |
 | `/api/chat`                  | POST      | AI chat streaming (Vercel AI SDK)          |
 | `/api/opdrachten`            | GET/POST  | Vacatures ophalen/aanmaken                 |
 | `/api/opdrachten/[id]`       | GET/PATCH | Vacature ophalen/bijwerken                 |
@@ -908,6 +923,8 @@ Alle API routes gebruiken **Nederlandse padnamen**.
 | `/api/embeddings/backfill`   | POST      | Ontbrekende embeddings genereren           |
 | `/api/events`                | GET       | SSE event stream                           |
 | `/api/reports`               | GET       | Platform rapporten genereren               |
+
+Open `/api-docs` in de hoofdapp voor interactieve API-documentatie op basis van Scalar.
 
 ---
 

--- a/app/api-docs/route.ts
+++ b/app/api-docs/route.ts
@@ -1,0 +1,13 @@
+import { buildScalarHtml, OPENAPI_ROUTE } from "@/src/lib/api-docs";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  const specUrl = new URL(OPENAPI_ROUTE, request.url).toString();
+
+  return new Response(buildScalarHtml(specUrl), {
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+    },
+  });
+}

--- a/app/api/openapi/route.ts
+++ b/app/api/openapi/route.ts
@@ -1,0 +1,7 @@
+import { buildOpenApiDocument } from "@/src/lib/api-docs";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  return Response.json(buildOpenApiDocument(request));
+}

--- a/fumadocs/content/docs/api/index.mdx
+++ b/fumadocs/content/docs/api/index.mdx
@@ -5,6 +5,12 @@ description: REST API documentatie voor het Motian platform.
 
 Alle API routes gebruiken Next.js App Router route handlers met Zod validatie.
 
+## Interactieve docs
+
+- OpenAPI JSON: `/api/openapi`
+- Scalar UI: `/api-docs`
+- Externe clients moeten voor beschermde routes een bearer token sturen via `Authorization: Bearer <API_SECRET>`.
+
 ## Overzicht
 
 <Mermaid chart={`

--- a/package.json
+++ b/package.json
@@ -69,8 +69,9 @@
     "zod-to-json-schema": "^3.25.1"
   },
   "scripts": {
-    "dev": "next dev --port 3001",
+    "dev": "next dev --hostname ${HOSTNAME:-0.0.0.0} --port ${PORT:-3001}",
     "build": "next build",
+    "start": "next start --hostname ${HOSTNAME:-0.0.0.0} --port ${PORT:-3001}",
     "test": "vitest run",
     "test:watch": "vitest",
     "db:generate": "drizzle-kit generate",

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,45 +1,28 @@
 import { type NextRequest, NextResponse } from "next/server";
+import { buildCorsHeaders, shouldRejectCorsPreflight } from "@/src/lib/api-cors";
 
 /** Routes that bypass bearer token authentication */
-const PUBLIC_PATHS = ["/api/gezondheid", "/api/cron"];
-
-const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? "")
-  .split(",")
-  .map((origin) => origin.trim())
-  .filter(Boolean);
-
-const devFallbackOrigin =
-  process.env.NODE_ENV === "development" ? "http://localhost:3001" : null;
+const PUBLIC_PATHS = ["/api/gezondheid", "/api/cron", "/api/openapi"];
 
 function isPublicRoute(pathname: string): boolean {
   return PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
 }
 
-function getAllowedOrigin(request: NextRequest): string | null {
-  const allowlist =
-    allowedOrigins.length > 0
-      ? allowedOrigins
-      : devFallbackOrigin
-        ? [devFallbackOrigin]
-        : [];
-
-  const origin = request.headers.get("origin");
-  return origin && allowlist.includes(origin) ? origin : null;
-}
-
 function corsHeaders(request: NextRequest): HeadersInit {
-  const allowedOrigin = getAllowedOrigin(request);
-  return {
-    "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",
-    "Access-Control-Allow-Headers": "Content-Type, Authorization",
-    "Access-Control-Max-Age": "86400",
-    ...(allowedOrigin ? { "Access-Control-Allow-Origin": allowedOrigin, Vary: "Origin" } : {}),
-  };
+  return buildCorsHeaders(request.headers.get("origin"));
 }
 
 export function proxy(request: NextRequest) {
   // Handle CORS preflight
   if (request.method === "OPTIONS") {
+    const origin = request.headers.get("origin");
+    if (shouldRejectCorsPreflight(origin)) {
+      return NextResponse.json(
+        { error: "Origin niet toegestaan" },
+        { status: 403, headers: corsHeaders(request) },
+      );
+    }
+
     return new NextResponse(null, { status: 204, headers: corsHeaders(request) });
   }
 

--- a/src/lib/api-cors.ts
+++ b/src/lib/api-cors.ts
@@ -1,0 +1,56 @@
+const DEFAULT_DEV_ORIGINS = ["http://localhost:3001", "http://127.0.0.1:3001"];
+
+type CorsEnv = Partial<Pick<NodeJS.ProcessEnv, "ALLOWED_ORIGINS" | "NODE_ENV">>;
+
+export function parseAllowedOrigins(value: string | undefined): string[] {
+  if (!value) return [];
+
+  return value
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
+export function getCorsAllowlist(env: CorsEnv = process.env): string[] {
+  const configuredOrigins = parseAllowedOrigins(env.ALLOWED_ORIGINS);
+  if (configuredOrigins.length > 0) {
+    return configuredOrigins;
+  }
+
+  return env.NODE_ENV === "development" ? DEFAULT_DEV_ORIGINS : [];
+}
+
+export function getAllowedCorsOrigin(
+  origin: string | null,
+  env: CorsEnv = process.env,
+): string | null {
+  if (!origin) return null;
+
+  const allowlist = getCorsAllowlist(env);
+  return allowlist.includes(origin) ? origin : null;
+}
+
+export function shouldRejectCorsPreflight(
+  origin: string | null,
+  env: CorsEnv = process.env,
+): boolean {
+  if (!origin) return false;
+
+  const allowlist = getCorsAllowlist(env);
+  return allowlist.length > 0 && !allowlist.includes(origin);
+}
+
+export function buildCorsHeaders(
+  origin: string | null,
+  env: CorsEnv = process.env,
+): Record<string, string> {
+  const allowedOrigin = getAllowedCorsOrigin(origin, env);
+
+  return {
+    "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization, Accept, X-Requested-With",
+    "Access-Control-Max-Age": "86400",
+    Vary: "Origin, Access-Control-Request-Headers",
+    ...(allowedOrigin ? { "Access-Control-Allow-Origin": allowedOrigin } : {}),
+  };
+}

--- a/src/lib/api-docs.ts
+++ b/src/lib/api-docs.ts
@@ -1,0 +1,241 @@
+export const OPENAPI_ROUTE = "/api/openapi";
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}
+
+export function getApiBaseUrl(request: Request): string {
+  const configuredUrl = process.env.PUBLIC_API_BASE_URL ?? process.env.NEXT_URL;
+  if (configuredUrl) {
+    return trimTrailingSlash(configuredUrl);
+  }
+
+  return trimTrailingSlash(new URL(request.url).origin);
+}
+
+export function buildOpenApiDocument(request: Request): Record<string, unknown> {
+  const serverUrl = getApiBaseUrl(request);
+
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "Motian API",
+      version: "0.1.0",
+      description:
+        "External REST API for the Motian recruitment platform. Most endpoints use Dutch route names and bearer-token authentication.",
+    },
+    servers: [{ url: serverUrl, description: "Current API server" }],
+    tags: [
+      { name: "System", description: "Health, documentation, and system routes" },
+      { name: "Jobs", description: "Vacancy listing and detail operations" },
+      { name: "Candidates", description: "Candidate listing and matching data" },
+      { name: "Matching", description: "Match retrieval and generation routes" },
+      { name: "Pipeline", description: "Applications, interviews, and messages" },
+      { name: "Scraping", description: "Scraping configuration and run history" },
+      { name: "Files", description: "CV upload and retrieval routes" },
+      { name: "Privacy", description: "GDPR export and deletion routes" },
+    ],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: "http",
+          scheme: "bearer",
+          bearerFormat: "API secret",
+          description: "Send the API secret as `Authorization: Bearer <token>`.",
+        },
+      },
+    },
+    security: [{ bearerAuth: [] }],
+    paths: {
+      [OPENAPI_ROUTE]: {
+        get: {
+          tags: ["System"],
+          summary: "Get the OpenAPI document",
+          security: [],
+          responses: { "200": { description: "OpenAPI JSON document" } },
+        },
+      },
+      "/api/gezondheid": {
+        get: {
+          tags: ["System"],
+          summary: "Read service health status",
+          security: [],
+          responses: { "200": { description: "Current health status" } },
+        },
+      },
+      "/api/opdrachten": {
+        get: {
+          tags: ["Jobs"],
+          summary: "List vacancies",
+          description: "Supports query, platform, location, status, rate, and pagination filters.",
+          responses: { "200": { description: "Paginated vacancy collection" } },
+        },
+        post: {
+          tags: ["Jobs"],
+          summary: "Create a vacancy",
+          responses: { "201": { description: "Created vacancy" } },
+        },
+      },
+      "/api/opdrachten/{id}": {
+        get: {
+          tags: ["Jobs"],
+          summary: "Get a vacancy by id",
+          responses: {
+            "200": { description: "Vacancy detail" },
+            "404": { description: "Not found" },
+          },
+        },
+        patch: {
+          tags: ["Jobs"],
+          summary: "Update a vacancy",
+          responses: { "200": { description: "Updated vacancy" } },
+        },
+      },
+      "/api/kandidaten": {
+        get: {
+          tags: ["Candidates"],
+          summary: "List candidates",
+          responses: { "200": { description: "Paginated candidate collection" } },
+        },
+        post: {
+          tags: ["Candidates"],
+          summary: "Create a candidate",
+          responses: { "201": { description: "Created candidate" } },
+        },
+      },
+      "/api/candidates/{id}/matches": {
+        get: {
+          tags: ["Candidates"],
+          summary: "List saved matches for one candidate",
+          responses: { "200": { description: "Candidate match list" } },
+        },
+      },
+      "/api/matches": {
+        get: {
+          tags: ["Matching"],
+          summary: "List matches",
+          responses: { "200": { description: "Match collection" } },
+        },
+        post: {
+          tags: ["Matching"],
+          summary: "Create or persist a match result",
+          responses: { "201": { description: "Created match" } },
+        },
+      },
+      "/api/sollicitaties": {
+        get: {
+          tags: ["Pipeline"],
+          summary: "List applications",
+          responses: { "200": { description: "Application collection" } },
+        },
+        post: {
+          tags: ["Pipeline"],
+          summary: "Create an application",
+          responses: { "201": { description: "Created application" } },
+        },
+      },
+      "/api/interviews": {
+        get: {
+          tags: ["Pipeline"],
+          summary: "List interviews",
+          responses: { "200": { description: "Interview collection" } },
+        },
+        post: {
+          tags: ["Pipeline"],
+          summary: "Create an interview",
+          responses: { "201": { description: "Created interview" } },
+        },
+      },
+      "/api/berichten": {
+        get: {
+          tags: ["Pipeline"],
+          summary: "List messages",
+          responses: { "200": { description: "Message collection" } },
+        },
+        post: {
+          tags: ["Pipeline"],
+          summary: "Create a message",
+          responses: { "201": { description: "Created message" } },
+        },
+      },
+      "/api/cv-upload": {
+        post: {
+          tags: ["Files"],
+          summary: "Upload a CV file",
+          responses: { "200": { description: "Stored file metadata" } },
+        },
+      },
+      "/api/cv-file": {
+        get: {
+          tags: ["Files"],
+          summary: "Read an uploaded CV file",
+          responses: { "200": { description: "CV file stream or metadata" } },
+        },
+      },
+      "/api/scraper-configuraties": {
+        get: {
+          tags: ["Scraping"],
+          summary: "List scraper configurations",
+          responses: { "200": { description: "Scraper configuration list" } },
+        },
+        patch: {
+          tags: ["Scraping"],
+          summary: "Update scraper configuration",
+          responses: { "200": { description: "Updated configuration" } },
+        },
+      },
+      "/api/scrape-resultaten": {
+        get: {
+          tags: ["Scraping"],
+          summary: "List scrape run history",
+          responses: { "200": { description: "Scrape run collection" } },
+        },
+      },
+      "/api/scrape/starten": {
+        post: {
+          tags: ["Scraping"],
+          summary: "Trigger a manual scrape",
+          responses: {
+            "202": { description: "Scrape accepted" },
+            "200": { description: "Scrape started" },
+          },
+        },
+      },
+      "/api/gdpr/{action}": {
+        post: {
+          tags: ["Privacy"],
+          summary: "Run GDPR export or deletion actions",
+          responses: { "200": { description: "GDPR action completed" } },
+        },
+      },
+    },
+  };
+}
+
+export function buildScalarHtml(specUrl: string): string {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Motian API Docs</title>
+    <style>
+      body { margin: 0; }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+    <script>
+      Scalar.createApiReference('#app', {
+        url: ${JSON.stringify(specUrl)},
+        layout: 'modern',
+        theme: 'purple',
+        darkMode: true,
+        defaultHttpClient: { targetKey: 'js', clientKey: 'fetch' },
+        authentication: { preferredSecurityScheme: 'bearerAuth' },
+      })
+    </script>
+  </body>
+</html>`;
+}

--- a/tests/api-docs.test.ts
+++ b/tests/api-docs.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GET as getOpenApi } from "../app/api/openapi/route";
+import { GET as getApiDocs } from "../app/api-docs/route";
+import {
+  buildCorsHeaders,
+  getAllowedCorsOrigin,
+  getCorsAllowlist,
+  shouldRejectCorsPreflight,
+} from "../src/lib/api-cors";
+
+describe("API docs routes", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("serves an OpenAPI document with the current server URL", async () => {
+    const response = await getOpenApi(new Request("http://localhost:3001/api/openapi"));
+    const body = (await response.json()) as {
+      openapi: string;
+      servers: Array<{ url: string }>;
+      paths: Record<string, unknown>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(body.openapi).toBe("3.1.0");
+    expect(body.servers[0]?.url).toBe("http://localhost:3001");
+    expect(body.paths["/api/gezondheid"]).toBeDefined();
+    expect(body.paths["/api/opdrachten"]).toBeDefined();
+  });
+
+  it("prefers PUBLIC_API_BASE_URL when generating the OpenAPI server URL", async () => {
+    vi.stubEnv("PUBLIC_API_BASE_URL", "https://api.example.com/");
+
+    const response = await getOpenApi(new Request("http://localhost:3001/api/openapi"));
+    const body = (await response.json()) as { servers: Array<{ url: string }> };
+
+    expect(body.servers[0]?.url).toBe("https://api.example.com");
+  });
+
+  it("serves a Scalar HTML shell wired to the local OpenAPI route", async () => {
+    const response = await getApiDocs(new Request("http://localhost:3001/api-docs"));
+    const body = await response.text();
+
+    expect(response.headers.get("content-type")).toContain("text/html");
+    expect(body).toContain("Scalar.createApiReference");
+    expect(body).toContain("http://localhost:3001/api/openapi");
+  });
+});
+
+describe("API CORS helpers", () => {
+  it("uses localhost and 127.0.0.1 as development fallbacks", () => {
+    const allowlist = getCorsAllowlist({ NODE_ENV: "development", ALLOWED_ORIGINS: "" });
+
+    expect(allowlist).toContain("http://localhost:3001");
+    expect(allowlist).toContain("http://127.0.0.1:3001");
+  });
+
+  it("respects configured allowlists and rejects unknown preflight origins", () => {
+    const env = {
+      NODE_ENV: "production",
+      ALLOWED_ORIGINS: "https://docs.example.com, https://app.example.com",
+    };
+
+    expect(getAllowedCorsOrigin("https://docs.example.com", env)).toBe("https://docs.example.com");
+    expect(getAllowedCorsOrigin("https://evil.example.com", env)).toBeNull();
+    expect(shouldRejectCorsPreflight("https://evil.example.com", env)).toBe(true);
+    expect(buildCorsHeaders("https://docs.example.com", env)["Access-Control-Allow-Origin"]).toBe(
+      "https://docs.example.com",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- expose the Next.js API on a configurable external host/port
- add allowlist-based external CORS handling and public OpenAPI output
- add Scalar interactive docs in the main app and document the new endpoints/config

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm exec biome check proxy.ts src/lib/api-cors.ts src/lib/api-docs.ts app/api/openapi/route.ts app/api-docs/route.ts tests/api-docs.test.ts`
- `pnpm exec vitest run tests/api-docs.test.ts`
- `pnpm build`

## Notes
- Scalar integration is CDN-based; no new package was added.
- Build emits an existing non-blocking Next.js warning about multiple lockfiles / inferred workspace root, but completes successfully.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced interactive API documentation at `/api-docs` with OpenAPI specification endpoint.
  * Added configurable deployment settings: external hostname binding, custom port, and allowed origins.

* **Documentation**
  * Updated guides with API endpoint listings and authentication requirements.
  * Documented new environment variables for API configuration and CORS handling.

* **Chores**
  * Extended environment configuration for server deployment flexibility and API access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->