### PR TITLE
fix: dedupe overview feeds

### DIFF
--- a/app/overzicht/data.ts
+++ b/app/overzicht/data.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gte, isNull, sql } from "drizzle-orm";
+import { and, asc, eq, gte, isNull, sql } from "drizzle-orm";
 import { db } from "@/src/db";
 import {
   applications,
@@ -8,6 +8,144 @@ import {
   scrapeResults,
   scraperConfigs,
 } from "@/src/db/schema";
+
+type RecentScrapeRow = {
+  id: string;
+  config_id: string | null;
+  platform: string;
+  run_at: Date | null;
+  duration_ms: number | null;
+  jobs_found: number | null;
+  jobs_new: number | null;
+  duplicates: number | null;
+  status: string;
+  errors: unknown;
+};
+
+type RecentScrape = {
+  id: string;
+  configId: string | null;
+  platform: string;
+  runAt: Date | null;
+  durationMs: number | null;
+  jobsFound: number | null;
+  jobsNew: number | null;
+  duplicates: number | null;
+  status: string;
+  errors: string[];
+};
+
+function normalizeOverviewPlatform(platform: string | null | undefined) {
+  return platform?.trim().toLowerCase() ?? "";
+}
+
+function dedupeRecentScrapes(rows: RecentScrape[]): RecentScrape[] {
+  const seen = new Set<string>();
+
+  return rows.flatMap((row) => {
+    const platform = normalizeOverviewPlatform(row.platform);
+    if (!platform || seen.has(platform)) return [];
+
+    seen.add(platform);
+    return [{ ...row, platform }];
+  });
+}
+
+type RecentJobRow = {
+  id: string;
+  title: string;
+  company: string | null;
+  platform: string;
+  location: string | null;
+  scraped_at: Date | null;
+};
+
+type RecentJob = {
+  id: string;
+  title: string;
+  company: string | null;
+  platform: string;
+  location: string | null;
+  scrapedAt: Date | null;
+};
+
+async function getRecentJobs(database: Pick<typeof db, "execute">): Promise<RecentJob[]> {
+  const result = await database.execute(sql<RecentJobRow>`
+    select *
+    from (
+      select distinct on (
+        trim(regexp_replace(lower(coalesce(${jobs.title}, '')), '[^[:alnum:]]+', ' ', 'g')),
+        trim(regexp_replace(lower(coalesce(${jobs.endClient}, ${jobs.company}, '')), '[^[:alnum:]]+', ' ', 'g')),
+        trim(regexp_replace(lower(coalesce(${jobs.province}, ${jobs.location}, '')), '[^[:alnum:]]+', ' ', 'g'))
+      )
+        ${jobs.id} as id,
+        ${jobs.title} as title,
+        coalesce(${jobs.endClient}, ${jobs.company}) as company,
+        ${jobs.platform} as platform,
+        coalesce(${jobs.location}, ${jobs.province}) as location,
+        ${jobs.scrapedAt} as scraped_at
+      from ${jobs}
+      where ${jobs.deletedAt} is null
+      order by
+        trim(regexp_replace(lower(coalesce(${jobs.title}, '')), '[^[:alnum:]]+', ' ', 'g')) asc,
+        trim(regexp_replace(lower(coalesce(${jobs.endClient}, ${jobs.company}, '')), '[^[:alnum:]]+', ' ', 'g')) asc,
+        trim(regexp_replace(lower(coalesce(${jobs.province}, ${jobs.location}, '')), '[^[:alnum:]]+', ' ', 'g')) asc,
+        ${jobs.scrapedAt} desc nulls last,
+        ${jobs.id} desc
+    ) latest_job_groups
+    order by scraped_at desc nulls last, id desc
+    limit 5
+  `);
+
+  return (result.rows as RecentJobRow[]).map((row) => ({
+    id: row.id,
+    title: row.title,
+    company: row.company,
+    platform: row.platform,
+    location: row.location,
+    scrapedAt: row.scraped_at,
+  }));
+}
+
+async function getRecentScrapes(database: Pick<typeof db, "execute">): Promise<RecentScrape[]> {
+  const result = await database.execute(sql<RecentScrapeRow>`
+    select *
+    from (
+      select distinct on (${scrapeResults.platform})
+        ${scrapeResults.id} as id,
+        ${scrapeResults.configId} as config_id,
+        ${scrapeResults.platform} as platform,
+        ${scrapeResults.runAt} as run_at,
+        ${scrapeResults.durationMs} as duration_ms,
+        ${scrapeResults.jobsFound} as jobs_found,
+        ${scrapeResults.jobsNew} as jobs_new,
+        ${scrapeResults.duplicates} as duplicates,
+        ${scrapeResults.status} as status,
+        ${scrapeResults.errors} as errors
+      from ${scrapeResults}
+      order by ${scrapeResults.platform} asc, ${scrapeResults.runAt} desc nulls last, ${scrapeResults.id} desc
+    ) latest_platform_runs
+    order by run_at desc nulls last, platform asc
+    limit 5
+  `);
+
+  return dedupeRecentScrapes(
+    (result.rows as RecentScrapeRow[]).map((row) => ({
+      id: row.id,
+      configId: row.config_id,
+      platform: row.platform,
+      runAt: row.run_at,
+      durationMs: row.duration_ms,
+      jobsFound: row.jobs_found,
+      jobsNew: row.jobs_new,
+      duplicates: row.duplicates,
+      status: row.status,
+      errors: Array.isArray(row.errors)
+        ? row.errors.filter((value): value is string => typeof value === "string")
+        : [],
+    })),
+  );
+}
 
 export async function getOverviewData(database: typeof db = db) {
   const sevenDaysAgo = new Date();
@@ -28,41 +166,14 @@ export async function getOverviewData(database: typeof db = db) {
       .groupBy(jobs.platform)
       .orderBy(sql`count(*) desc`);
 
-    const recentJobs = await tx
-      .select({
-        id: jobs.id,
-        title: jobs.title,
-        company: jobs.company,
-        platform: jobs.platform,
-        location: jobs.location,
-        scrapedAt: jobs.scrapedAt,
-      })
-      .from(jobs)
-      .where(isNull(jobs.deletedAt))
-      .orderBy(desc(jobs.scrapedAt))
-      .limit(5);
+    const recentJobs = await getRecentJobs(tx);
 
     const activeScrapers = await tx
       .select()
       .from(scraperConfigs)
       .where(eq(scraperConfigs.isActive, true));
 
-    const recentScrapes = await tx
-      .select({
-        id: scrapeResults.id,
-        configId: scrapeResults.configId,
-        platform: scrapeResults.platform,
-        runAt: scrapeResults.runAt,
-        durationMs: scrapeResults.durationMs,
-        jobsFound: scrapeResults.jobsFound,
-        jobsNew: scrapeResults.jobsNew,
-        duplicates: scrapeResults.duplicates,
-        status: scrapeResults.status,
-        errors: scrapeResults.errors,
-      })
-      .from(scrapeResults)
-      .orderBy(desc(scrapeResults.runAt))
-      .limit(5);
+    const recentScrapes = await getRecentScrapes(tx);
 
     const topCompanies = await tx
       .select({

--- a/tests/overzicht-data.test.ts
+++ b/tests/overzicht-data.test.ts
@@ -17,30 +17,275 @@ function createAwaitableQuery<T>(result: T) {
   return chain;
 }
 
+function createExecuteResult<T>(rows: T[]) {
+  return Promise.resolve({ rows });
+}
+
 describe("getOverviewData", () => {
   it("executes dashboard reads through one transaction-backed connection", async () => {
     const select = vi
       .fn()
       .mockReturnValueOnce(createAwaitableQuery([{ platform: "linkedin", count: 3, weeklyNew: 1 }]))
-      .mockReturnValueOnce(createAwaitableQuery([{ id: "job-1", title: "Engineer" }]))
       .mockReturnValueOnce(createAwaitableQuery([{ id: "cfg-1", platform: "linkedin" }]))
-      .mockReturnValueOnce(createAwaitableQuery([{ id: "run-1", platform: "linkedin" }]))
       .mockReturnValueOnce(createAwaitableQuery([{ company: "Motian", count: 2 }]))
       .mockReturnValueOnce(createAwaitableQuery([{ province: "Utrecht", count: 2 }]))
       .mockReturnValueOnce(createAwaitableQuery([{ stage: "new", count: 4 }]))
       .mockReturnValueOnce(createAwaitableQuery([{ count: 2 }]))
       .mockReturnValueOnce(createAwaitableQuery([{ id: "interview-1", candidateName: "Jane" }]));
+    const execute = vi
+      .fn()
+      .mockReturnValueOnce(
+        createExecuteResult([
+          {
+            id: "job-1",
+            title: "Engineer",
+            company: "Motian",
+            platform: "linkedin",
+            location: "Utrecht",
+            scraped_at: new Date("2026-03-08T09:30:00.000Z"),
+          },
+        ]),
+      )
+      .mockReturnValueOnce(
+        createExecuteResult([
+          { id: "run-1", config_id: "cfg-1", platform: "linkedin", status: "success" },
+        ]),
+      );
 
-    const transaction = vi.fn(async (callback: (tx: { select: typeof select }) => unknown) =>
-      callback({ select }),
+    const transaction = vi.fn(
+      async (callback: (tx: { execute: typeof execute; select: typeof select }) => unknown) =>
+        callback({ execute, select }),
     );
 
     const result = await getOverviewData({ transaction } as unknown as typeof db);
 
     expect(transaction).toHaveBeenCalledTimes(1);
-    expect(select).toHaveBeenCalledTimes(9);
+    expect(select).toHaveBeenCalledTimes(7);
+    expect(execute).toHaveBeenCalledTimes(2);
     expect(result.platformCounts).toEqual([{ platform: "linkedin", count: 3, weeklyNew: 1 }]);
+    expect(result.recentJobs).toEqual([
+      {
+        id: "job-1",
+        title: "Engineer",
+        company: "Motian",
+        platform: "linkedin",
+        location: "Utrecht",
+        scrapedAt: new Date("2026-03-08T09:30:00.000Z"),
+      },
+    ]);
+    expect(result.recentScrapes).toEqual([
+      {
+        id: "run-1",
+        configId: "cfg-1",
+        platform: "linkedin",
+        runAt: undefined,
+        durationMs: undefined,
+        jobsFound: undefined,
+        jobsNew: undefined,
+        duplicates: undefined,
+        status: "success",
+        errors: [],
+      },
+    ]);
     expect(result.pipelineStageCounts).toEqual([{ stage: "new", count: 4 }]);
     expect(result.upcomingInterviewCountResult).toEqual([{ count: 2 }]);
+  });
+
+  it("keeps one latest scrape row per platform for the overview data sources", async () => {
+    const select = vi
+      .fn()
+      .mockReturnValueOnce(createAwaitableQuery([{ platform: "linkedin", count: 3, weeklyNew: 1 }]))
+      .mockReturnValueOnce(createAwaitableQuery([{ id: "cfg-1", platform: "linkedin" }]))
+      .mockReturnValueOnce(createAwaitableQuery([{ company: "Motian", count: 2 }]))
+      .mockReturnValueOnce(createAwaitableQuery([{ province: "Utrecht", count: 2 }]))
+      .mockReturnValueOnce(createAwaitableQuery([{ stage: "new", count: 4 }]))
+      .mockReturnValueOnce(createAwaitableQuery([{ count: 2 }]))
+      .mockReturnValueOnce(createAwaitableQuery([{ id: "interview-1", candidateName: "Jane" }]));
+    const execute = vi
+      .fn()
+      .mockReturnValueOnce(
+        createExecuteResult([
+          {
+            id: "job-latest",
+            title: "Communicatieadviseur",
+            company: "Gemeente Veere",
+            platform: "flextender",
+            location: "Zeeland",
+            scraped_at: new Date("2026-03-08T09:30:00.000Z"),
+          },
+        ]),
+      )
+      .mockReturnValueOnce(
+        createExecuteResult([
+          {
+            id: "run-linkedin",
+            config_id: "cfg-1",
+            platform: "linkedin",
+            run_at: new Date("2026-03-08T09:00:00.000Z"),
+            duration_ms: 1200,
+            jobs_found: 10,
+            jobs_new: 4,
+            duplicates: 6,
+            status: "success",
+            errors: [],
+          },
+          {
+            id: "run-indeed",
+            config_id: "cfg-2",
+            platform: "indeed",
+            run_at: new Date("2026-03-08T08:00:00.000Z"),
+            duration_ms: 1800,
+            jobs_found: 8,
+            jobs_new: 3,
+            duplicates: 5,
+            status: "partial",
+            errors: ["Timeout"],
+          },
+        ]),
+      );
+
+    const transaction = vi.fn(
+      async (callback: (tx: { execute: typeof execute; select: typeof select }) => unknown) =>
+        callback({ execute, select }),
+    );
+
+    const result = await getOverviewData({ transaction } as unknown as typeof db);
+
+    expect(result.recentJobs).toEqual([
+      {
+        id: "job-latest",
+        title: "Communicatieadviseur",
+        company: "Gemeente Veere",
+        platform: "flextender",
+        location: "Zeeland",
+        scrapedAt: new Date("2026-03-08T09:30:00.000Z"),
+      },
+    ]);
+    expect(result.recentScrapes).toEqual([
+      {
+        id: "run-linkedin",
+        configId: "cfg-1",
+        platform: "linkedin",
+        runAt: new Date("2026-03-08T09:00:00.000Z"),
+        durationMs: 1200,
+        jobsFound: 10,
+        jobsNew: 4,
+        duplicates: 6,
+        status: "success",
+        errors: [],
+      },
+      {
+        id: "run-indeed",
+        configId: "cfg-2",
+        platform: "indeed",
+        runAt: new Date("2026-03-08T08:00:00.000Z"),
+        durationMs: 1800,
+        jobsFound: 8,
+        jobsNew: 3,
+        duplicates: 5,
+        status: "partial",
+        errors: ["Timeout"],
+      },
+    ]);
+  });
+
+  it("deduplicates recent scrapes that only differ by platform casing or whitespace", async () => {
+    const select = vi
+      .fn()
+      .mockReturnValueOnce(createAwaitableQuery([{ platform: "linkedin", count: 3, weeklyNew: 1 }]))
+      .mockReturnValueOnce(createAwaitableQuery([{ id: "cfg-1", platform: "linkedin" }]))
+      .mockReturnValueOnce(createAwaitableQuery([{ company: "Motian", count: 2 }]))
+      .mockReturnValueOnce(createAwaitableQuery([{ province: "Utrecht", count: 2 }]))
+      .mockReturnValueOnce(createAwaitableQuery([{ stage: "new", count: 4 }]))
+      .mockReturnValueOnce(createAwaitableQuery([{ count: 2 }]))
+      .mockReturnValueOnce(createAwaitableQuery([{ id: "interview-1", candidateName: "Jane" }]));
+    const execute = vi
+      .fn()
+      .mockReturnValueOnce(
+        createExecuteResult([
+          {
+            id: "job-latest",
+            title: "Communicatieadviseur",
+            company: "Gemeente Veere",
+            platform: "flextender",
+            location: "Zeeland",
+            scraped_at: new Date("2026-03-08T09:30:00.000Z"),
+          },
+        ]),
+      )
+      .mockReturnValueOnce(
+        createExecuteResult([
+          {
+            id: "run-flextender-latest",
+            config_id: "cfg-1",
+            platform: " Flextender ",
+            run_at: new Date("2026-03-08T09:00:00.000Z"),
+            duration_ms: 1200,
+            jobs_found: 10,
+            jobs_new: 4,
+            duplicates: 6,
+            status: "success",
+            errors: [],
+          },
+          {
+            id: "run-flextender-older",
+            config_id: "cfg-2",
+            platform: "flextender",
+            run_at: new Date("2026-03-08T08:00:00.000Z"),
+            duration_ms: 1800,
+            jobs_found: 8,
+            jobs_new: 3,
+            duplicates: 5,
+            status: "partial",
+            errors: ["Timeout"],
+          },
+          {
+            id: "run-striive",
+            config_id: "cfg-3",
+            platform: "Striive",
+            run_at: new Date("2026-03-08T07:00:00.000Z"),
+            duration_ms: 900,
+            jobs_found: 12,
+            jobs_new: 2,
+            duplicates: 10,
+            status: "success",
+            errors: [],
+          },
+        ]),
+      );
+
+    const transaction = vi.fn(
+      async (callback: (tx: { execute: typeof execute; select: typeof select }) => unknown) =>
+        callback({ execute, select }),
+    );
+
+    const result = await getOverviewData({ transaction } as unknown as typeof db);
+
+    expect(result.recentScrapes).toEqual([
+      {
+        id: "run-flextender-latest",
+        configId: "cfg-1",
+        platform: "flextender",
+        runAt: new Date("2026-03-08T09:00:00.000Z"),
+        durationMs: 1200,
+        jobsFound: 10,
+        jobsNew: 4,
+        duplicates: 6,
+        status: "success",
+        errors: [],
+      },
+      {
+        id: "run-striive",
+        configId: "cfg-3",
+        platform: "striive",
+        runAt: new Date("2026-03-08T07:00:00.000Z"),
+        durationMs: 900,
+        jobsFound: 12,
+        jobsNew: 2,
+        duplicates: 10,
+        status: "success",
+        errors: [],
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- dedupe overview data-source rows so each platform appears once in `Databronnen`
- dedupe overview recent jobs so duplicate/cross-posted vacancies don’t repeat in `Nieuwe vacatures om op te volgen`
- expand overview data tests to cover both dedupe paths and mapped result shapes

## Root cause
- `recentScrapes` previously selected the latest raw scrape-result rows overall, so repeated runs for the same platform could render duplicate data-source rows
- `recentJobs` previously selected the latest raw job rows by `scrapedAt`, so duplicate/cross-posted vacancies in the jobs table could surface directly in the overview feed

## Implementation
- add overview helpers in `app/overzicht/data.ts` to select the latest scrape row per platform and the latest visible job per normalized vacancy identity
- normalize/dedupe overview platform keys for scrape rows
- update `tests/overzicht-data.test.ts` for the execute-based overview queries and dedupe coverage

## Verification
- `pnpm test -- --run tests/overzicht-data.test.ts`
- `pnpm exec biome check app/overzicht/data.ts tests/overzicht-data.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm test`
- live `/overzicht` verification showing 3 unique `Databronnen` rows

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author