### PR TITLE
feat(autopilot): Phase 2 — AI analysis, full pipeline wiring, extended journeys

### DIFF
--- a/src/autopilot/analysis/analyze-evidence.ts
+++ b/src/autopilot/analysis/analyze-evidence.ts
@@ -1,0 +1,173 @@
+import crypto from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { Output } from "ai";
+import { geminiFlash, tracedGenerateText as generateText } from "@/src/lib/ai-models";
+import { withRetry } from "@/src/lib/retry";
+import type { EvidenceManifest } from "../types/evidence";
+import type { AutopilotFinding } from "../types/finding";
+import { type EvidenceAnalysisOutput, evidenceAnalysisSchema } from "./schemas";
+
+const ANALYSIS_SYSTEM_PROMPT = `You are a QA engineer analyzing browser evidence from a Dutch recruitment platform called Motian.
+
+You receive:
+1. A screenshot of a web page (PNG image)
+2. Console logs captured during page load
+
+Your job is to identify any issues:
+- **bug**: Broken functionality, error states, missing elements, JavaScript errors in console
+- **ux**: Poor user experience, confusing layout, accessibility issues, broken styling
+- **perf**: Slow loading, excessive console warnings, performance issues
+- **ai-quality**: AI chat responses that are incorrect, unhelpful, or not in Dutch
+
+Rules:
+- Only report REAL issues you can see in the evidence. Do not speculate.
+- Console warnings about React hydration or development mode are NOT bugs.
+- An empty state (no data) is NOT a bug — it's expected for a new/demo instance.
+- If the page looks healthy with no errors, return an empty findings array and overallHealthy=true.
+- Be conservative — a false positive wastes developer time.
+- Severity guide:
+  - critical: Page completely broken, shows error page, or key functionality unusable
+  - high: Major feature broken but page partially works
+  - medium: Minor visual/UX issue or non-critical console errors
+  - low: Cosmetic issue or suggestion for improvement`;
+
+export interface AnalysisConfig {
+  /** Max console log lines to include in prompt */
+  maxConsoleLines?: number;
+}
+
+export async function analyzeManifestEvidence(
+  manifest: EvidenceManifest,
+  runId: string,
+  config?: AnalysisConfig,
+): Promise<AutopilotFinding[]> {
+  const maxLines = config?.maxConsoleLines ?? 200;
+
+  const screenshot = manifest.artifacts.find((a) => a.kind === "screenshot");
+  const consoleLog = manifest.artifacts.find((a) => a.kind === "console-log");
+
+  // If journey failed and we have no screenshot, create a finding from the failure
+  if (!manifest.success && manifest.failureReason) {
+    return [
+      {
+        id: crypto.randomUUID(),
+        runId,
+        category: "bug",
+        surface: manifest.surface,
+        title: `Journey "${manifest.journeyId}" failed to complete`,
+        description: `The journey could not be executed: ${manifest.failureReason}`,
+        severity: "critical",
+        confidence: 1.0,
+        autoFixable: false,
+        status: "detected",
+        fingerprint: `${manifest.surface}|bug|journey-execution-failure`,
+        suspectedRootCause: manifest.failureReason,
+        recommendedAction: "Check if the page is accessible and loads correctly",
+      },
+    ];
+  }
+
+  // Build multimodal prompt parts
+  const promptParts: Array<{ type: "text"; text: string } | { type: "image"; image: Buffer }> = [];
+
+  promptParts.push({
+    type: "text" as const,
+    text: `Analyzing journey: "${manifest.journeyId}" on surface: "${manifest.surface}"\n\nJourney completed: ${manifest.success ? "Yes" : "No"}`,
+  });
+
+  if (screenshot) {
+    try {
+      const imageBuffer = await readFile(screenshot.path);
+      promptParts.push({ type: "image" as const, image: imageBuffer });
+    } catch {
+      promptParts.push({ type: "text" as const, text: "[Screenshot could not be loaded]" });
+    }
+  }
+
+  if (consoleLog) {
+    try {
+      const logContent = await readFile(consoleLog.path, "utf-8");
+      const lines = logContent.split("\n").slice(0, maxLines);
+      const truncated = logContent.split("\n").length > maxLines;
+      promptParts.push({
+        type: "text" as const,
+        text: `\n\nConsole logs (${lines.length} lines${truncated ? ", truncated" : ""}):\n\`\`\`\n${lines.join("\n")}\n\`\`\``,
+      });
+    } catch {
+      promptParts.push({ type: "text" as const, text: "\n\n[Console logs could not be loaded]" });
+    }
+  }
+
+  const { output } = await withRetry(
+    () =>
+      generateText({
+        model: geminiFlash,
+        output: Output.object({ schema: evidenceAnalysisSchema }),
+        system: ANALYSIS_SYSTEM_PROMPT,
+        messages: [{ role: "user", content: promptParts }],
+        providerOptions: { google: { structuredOutputs: true } },
+      }),
+    { label: `Autopilot Analysis (${manifest.journeyId})` },
+  );
+
+  if (!output) return [];
+
+  const result = output as EvidenceAnalysisOutput;
+
+  return result.findings.map((f) => ({
+    id: crypto.randomUUID(),
+    runId,
+    category: f.category,
+    surface: manifest.surface,
+    title: f.title,
+    description: f.description,
+    severity: f.severity,
+    confidence: f.confidence,
+    autoFixable: f.autoFixable,
+    status: "detected" as const,
+    fingerprint: `${manifest.surface}|${f.category}|${f.title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .slice(0, 60)}`,
+    suspectedRootCause: f.suspectedRootCause,
+    recommendedAction: f.recommendedAction,
+  }));
+}
+
+/**
+ * Analyze all evidence manifests from a run, return combined findings.
+ */
+export async function analyzeAllEvidence(
+  manifests: EvidenceManifest[],
+  runId: string,
+  config?: AnalysisConfig,
+): Promise<AutopilotFinding[]> {
+  const allFindings: AutopilotFinding[] = [];
+
+  for (const manifest of manifests) {
+    try {
+      const findings = await analyzeManifestEvidence(manifest, runId, config);
+      allFindings.push(...findings);
+    } catch (err) {
+      console.error(
+        `[autopilot] Analysis failed for journey ${manifest.journeyId}:`,
+        err instanceof Error ? err.message : err,
+      );
+      allFindings.push({
+        id: crypto.randomUUID(),
+        runId,
+        category: "bug",
+        surface: manifest.surface,
+        title: `Evidence analysis failed for "${manifest.journeyId}"`,
+        description: `The AI analysis could not be completed: ${err instanceof Error ? err.message : String(err)}`,
+        severity: "medium",
+        confidence: 1.0,
+        autoFixable: false,
+        status: "detected",
+        fingerprint: `${manifest.surface}|bug|analysis-failure`,
+      });
+    }
+  }
+
+  return allFindings;
+}

