### PR TITLE
fix: allow first-party CV upload without bearer token

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -11,7 +11,7 @@ const PUBLIC_PATHS = ["/api/gezondheid", "/api/cron", "/api/openapi"];
  * origin.  External / cross-origin callers without a valid bearer token are
  * still rejected.
  */
-const FIRST_PARTY_PATHS = ["/api/chat", "/api/chat-sessies"];
+const FIRST_PARTY_PATHS = ["/api/chat", "/api/chat-sessies", "/api/cv-upload", "/api/cv-analyse"];
 
 const PUBLIC_GET_PATHS = ["/api/opdrachten/zoeken"];
 

--- a/tests/salesforce-feed-auth.test.ts
+++ b/tests/salesforce-feed-auth.test.ts
@@ -24,6 +24,19 @@ describe("API auth via proxy", () => {
     },
   ] as const;
 
+  const cvFirstPartyEndpoints = [
+    {
+      description: "the CV upload endpoint",
+      method: "POST",
+      url: "http://localhost/api/cv-upload",
+    },
+    {
+      description: "the CV analyse endpoint",
+      method: "POST",
+      url: "http://localhost/api/cv-analyse",
+    },
+  ] as const;
+
   afterEach(() => {
     if (originalApiSecret === undefined) {
       delete process.env.API_SECRET;
@@ -75,80 +88,129 @@ describe("API auth via proxy", () => {
     expect(response.status).toBe(200);
   });
 
-  it.each(
-    chatFirstPartyEndpoints,
-  )("allows same-origin $description without a bearer token when API_SECRET is configured", ({
-    method,
-    url,
-  }) => {
+  it.each(chatFirstPartyEndpoints)(
+    "allows same-origin $description without a bearer token when API_SECRET is configured",
+    ({ method, url }) => {
     process.env.API_SECRET = "test-secret";
     process.env.NODE_ENV = "production";
     process.env.VERCEL_ENV = "production";
 
-    // Same-origin requests have no Origin header
-    const response = proxy(new NextRequest(url, { method }));
+      // Same-origin requests have no Origin header
+      const response = proxy(new NextRequest(url, { method }));
 
-    expect(response.status).toBe(200);
-  });
+      expect(response.status).toBe(200);
+    },
+  );
 
-  it.each(
-    chatFirstPartyEndpoints,
-  )("allows same-origin $description when the browser sends its own Origin header", ({
-    method,
-    url,
-  }) => {
+  it.each(chatFirstPartyEndpoints)(
+    "allows same-origin $description when the browser sends its own Origin header",
+    ({ method, url }) => {
     process.env.API_SECRET = "test-secret";
     process.env.NODE_ENV = "production";
     process.env.VERCEL_ENV = "production";
 
-    const response = proxy(
-      new NextRequest(url, {
-        method,
-        headers: { Origin: new URL(url).origin },
-      }),
-    );
+      const response = proxy(
+        new NextRequest(url, {
+          method,
+          headers: { Origin: new URL(url).origin },
+        }),
+      );
 
-    expect(response.status).toBe(200);
-  });
+      expect(response.status).toBe(200);
+    },
+  );
 
-  it.each(chatFirstPartyEndpoints)("blocks cross-origin $description without a bearer token", ({
-    method,
-    url,
-  }) => {
+  it.each(chatFirstPartyEndpoints)(
+    "blocks cross-origin $description without a bearer token",
+    ({ method, url }) => {
     process.env.API_SECRET = "test-secret";
     process.env.NODE_ENV = "production";
     process.env.VERCEL_ENV = "production";
 
     // Cross-origin request from unknown origin should be rejected
-    const response = proxy(
-      new NextRequest(url, {
-        method,
-        headers: { Origin: "https://evil.example.com" },
-      }),
-    );
+      const response = proxy(
+        new NextRequest(url, {
+          method,
+          headers: { Origin: "https://evil.example.com" },
+        }),
+      );
 
-    expect(response.status).toBe(401);
-  });
+      expect(response.status).toBe(401);
+    },
+  );
 
-  it.each(
-    chatFirstPartyEndpoints,
-  )("allows $description with valid bearer token regardless of origin", ({ method, url }) => {
+  it.each(chatFirstPartyEndpoints)(
+    "allows $description with valid bearer token regardless of origin",
+    ({ method, url }) => {
     process.env.API_SECRET = "test-secret";
     process.env.NODE_ENV = "production";
     process.env.VERCEL_ENV = "production";
 
-    const response = proxy(
-      new NextRequest(url, {
-        method,
-        headers: {
-          Authorization: "Bearer test-secret",
-          Origin: "https://evil.example.com",
-        },
-      }),
-    );
+      const response = proxy(
+        new NextRequest(url, {
+          method,
+          headers: {
+            Authorization: "Bearer test-secret",
+            Origin: "https://evil.example.com",
+          },
+        }),
+      );
 
-    expect(response.status).toBe(200);
-  });
+      expect(response.status).toBe(200);
+    },
+  );
+
+  it.each(cvFirstPartyEndpoints)(
+    "allows same-origin $description without a bearer token when API_SECRET is configured",
+    ({ method, url }) => {
+      process.env.API_SECRET = "test-secret";
+      process.env.NODE_ENV = "production";
+      process.env.VERCEL_ENV = "production";
+
+      const response = proxy(new NextRequest(url, { method }));
+
+      expect(response.status).toBe(200);
+    },
+  );
+
+  it.each(cvFirstPartyEndpoints)(
+    "blocks cross-origin $description without a bearer token",
+    ({ method, url }) => {
+      process.env.API_SECRET = "test-secret";
+      process.env.NODE_ENV = "production";
+      process.env.VERCEL_ENV = "production";
+
+      const response = proxy(
+        new NextRequest(url, {
+          method,
+          headers: { Origin: "https://evil.example.com" },
+        }),
+      );
+
+      expect(response.status).toBe(401);
+    },
+  );
+
+  it.each(cvFirstPartyEndpoints)(
+    "allows $description with valid bearer token regardless of origin",
+    ({ method, url }) => {
+      process.env.API_SECRET = "test-secret";
+      process.env.NODE_ENV = "production";
+      process.env.VERCEL_ENV = "production";
+
+      const response = proxy(
+        new NextRequest(url, {
+          method,
+          headers: {
+            Authorization: "Bearer test-secret",
+            Origin: "https://evil.example.com",
+          },
+        }),
+      );
+
+      expect(response.status).toBe(200);
+    },
+  );
 
   it("fails closed in production when API_SECRET is missing", async () => {
     delete process.env.API_SECRET;


### PR DESCRIPTION
## Summary
- Treat `/api/cv-upload` and `/api/cv-analyse` as first-party browser routes so same-origin requests can upload CVs without a bearer token.
- Keep cross-origin callers locked behind API_SECRET while updating the auth proxy suite to cover these CV endpoints.

## Test plan
- pnpm test -- tests/salesforce-feed-auth.test.ts tests/cv-upload-api.test.ts

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
