### PR TITLE
fix(storybook): address PR 74 review comments

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -5,14 +5,17 @@ const VIEWPORT_PRESETS = {
   mobile: {
     name: "Mobile",
     styles: { width: "375px", height: "667px" },
+    type: "mobile" as const,
   },
   tablet: {
     name: "Tablet",
     styles: { width: "768px", height: "1024px" },
+    type: "tablet" as const,
   },
   desktop: {
     name: "Desktop",
     styles: { width: "1280px", height: "800px" },
+    type: "desktop" as const,
   },
 };
 
@@ -36,7 +39,7 @@ const preview: Preview = {
       appDirectory: true,
     },
     docs: {
-      autodocs: true,
+      autodocs: "tag",
     },
     viewport: {
       viewports: VIEWPORT_PRESETS,


### PR DESCRIPTION
Follow-up to #74 (Storybook preview theming).

**Review comments addressed:**
1. **Greptile – autodocs**: Use `autodocs: 'tag'` instead of `true` so only stories with `tags: ['autodocs']` get auto-generated docs (Storybook 8+ tag-based opt-in).
2. **Greptile – viewport type**: Add `type: 'mobile' | 'tablet' | 'desktop'` to each viewport preset for addon toolbar icons and sorting.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced viewport preset definitions with explicit type declarations for mobile, tablet, and desktop breakpoints to improve type safety across responsive design previews
  * Updated Storybook documentation generation configuration for improved documentation handling and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->