--- a/src/autopilot/analysis/index.ts
+++ b/src/autopilot/analysis/index.ts
@@ -1,0 +1,6 @@
+export {
+  type AnalysisConfig,
+  analyzeAllEvidence,
+  analyzeManifestEvidence,
+} from "./analyze-evidence";
+export { type EvidenceAnalysisOutput, evidenceAnalysisSchema } from "./schemas";

--- a/src/autopilot/analysis/schemas.ts
+++ b/src/autopilot/analysis/schemas.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const evidenceAnalysisSchema = z.object({
+  findings: z.array(
+    z.object({
+      title: z.string().describe("Short descriptive title of the finding"),
+      category: z.enum(["bug", "ux", "perf", "ai-quality"]),
+      severity: z.enum(["critical", "high", "medium", "low"]),
+      confidence: z.number().min(0).max(1).describe("Confidence 0-1"),
+      description: z.string().describe("Detailed description of what was found"),
+      suspectedRootCause: z.string().optional().describe("What might be causing this"),
+      recommendedAction: z.string().optional().describe("Suggested fix"),
+      autoFixable: z.boolean().describe("Whether this could be auto-fixed"),
+    }),
+  ),
+  overallHealthy: z.boolean().describe("Whether the page looks generally healthy"),
+  summary: z.string().describe("One sentence summary of the analysis"),
+});
+
+export type EvidenceAnalysisOutput = z.infer<typeof evidenceAnalysisSchema>;

