### PR TITLE
feat(storybook): optional theme toggle and viewport presets

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,18 +1,58 @@
 import type { Preview } from "@storybook/nextjs-vite";
 import "../app/globals.css";
 
+const VIEWPORT_PRESETS = {
+  mobile: {
+    name: "Mobile",
+    styles: { width: "375px", height: "667px" },
+  },
+  tablet: {
+    name: "Tablet",
+    styles: { width: "768px", height: "1024px" },
+  },
+  desktop: {
+    name: "Desktop",
+    styles: { width: "1280px", height: "800px" },
+  },
+};
+
 const preview: Preview = {
+  globalTypes: {
+    theme: {
+      description: "Theme",
+      toolbar: {
+        title: "Theme",
+        icon: "circlehollow",
+        items: ["light", "dark"],
+        dynamicTitle: true,
+      },
+    },
+  },
+  initialGlobals: {
+    theme: "dark",
+  },
   parameters: {
     nextjs: {
       appDirectory: true,
     },
+    docs: {
+      autodocs: true,
+    },
+    viewport: {
+      viewports: VIEWPORT_PRESETS,
+    },
   },
   decorators: [
-    (Story) => (
-      <div className="dark bg-[#0d0d0d] p-6 min-h-screen">
-        <Story />
-      </div>
-    ),
+    (Story, context) => {
+      const theme = (context.globals?.theme as "light" | "dark" | undefined) ?? "dark";
+      const wrapperClass =
+        theme === "dark" ? "dark bg-[#0d0d0d] p-6 min-h-screen" : "p-6 min-h-screen bg-background";
+      return (
+        <div className={wrapperClass}>
+          <Story />
+        </div>
+      );
+    },
   ],
 };
 


### PR DESCRIPTION
Preview and theming: Theme toggle and viewport presets added; existing dark decorator unchanged (default remains dark).

- **Theme toggle**: `globalTypes.theme` (light/dark) with toolbar; `initialGlobals.theme = 'dark'` so default is unchanged.
- **Decorator**: Reads `context.globals.theme` and applies `dark bg-[#0d0d0d]` or light `bg-background` wrapper.
- **Viewport presets**: Mobile (375px), Tablet (768px), Desktop (1280px) in `parameters.viewport.viewports`.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added viewport presets for mobile, tablet, and desktop component previews
  * Introduced dynamic theme switching (light/dark mode) in Storybook
  * Enabled automatic documentation generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->