### PR TITLE
fix: remove debug logging from flextender scraper

### DIFF
--- a/packages/scrapers/src/flextender.ts
+++ b/packages/scrapers/src/flextender.ts
@@ -129,28 +129,6 @@ function parseFlextenderHtml(html: string): FlextenderListing[] {
     const parsed = parseHoursPerWeek(fields["Uren per week"]);
     const hoursPerWeek = parsed.hoursPerWeek != null ? Math.min(MAX_HOURS_PER_WEEK, parsed.hoursPerWeek) : undefined;
     const minHoursPerWeek = parsed.minHoursPerWeek != null ? Math.min(MAX_HOURS_PER_WEEK, parsed.minHoursPerWeek) : undefined;
-    // #region agent log
-    if (hoursPerWeek === 0 || minHoursPerWeek === 0) {
-      fetch("http://127.0.0.1:7696/ingest/807648ac-0e4a-43e7-9281-fc9626035545", {
-        method: "POST",
-        headers: { "Content-Type": "application/json", "X-Debug-Session-Id": "df9709" },
-        body: JSON.stringify({
-          sessionId: "df9709",
-          hypothesisId: "H1",
-          location: "flextender.ts:listing-hours",
-          message: "listing hoursPerWeek or minHoursPerWeek is 0",
-          data: {
-            externalId,
-            rawUrenPerWeek: fields["Uren per week"],
-            hoursPerWeek,
-            minHoursPerWeek,
-          },
-          timestamp: Date.now(),
-        }),
-      }).catch(() => {});
-    }
-    // #endregion
-
     // Extract company logo URL
     const logoMatch =
       cardHtml.match(/class="flx-client-logo"[^>]*src="([^"]+)"/i) ??
@@ -216,29 +194,6 @@ async function enrichListings(
           }
           const { _rawHours, ...listingClean } = listing;
           const merged = { ...listingClean, ...detail };
-          // #region agent log
-          if (
-            (merged as { hoursPerWeek?: number }).hoursPerWeek === 0 ||
-            (merged as { minHoursPerWeek?: number }).minHoursPerWeek === 0
-          ) {
-            fetch("http://127.0.0.1:7696/ingest/807648ac-0e4a-43e7-9281-fc9626035545", {
-              method: "POST",
-              headers: { "Content-Type": "application/json", "X-Debug-Session-Id": "df9709" },
-              body: JSON.stringify({
-                sessionId: "df9709",
-                hypothesisId: "H5",
-                location: "flextender.ts:enrich-merged",
-                message: "merged listing has hoursPerWeek or minHoursPerWeek 0",
-                data: {
-                  externalId: merged.externalId,
-                  hoursPerWeek: (merged as { hoursPerWeek?: number }).hoursPerWeek,
-                  minHoursPerWeek: (merged as { minHoursPerWeek?: number }).minHoursPerWeek,
-                },
-                timestamp: Date.now(),
-              }),
-            }).catch(() => {});
-          }
-          // #endregion
           return merged;
         } catch (err) {
           detailFailures++;
@@ -415,29 +370,6 @@ function parseDetailHtml(html: string): FlextenderDetail {
 
   // hoursPerWeek from summary (may override listing-level if detail has it)
   const summaryHours = parseHoursPerWeek(summaryFields["Uren per week"]);
-  // #region agent log
-  if (
-    summaryHours.hoursPerWeek === 0 ||
-    summaryHours.minHoursPerWeek === 0 ||
-    (summaryHours.hoursPerWeek !== undefined && summaryHours.hoursPerWeek <= 0)
-  ) {
-    fetch("http://127.0.0.1:7696/ingest/807648ac-0e4a-43e7-9281-fc9626035545", {
-      method: "POST",
-      headers: { "Content-Type": "application/json", "X-Debug-Session-Id": "df9709" },
-      body: JSON.stringify({
-        sessionId: "df9709",
-        hypothesisId: "H2",
-        location: "flextender.ts:detail-summary-hours",
-        message: "detail summaryHours has 0 or non-positive",
-        data: {
-          rawUrenPerWeek: summaryFields["Uren per week"],
-          summaryHours,
-        },
-        timestamp: Date.now(),
-      }),
-    }).catch(() => {});
-  }
-  // #endregion
   if (summaryHours.hoursPerWeek) {
     result.hoursPerWeek = Math.min(MAX_HOURS_PER_WEEK, summaryHours.hoursPerWeek);
     if (summaryHours.minHoursPerWeek)


### PR DESCRIPTION
## Summary
- Remove 3 leftover `#region agent log` blocks from `packages/scrapers/src/flextender.ts`
- These blocks fire HTTP POSTs to `127.0.0.1:7696` (local debug agent) on every scrape run
- In production (Trigger.dev), these silently fail but add unnecessary network calls and latency

## Scraper Health Analysis
Reviewed all 6 platform scrapers for issues:

| Platform | Status | Notes |
|----------|--------|-------|
| Opdrachtoverheid | Healthy | API-based, retry logic, stable |
| Flextender | **Fixed** | Removed debug logging leak |
| Striive | Fragile | Modal sandbox + Playwright auth, depends on credentials |
| NVB | Fragile | Consent gate requires Playwright browser bootstrap |
| Werkzoeken | Healthy | HTML parsing with detail enrichment |
| Monsterboard | Fragile | DataDome anti-bot detection possible |

No Sentry issues found. Trigger.dev config has proper Sentry integration for error reporting.

## Test plan
- [x] `pnpm test` — 920/920 pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [x] No remaining `127.0.0.1:7696` references in scrapers package

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal debug instrumentation code to improve code maintainability and reduce technical debt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->