--- a/src/autopilot/config/index.ts
+++ b/src/autopilot/config/index.ts
@@ -1,1 +1,1 @@
-export { MVP_JOURNEYS } from "./journeys";
+export { ALL_JOURNEYS, EXTENDED_JOURNEYS, MVP_JOURNEYS } from "./journeys";

--- a/src/autopilot/config/journeys.ts
+++ b/src/autopilot/config/journeys.ts
@@ -1,5 +1,6 @@
 import type { JourneySpec } from "../types/journey";
 
+/** Core MVP journeys — always run */
 export const MVP_JOURNEYS: JourneySpec[] = [
   {
     id: "chat-page-load",
@@ -7,6 +8,7 @@ export const MVP_JOURNEYS: JourneySpec[] = [
     kind: "interactive",
     description: "Load chat page and verify it renders with input ready",
     timeoutMs: 30_000,
+    expectedSelectors: ["textarea, input[type='text'], [contenteditable]"],
   },
   {
     id: "matching-redirect",
@@ -24,3 +26,58 @@ export const MVP_JOURNEYS: JourneySpec[] = [
     timeoutMs: 30_000,
   },
 ];
+
+/** Extended journeys — Phase 2 additions */
+export const EXTENDED_JOURNEYS: JourneySpec[] = [
+  {
+    id: "chat-send-message",
+    surface: "/chat",
+    kind: "interactive",
+    description: "Open chat, type a message, and verify AI responds",
+    timeoutMs: 60_000,
+    interactions: [
+      {
+        action: "wait-for-selector",
+        selector: "textarea, input[type='text'], [contenteditable]",
+        description: "Wait for chat input to be ready",
+        timeoutMs: 10_000,
+      },
+      {
+        action: "type",
+        selector: "textarea, input[type='text'], [contenteditable]",
+        text: "Hallo, kun je me helpen met vacatures zoeken?",
+        description: "Type a test message in Dutch",
+      },
+      {
+        action: "click",
+        selector:
+          "button[type='submit'], button[aria-label*='send'], button[aria-label*='verzend']",
+        description: "Click send button",
+        timeoutMs: 5_000,
+      },
+      {
+        action: "wait-for-selector",
+        selector: "[data-role='assistant'], .assistant-message, [class*='assistant']",
+        description: "Wait for AI response to appear",
+        timeoutMs: 45_000,
+      },
+    ],
+  },
+  {
+    id: "professionals-list",
+    surface: "/professionals",
+    kind: "page-load",
+    description: "Load professionals/talent pool page and verify it renders",
+    timeoutMs: 30_000,
+  },
+  {
+    id: "dashboard-load",
+    surface: "/dashboard",
+    kind: "page-load",
+    description: "Load dashboard page and verify KPI cards or empty state renders",
+    timeoutMs: 30_000,
+  },
+];
+
+/** All journeys combined */
+export const ALL_JOURNEYS: JourneySpec[] = [...MVP_JOURNEYS, ...EXTENDED_JOURNEYS];

--- a/src/autopilot/evidence/journey-runner.ts
+++ b/src/autopilot/evidence/journey-runner.ts
@@ -53,10 +53,41 @@ export async function runJourney(
     const url = `${config.baseUrl}${spec.surface}`;
 
     switch (spec.kind) {
-      case "page-load":
-      case "interactive": {
-        // For MVP, interactive is treated the same as page-load
+      case "page-load": {
         await page.goto(url, { waitUntil: "networkidle" });
+        break;
+      }
+      case "interactive": {
+        await page.goto(url, { waitUntil: "networkidle" });
+
+        // Execute interaction steps if defined
+        if (spec.interactions?.length) {
+          for (const step of spec.interactions) {
+            const stepTimeout = step.timeoutMs ?? spec.timeoutMs;
+            switch (step.action) {
+              case "click":
+                if (step.selector) {
+                  await page.click(step.selector, { timeout: stepTimeout });
+                }
+                break;
+              case "type":
+                if (step.selector && step.text) {
+                  await page.fill(step.selector, step.text, { timeout: stepTimeout });
+                }
+                break;
+              case "wait-for-selector":
+                if (step.selector) {
+                  await page.waitForSelector(step.selector, { timeout: stepTimeout });
+                }
+                break;
+              case "wait-for-text":
+                if (step.waitForText) {
+                  await page.waitForSelector(`text=${step.waitForText}`, { timeout: stepTimeout });
+                }
+                break;
+            }
+          }
+        }
         break;
       }
       case "redirect": {
@@ -71,6 +102,18 @@ export async function runJourney(
         // Allow the destination page to finish loading
         await page.waitForLoadState("networkidle");
         break;
+      }
+    }
+
+    // Validate expected selectors
+    if (spec.expectedSelectors?.length) {
+      for (const selector of spec.expectedSelectors) {
+        try {
+          await page.waitForSelector(selector, { timeout: 5000 });
+        } catch {
+          success = false;
+          errorMessage = `Expected selector not found: ${selector}`;
+        }
       }
     }
 

--- a/src/autopilot/index.ts
+++ b/src/autopilot/index.ts
@@ -1,4 +1,9 @@
-export { MVP_JOURNEYS } from "./config";
+export {
+  type AnalysisConfig,
+  analyzeAllEvidence,
+  analyzeManifestEvidence,
+} from "./analysis";
+export { ALL_JOURNEYS, EXTENDED_JOURNEYS, MVP_JOURNEYS } from "./config";
 export {
   type CaptureConfig,
   type CaptureResult,

--- a/src/autopilot/types/journey.ts
+++ b/src/autopilot/types/journey.ts
@@ -1,7 +1,28 @@
 // Journey types for autopilot browser audit
-export type AutopilotSurface = "/chat" | "/matching" | "/opdrachten" | "/opdrachten/[id]";
+export type AutopilotSurface =
+  | "/chat"
+  | "/matching"
+  | "/opdrachten"
+  | "/opdrachten/[id]"
+  | "/professionals"
+  | "/dashboard";
 
 export type JourneyKind = "interactive" | "redirect" | "page-load";
+
+export interface InteractionStep {
+  /** Action to perform */
+  action: "click" | "type" | "wait-for-selector" | "wait-for-text";
+  /** CSS selector for click/type targets */
+  selector?: string;
+  /** Text to type (for "type" action) */
+  text?: string;
+  /** Text to wait for (for "wait-for-text" action) */
+  waitForText?: string;
+  /** Timeout for this specific step */
+  timeoutMs?: number;
+  /** Description of what this step does */
+  description?: string;
+}
 
 export interface JourneySpec {
   id: string;
@@ -12,4 +33,8 @@ export interface JourneySpec {
   expectedRedirectTarget?: string;
   /** Timeout for the journey execution */
   timeoutMs: number;
+  /** Steps to execute for interactive journeys */
+  interactions?: InteractionStep[];
+  /** CSS selectors that must be visible after page load for the journey to pass */
+  expectedSelectors?: string[];
 }

--- a/tests/autopilot.test.ts
+++ b/tests/autopilot.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { MVP_JOURNEYS } from "@/src/autopilot/config/journeys";
+import { evidenceAnalysisSchema } from "@/src/autopilot/analysis/schemas";
+import { ALL_JOURNEYS, EXTENDED_JOURNEYS, MVP_JOURNEYS } from "@/src/autopilot/config/journeys";
 import { generateMarkdownReport } from "@/src/autopilot/reporting/markdown";
 import type {
   AutopilotFinding,
@@ -244,5 +245,241 @@ describe("autopilot markdown report", () => {
     });
     const report = generateMarkdownReport(allPass);
     expect(report).not.toContain("❌");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Analysis Schemas (Phase 2)
+// ---------------------------------------------------------------------------
+describe("autopilot analysis schemas", () => {
+  it("validates a correct analysis output", () => {
+    const validOutput = {
+      findings: [
+        {
+          title: "Error message visible on page",
+          category: "bug",
+          severity: "high",
+          confidence: 0.85,
+          description: "An error banner is displayed at the top of the page",
+          autoFixable: false,
+        },
+      ],
+      overallHealthy: false,
+      summary: "Page shows error state",
+    };
+
+    const result = evidenceAnalysisSchema.safeParse(validOutput);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid severity values", () => {
+    const invalidOutput = {
+      findings: [
+        {
+          title: "Test",
+          category: "bug",
+          severity: "extreme", // invalid
+          confidence: 0.5,
+          description: "Test",
+          autoFixable: false,
+        },
+      ],
+      overallHealthy: true,
+      summary: "Test",
+    };
+
+    const result = evidenceAnalysisSchema.safeParse(invalidOutput);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects confidence outside 0-1 range", () => {
+    const invalidOutput = {
+      findings: [
+        {
+          title: "Test",
+          category: "bug",
+          severity: "low",
+          confidence: 1.5, // invalid
+          description: "Test",
+          autoFixable: false,
+        },
+      ],
+      overallHealthy: true,
+      summary: "Test",
+    };
+
+    const result = evidenceAnalysisSchema.safeParse(invalidOutput);
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts empty findings array", () => {
+    const healthyOutput = {
+      findings: [],
+      overallHealthy: true,
+      summary: "Page looks healthy",
+    };
+
+    const result = evidenceAnalysisSchema.safeParse(healthyOutput);
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Extended Journey Specs (Phase 2)
+// ---------------------------------------------------------------------------
+describe("extended journey specs", () => {
+  it("ALL_JOURNEYS includes MVP + extended journeys", () => {
+    expect(ALL_JOURNEYS.length).toBe(MVP_JOURNEYS.length + EXTENDED_JOURNEYS.length);
+    expect(ALL_JOURNEYS.length).toBeGreaterThan(MVP_JOURNEYS.length);
+  });
+
+  it("extended journeys have unique IDs", () => {
+    const ids = ALL_JOURNEYS.map((j) => j.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(ids.length);
+  });
+
+  it("interactive journeys with interactions have valid step actions", () => {
+    const validActions = ["click", "type", "wait-for-selector", "wait-for-text"];
+
+    for (const journey of ALL_JOURNEYS) {
+      if (journey.interactions) {
+        for (const step of journey.interactions) {
+          expect(validActions).toContain(step.action);
+        }
+      }
+    }
+  });
+
+  it("chat-send-message journey has interaction steps", () => {
+    const chatJourney = EXTENDED_JOURNEYS.find((j) => j.id === "chat-send-message");
+    expect(chatJourney).toBeDefined();
+    expect(chatJourney?.interactions).toBeDefined();
+    expect(chatJourney?.interactions?.length).toBeGreaterThan(0);
+  });
+
+  it("InteractionStep type validation", () => {
+    const step = {
+      action: "type" as const,
+      selector: "textarea",
+      text: "test message",
+      description: "Type a message",
+    };
+    expect(step.action).toBe("type");
+    expect(step.selector).toBeDefined();
+    expect(step.text).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Report with Findings (Phase 2)
+// ---------------------------------------------------------------------------
+describe("autopilot report with findings", () => {
+  it("includes findings table when findings exist", () => {
+    const summary: AutopilotRunSummary = {
+      runId: "test-run",
+      status: "failed",
+      startedAt: "2026-03-12T04:00:00.000Z",
+      completedAt: "2026-03-12T04:02:00.000Z",
+      commitSha: "abc123",
+      journeyResults: [
+        {
+          journeyId: "chat-page-load",
+          surface: "/chat",
+          success: false,
+          durationMs: 5000,
+          errorMessage: "Timeout",
+        },
+      ],
+      findings: [
+        {
+          id: "f-1",
+          runId: "test-run",
+          category: "bug",
+          surface: "/chat",
+          title: "Chat input not rendering",
+          description: "The chat input field is missing",
+          severity: "high",
+          confidence: 0.9,
+          autoFixable: false,
+          status: "detected",
+          fingerprint: "/chat|bug|chat-input-not-rendering",
+        },
+      ],
+      evidenceManifests: [],
+      stats: {
+        totalJourneys: 1,
+        passedJourneys: 0,
+        failedJourneys: 1,
+        totalFindings: 1,
+        findingsBySeverity: { high: 1 },
+        findingsByCategory: { bug: 1 },
+      },
+    };
+
+    const report = generateMarkdownReport(summary);
+    expect(report).toContain("## Findings");
+    expect(report).toContain("Chat input not rendering");
+    expect(report).toContain("high");
+    expect(report).toContain("bug");
+  });
+
+  it("omits findings table when no findings", () => {
+    const summary: AutopilotRunSummary = {
+      runId: "test-run",
+      status: "completed",
+      startedAt: "2026-03-12T04:00:00.000Z",
+      completedAt: "2026-03-12T04:01:00.000Z",
+      commitSha: "abc123",
+      journeyResults: [
+        { journeyId: "chat-page-load", surface: "/chat", success: true, durationMs: 1000 },
+      ],
+      findings: [],
+      evidenceManifests: [],
+      stats: {
+        totalJourneys: 1,
+        passedJourneys: 1,
+        failedJourneys: 0,
+        totalFindings: 0,
+        findingsBySeverity: {},
+        findingsByCategory: {},
+      },
+    };
+
+    const report = generateMarkdownReport(summary);
+    expect(report).not.toContain("## Findings");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Fingerprint Consistency (Phase 2)
+// ---------------------------------------------------------------------------
+describe("autopilot fingerprint generation", () => {
+  it("generates consistent fingerprints for same input", () => {
+    const surface = "/chat";
+    const category = "bug";
+    const title = "Button Not Clickable";
+
+    const fingerprint1 = `${surface}|${category}|${title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .slice(0, 60)}`;
+    const fingerprint2 = `${surface}|${category}|${title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .slice(0, 60)}`;
+
+    expect(fingerprint1).toBe(fingerprint2);
+    expect(fingerprint1).toBe("/chat|bug|button-not-clickable");
+  });
+
+  it("truncates long titles in fingerprint", () => {
+    const title =
+      "This is a very long finding title that should be truncated to ensure fingerprints stay manageable in length";
+    const normalized = title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .slice(0, 60);
+    expect(normalized.length).toBeLessThanOrEqual(60);
   });
 });

--- a/trigger/autopilot-nightly.ts
+++ b/trigger/autopilot-nightly.ts
@@ -1,12 +1,16 @@
 import { logger, schedules } from "@trigger.dev/sdk";
-import { MVP_JOURNEYS } from "@/src/autopilot/config";
+import { analyzeAllEvidence } from "@/src/autopilot/analysis";
+import { ALL_JOURNEYS } from "@/src/autopilot/config";
 import { captureJourneyEvidence } from "@/src/autopilot/evidence";
+import { publishFindings } from "@/src/autopilot/github";
+import { generateMarkdownReport, uploadReportArtifacts } from "@/src/autopilot/reporting";
 import {
+  trackAutopilotIssuePublished,
   trackAutopilotRunCompleted,
   trackAutopilotRunFailed,
   trackAutopilotRunStarted,
 } from "@/src/autopilot/telemetry";
-import type { AutopilotRunSummary, RunStats } from "@/src/autopilot/types";
+import type { AutopilotEvidence, AutopilotRunSummary, RunStats } from "@/src/autopilot/types";
 
 function resolveBaseUrl(): string {
   if (process.env.AUTOPILOT_BASE_URL) {
@@ -19,13 +23,28 @@ function resolveBaseUrl(): string {
   return "http://localhost:3002";
 }
 
+function resolveGitHubConfig() {
+  const token = process.env.AUTOPILOT_GITHUB_TOKEN ?? process.env.GITHUB_TOKEN;
+  if (!token) return null;
+
+  const repo = process.env.GITHUB_REPOSITORY; // "owner/repo"
+  if (repo) {
+    const [owner, name] = repo.split("/");
+    if (owner && name) return { owner, repo: name, token };
+  }
+
+  const owner = process.env.GITHUB_OWNER ?? "RyanLisse";
+  const name = process.env.GITHUB_REPO ?? "motian";
+  return { owner, repo: name, token };
+}
+
 export const autopilotNightlyTask = schedules.task({
   id: "autopilot-nightly",
   cron: {
     pattern: "0 4 * * *",
     timezone: "Europe/Amsterdam",
   },
-  maxDuration: 300,
+  maxDuration: 600,
   retry: {
     maxAttempts: 2,
   },
@@ -33,49 +52,136 @@ export const autopilotNightlyTask = schedules.task({
     const baseUrl = resolveBaseUrl();
     const evidenceDir = process.env.AUTOPILOT_EVIDENCE_DIR ?? "/tmp/autopilot-evidence";
 
-    logger.info("Autopilot nightly run gestart", { baseUrl, evidenceDir });
-    trackAutopilotRunStarted("pending", MVP_JOURNEYS.length);
+    logger.info("Autopilot nightly run gestart", {
+      baseUrl,
+      evidenceDir,
+      journeyCount: ALL_JOURNEYS.length,
+    });
+    trackAutopilotRunStarted("pending", ALL_JOURNEYS.length);
 
     try {
-      const result = await captureJourneyEvidence(MVP_JOURNEYS, {
+      // === Step 1: Capture evidence ===
+      logger.info("Step 1: Capturing evidence...");
+      const result = await captureJourneyEvidence(ALL_JOURNEYS, {
         baseUrl,
         evidenceDir,
       });
 
+      // === Step 2: AI analysis ===
+      logger.info("Step 2: Analyzing evidence with AI...");
+      const manifests = result.journeyOutputs.map((o) => o.manifest);
+      const findings = await analyzeAllEvidence(manifests, result.runId);
+      logger.info(`AI analysis complete: ${findings.length} findings`);
+
+      // === Step 3: Build summary ===
       const passedJourneys = result.journeyOutputs.filter((o) => o.result.success).length;
       const failedJourneys = result.journeyOutputs.filter((o) => !o.result.success).length;
+
+      const findingsBySeverity: Record<string, number> = {};
+      const findingsByCategory: Record<string, number> = {};
+      for (const f of findings) {
+        findingsBySeverity[f.severity] = (findingsBySeverity[f.severity] ?? 0) + 1;
+        findingsByCategory[f.category] = (findingsByCategory[f.category] ?? 0) + 1;
+      }
 
       const stats: RunStats = {
         totalJourneys: result.journeyOutputs.length,
         passedJourneys,
         failedJourneys,
-        totalFindings: 0,
-        findingsBySeverity: {},
-        findingsByCategory: {},
+        totalFindings: findings.length,
+        findingsBySeverity,
+        findingsByCategory,
       };
 
       const summary: AutopilotRunSummary = {
         runId: result.runId,
-        status: failedJourneys === 0 ? "completed" : "failed",
+        status:
+          failedJourneys === 0 && findings.filter((f) => f.severity === "critical").length === 0
+            ? "completed"
+            : "failed",
         startedAt: result.startedAt,
         completedAt: result.completedAt,
         commitSha: result.gitSha,
         journeyResults: result.journeyOutputs.map((o) => o.result),
-        findings: [],
-        evidenceManifests: result.journeyOutputs.map((o) => o.manifest),
+        findings,
+        evidenceManifests: manifests,
         stats,
       };
 
+      // === Step 4: Generate report ===
+      logger.info("Step 4: Generating markdown report...");
+      const markdownReport = generateMarkdownReport(summary);
+
+      // === Step 5: Upload to Vercel Blob ===
+      let reportUrl: string | undefined;
+      try {
+        logger.info("Step 5: Uploading artifacts to Vercel Blob...");
+        const uploadResult = await uploadReportArtifacts(summary, markdownReport, evidenceDir);
+        reportUrl = uploadResult.reportUrl;
+        logger.info("Upload complete", {
+          reportUrl,
+          artifactCount: uploadResult.artifactUrls.length,
+        });
+      } catch (uploadErr) {
+        logger.warn("Artifact upload failed (non-fatal)", {
+          error: uploadErr instanceof Error ? uploadErr.message : String(uploadErr),
+        });
+      }
+
+      // === Step 6: Publish GitHub issues ===
+      const ghConfig = resolveGitHubConfig();
+      if (ghConfig && findings.length > 0) {
+        try {
+          logger.info("Step 6: Publishing GitHub issues...", { findingCount: findings.length });
+
+          // Build evidence map: findingId -> evidence[]
+          const evidenceByFinding = new Map<string, AutopilotEvidence[]>();
+          for (const finding of findings) {
+            const relevantManifest = manifests.find((m) => m.surface === finding.surface);
+            if (relevantManifest) {
+              evidenceByFinding.set(finding.id, relevantManifest.artifacts);
+            }
+          }
+
+          const published = await publishFindings(findings, evidenceByFinding, ghConfig, reportUrl);
+
+          for (const issue of published) {
+            trackAutopilotIssuePublished(
+              result.runId,
+              issue.findingId,
+              issue.issueNumber,
+              issue.created,
+            );
+          }
+
+          logger.info("GitHub issues published", {
+            total: published.length,
+            created: published.filter((p) => p.created).length,
+            updated: published.filter((p) => !p.created).length,
+          });
+        } catch (ghErr) {
+          logger.warn("GitHub issue publishing failed (non-fatal)", {
+            error: ghErr instanceof Error ? ghErr.message : String(ghErr),
+          });
+        }
+      } else if (!ghConfig) {
+        logger.info("Step 6: Skipping GitHub issues (no token configured)");
+      } else {
+        logger.info("Step 6: Skipping GitHub issues (no findings)");
+      }
+
+      // === Done ===
       logger.info("Autopilot nightly run voltooid", {
         runId: summary.runId,
         status: summary.status,
         totalJourneys: stats.totalJourneys,
         passedJourneys: stats.passedJourneys,
         failedJourneys: stats.failedJourneys,
+        totalFindings: stats.totalFindings,
+        reportUrl,
       });
 
       trackAutopilotRunCompleted(summary);
-
       return summary;
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

Completes the autopilot system by adding AI-powered evidence analysis, wiring the full end-to-end pipeline, and extending journey coverage.

## What changed

### 1. AI Evidence Analysis (`src/autopilot/analysis/`)
- **Multimodal analysis** — sends screenshots (PNG) + console logs to Gemini 3 Flash
- Produces `AutopilotFinding[]` with severity, category, fingerprint
- Conservative prompting to minimize false positives (empty states, dev warnings are NOT bugs)
- Graceful error handling per-manifest

### 2. Full Pipeline Wiring (`trigger/autopilot-nightly.ts`)
The nightly task now executes ALL 6 steps:
```
capture evidence → AI analysis → generate report → upload to Blob → publish GitHub issues → telemetry
```
Previously only step 1 was wired. Steps 5-6 are non-fatal (failures logged but don't crash the run).

### 3. Extended Journeys (`src/autopilot/config/journeys.ts`)
- **`chat-send-message`** — Interactive: types a message, clicks send, waits for AI response
- **`professionals-list`** — Page-load: talent pool page
- **`dashboard-load`** — Page-load: dashboard KPI cards
- New `InteractionStep` system for click/type/wait actions
- `expectedSelectors` validation before screenshot capture
- `ALL_JOURNEYS` = MVP + Extended (6 total)

### 4. Test Coverage (`tests/autopilot.test.ts`)
- **34 tests** (was 21), all passing
- New: analysis schema validation, extended journey specs, report with findings, fingerprint consistency

## Beads completed
- `motian-dyu` — AI evidence analysis module
- `motian-6l0` — Wire full pipeline in nightly trigger
- `motian-tpb` — Extended autopilot journeys
- `motian-htr` — Phase 2 test coverage

## Verification
- ✅ `pnpm exec tsc --noEmit` — clean
- ✅ `pnpm lint` — no new errors
- ✅ 34/34 tests passing

Co-Authored-By: Claude <noreply@anthropic.com>

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
