### PR TITLE
feat: add salesforce feed parity for CLI and MCP

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -958,6 +958,31 @@ Motian exposes a live **read-only XML feed** for **pull-based Salesforce integra
 - **Salesforce object mapping**: `Application__c`, `Job__c`, `Candidate__c`
 - **Auth**: the route reuses shared `/api/*` bearer auth via `API_SECRET`, but production currently appears publicly reachable because `API_SECRET` is likely unset there
 
+### Access via API, CLI, and MCP
+
+```bash
+# HTTP API
+curl "https://motian.vercel.app/api/salesforce-feed?entity=jobs&status=open&limit=25"
+
+# Local CLI
+pnpm cli salesforce:feed --entity jobs --status open --updated-since 2026-03-01T00:00:00.000Z --limit 25
+
+# MCP tool
+{
+  "name": "salesforce_feed",
+  "arguments": {
+    "entity": "jobs",
+    "status": "open",
+    "updatedSince": "2026-03-01T00:00:00.000Z",
+    "limit": 25
+  }
+}
+```
+
+- **CLI output**: JSON containing `entity`, `count`, and the raw `xml` string
+- **MCP output**: JSON containing `entity`, `count`, and the same `xml` string
+- **Parity**: API, CLI, and MCP all reuse `src/services/salesforce-feed.ts`
+
 ---
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -983,6 +983,31 @@ Motian publiceert een live **read-only XML feed** voor **pull-based Salesforce i
 - **Salesforce object mapping**: `Application__c`, `Job__c`, `Candidate__c`
 - **Authenticatie**: de route hergebruikt de gedeelde `/api/*` bearer auth via `API_SECRET`, maar productie lijkt momenteel publiek bereikbaar omdat `API_SECRET` daar waarschijnlijk niet is ingesteld
 
+### Gebruik via API, CLI en MCP
+
+```bash
+# HTTP API
+curl "https://motian.vercel.app/api/salesforce-feed?entity=jobs&status=open&limit=25"
+
+# Lokale CLI
+pnpm cli salesforce:feed --entity jobs --status open --updated-since 2026-03-01T00:00:00.000Z --limit 25
+
+# MCP tool
+{
+  "name": "salesforce_feed",
+  "arguments": {
+    "entity": "jobs",
+    "status": "open",
+    "updatedSince": "2026-03-01T00:00:00.000Z",
+    "limit": 25
+  }
+}
+```
+
+- **CLI output**: JSON met `entity`, `count` en de ruwe `xml` string
+- **MCP output**: JSON met `entity`, `count` en dezelfde `xml` string
+- **Parity**: API, CLI en MCP gebruiken dezelfde service in `src/services/salesforce-feed.ts`
+
 ---
 
 ## Deployment

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,6 +98,12 @@ Live URL: `https://motian.vercel.app/api/salesforce-feed`
 
 Supported query params: `entity`, `id`, `updatedSince`, `status`, `page`, `limit`.
 
+Other surfaces for the same export:
+
+- CLI: `pnpm cli salesforce:feed --entity jobs --status open --limit 25`
+- MCP: `salesforce_feed` tool with `{ entity, status, updatedSince, limit, offset|page }`
+- Contract: API returns raw XML; CLI and MCP wrap the same XML string in JSON metadata (`entity`, `count`, `xml`)
+
 ## AI Models
 
 | Model | Provider | Purpose | Service |

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -48,6 +48,12 @@ import { createMessage, listMessages } from "../services/messages";
 // ========== GDPR ==========
 
 import { eraseCandidateData, exportCandidateData, scrubContactData } from "../services/gdpr";
+import {
+  buildSalesforceFeedXml,
+  getSalesforceFeed,
+  parseSalesforceFeedEntity,
+  parseUpdatedSinceParam,
+} from "../services/salesforce-feed";
 
 // ========== Operaties ==========
 
@@ -98,6 +104,20 @@ function optionalNumber(args: ParsedArgs, key: string): number | undefined {
 function optionalStringList(args: ParsedArgs, key: string): string[] | undefined {
   const val = args[key];
   return typeof val === "string" ? val.split(",").map((s) => s.trim()) : undefined;
+}
+
+function clampFeedLimit(value?: number): number {
+  if (value === undefined) return 50;
+  return Math.min(100, Math.max(1, value));
+}
+
+function resolveFeedOffset(args: ParsedArgs, limit: number): number {
+  const offset = optionalNumber(args, "offset");
+  if (offset !== undefined) return Math.max(0, offset);
+
+  const page = optionalNumber(args, "page");
+  const normalizedPage = page === undefined ? 1 : Math.max(1, page);
+  return normalizedPage > 1 ? (normalizedPage - 1) * limit : 0;
 }
 
 // ========== Command Registry ==========
@@ -710,6 +730,43 @@ export const commands: Record<string, Command> = {
         platform: optionalString(args, "platform"),
         limit: optionalNumber(args, "limit"),
       });
+    },
+  },
+
+  // ── Salesforce ────────────────────────────────────────────────────────
+
+  "salesforce:feed": {
+    description: "Toon de Salesforce XML-feed voor jobs, candidates of applications",
+    usage:
+      "[--entity <jobs|candidates|applications>] [--id <uuid>] [--status <status>] [--updated-since <ISO-datum>] [--limit <n>] [--offset <n>] [--page <n>]",
+    handler: async (args) => {
+      const entityArg = optionalString(args, "entity");
+      const entity = parseSalesforceFeedEntity(entityArg) ?? "applications";
+
+      if (entityArg && !parseSalesforceFeedEntity(entityArg)) {
+        throw new Error("Ongeldige entity. Gebruik jobs, candidates of applications.");
+      }
+
+      const updatedSince = parseUpdatedSinceParam(optionalString(args, "updated-since"));
+      if (optionalString(args, "updated-since") && updatedSince === null) {
+        throw new Error("Ongeldige updatedSince. Gebruik een geldige ISO 8601 datum.");
+      }
+
+      const limit = clampFeedLimit(optionalNumber(args, "limit"));
+      const records = await getSalesforceFeed({
+        entity,
+        id: optionalString(args, "id")?.trim() || undefined,
+        updatedSince: updatedSince ?? undefined,
+        status: optionalString(args, "status")?.trim() || undefined,
+        limit,
+        offset: resolveFeedOffset(args, limit),
+      });
+
+      return {
+        entity,
+        count: records.length,
+        xml: buildSalesforceFeedXml(records),
+      };
     },
   },
 

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -8,6 +8,10 @@ import { handlers as kandidatenHandlers, tools as kandidatenTools } from "./kand
 import { handlers as matchHandlers, tools as matchTools } from "./matches.js";
 import { handlers as pipelineHandlers, tools as pipelineTools } from "./pipeline.js";
 import { handlers as platformsHandlers, tools as platformsTools } from "./platforms.js";
+import {
+  handlers as salesforceFeedHandlers,
+  tools as salesforceFeedTools,
+} from "./salesforce-feed.js";
 import { handlers as vacatureHandlers, tools as vacatureTools } from "./vacatures.js";
 
 export const allTools = [
@@ -16,6 +20,7 @@ export const allTools = [
   ...matchTools,
   ...pipelineTools,
   ...platformsTools,
+  ...salesforceFeedTools,
   ...gdprOpsTools,
   ...analyticsTools,
   ...advancedMatchingTools,
@@ -27,6 +32,7 @@ export const allHandlers: Record<string, (args: unknown) => Promise<unknown>> = 
   ...matchHandlers,
   ...pipelineHandlers,
   ...platformsHandlers,
+  ...salesforceFeedHandlers,
   ...gdprOpsHandlers,
   ...analyticsHandlers,
   ...advancedMatchingHandlers,

--- a/src/mcp/tools/salesforce-feed.ts
+++ b/src/mcp/tools/salesforce-feed.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import {
+  buildSalesforceFeedXml,
+  getSalesforceFeed,
+  parseSalesforceFeedEntity,
+  parseUpdatedSinceParam,
+  SALESFORCE_FEED_ENTITIES,
+} from "../../services/salesforce-feed.js";
+
+const salesforceFeedSchema = z.object({
+  entity: z
+    .enum(SALESFORCE_FEED_ENTITIES)
+    .optional()
+    .describe("Salesforce entity: jobs, candidates of applications"),
+  id: z.string().optional().describe("Optioneel record-id filter"),
+  status: z.string().optional().describe("Optionele statusfilter"),
+  updatedSince: z
+    .string()
+    .optional()
+    .describe("Alleen records bijgewerkt sinds deze ISO 8601 datum"),
+  limit: z.number().int().min(1).max(100).optional().describe("Maximum aantal records"),
+  offset: z.number().int().min(0).optional().describe("Offset voor paginering"),
+  page: z.number().int().min(1).optional().describe("Paginanummer als alternatief voor offset"),
+});
+
+function resolveOffset(limit: number, offset?: number, page?: number): number {
+  if (offset !== undefined) return offset;
+  return page && page > 1 ? (page - 1) * limit : 0;
+}
+
+export const tools = [
+  {
+    name: "salesforce_feed",
+    description: "Haal de Salesforce XML-feed op voor jobs, candidates of applications.",
+    inputSchema: zodToJsonSchema(salesforceFeedSchema, { $refStrategy: "none" }),
+  },
+];
+
+export const handlers: Record<string, (args: unknown) => Promise<unknown>> = {
+  salesforce_feed: async (raw) => {
+    const parsed = salesforceFeedSchema.parse(raw);
+    const entity = parseSalesforceFeedEntity(parsed.entity) ?? "applications";
+    const updatedSince = parseUpdatedSinceParam(parsed.updatedSince);
+
+    if (parsed.updatedSince && updatedSince === null) {
+      throw new Error("Ongeldige updatedSince. Gebruik een geldige ISO 8601 datum.");
+    }
+
+    const limit = parsed.limit ?? 50;
+    const records = await getSalesforceFeed({
+      entity,
+      id: parsed.id?.trim() || undefined,
+      updatedSince: updatedSince ?? undefined,
+      status: parsed.status?.trim() || undefined,
+      limit,
+      offset: resolveOffset(limit, parsed.offset, parsed.page),
+    });
+
+    return {
+      entity,
+      count: records.length,
+      xml: buildSalesforceFeedXml(records),
+    };
+  },
+};

--- a/tests/salesforce-feed-cli.test.ts
+++ b/tests/salesforce-feed-cli.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetSalesforceFeed } = vi.hoisted(() => ({
+  mockGetSalesforceFeed: vi.fn(),
+}));
+
+vi.mock("../src/services/auto-matching", () => ({
+  autoMatchCandidateToJobs: vi.fn(),
+  autoMatchJobToCandidates: vi.fn(),
+}));
+
+vi.mock("../src/services/candidates", () => ({
+  addNoteToCandidate: vi.fn(),
+  createCandidate: vi.fn(),
+  deleteCandidate: vi.fn(),
+  getCandidateById: vi.fn(),
+  listCandidates: vi.fn(),
+  searchCandidates: vi.fn(),
+  updateCandidate: vi.fn(),
+}));
+
+vi.mock("../src/services/jobs", () => ({
+  deleteJob: vi.fn(),
+  getJobById: vi.fn(),
+  getJobStats: vi.fn(),
+  searchJobsUnified: vi.fn(),
+  updateJob: vi.fn(),
+}));
+
+vi.mock("../src/services/matches", () => ({
+  createMatch: vi.fn(),
+  deleteMatch: vi.fn(),
+  getMatchById: vi.fn(),
+  listMatches: vi.fn(),
+  updateMatchStatus: vi.fn(),
+}));
+
+vi.mock("../src/services/applications", () => ({
+  createApplication: vi.fn(),
+  getApplicationById: vi.fn(),
+  getApplicationStats: vi.fn(),
+  listApplications: vi.fn(),
+  updateApplicationStage: vi.fn(),
+}));
+
+vi.mock("../src/services/interviews", () => ({
+  createInterview: vi.fn(),
+  listInterviews: vi.fn(),
+  updateInterview: vi.fn(),
+}));
+
+vi.mock("../src/services/messages", () => ({
+  createMessage: vi.fn(),
+  listMessages: vi.fn(),
+}));
+
+vi.mock("../src/services/gdpr", () => ({
+  eraseCandidateData: vi.fn(),
+  exportCandidateData: vi.fn(),
+  scrubContactData: vi.fn(),
+}));
+
+vi.mock("../src/services/operations-console", () => ({
+  importJobsFromActiveScrapers: vi.fn(),
+  reviewGdprRetention: vi.fn(),
+  runCandidateScoringBatch: vi.fn(),
+}));
+
+vi.mock("../src/services/scrape-results", () => ({
+  getHistory: vi.fn(),
+}));
+
+vi.mock("../src/services/scrapers", () => ({
+  activatePlatform: vi.fn(),
+  createConfig: vi.fn(),
+  createPlatformCatalogEntry: vi.fn(),
+  getAllConfigs: vi.fn(),
+  getHealth: vi.fn(),
+  getPlatformOnboardingStatus: vi.fn(),
+  listPlatformCatalog: vi.fn(),
+  triggerTestRun: vi.fn(),
+  updateConfig: vi.fn(),
+  validateConfig: vi.fn(),
+}));
+
+vi.mock("../src/services/salesforce-feed", async () => {
+  const actual = await vi.importActual<typeof import("../src/services/salesforce-feed")>(
+    "../src/services/salesforce-feed",
+  );
+
+  return {
+    ...actual,
+    getSalesforceFeed: mockGetSalesforceFeed,
+  };
+});
+
+import { commands } from "../src/cli/commands";
+
+describe("salesforce CLI command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSalesforceFeed.mockResolvedValue([]);
+  });
+
+  it("registers a Salesforce feed command that returns shared XML output", async () => {
+    mockGetSalesforceFeed.mockResolvedValue([
+      {
+        objectType: "Application__c",
+        fields: {
+          Id: "app-1",
+          Name: "R&D <Lead>",
+          Status__c: "screening",
+          LastModifiedDate: new Date("2026-03-01T00:00:00.000Z"),
+        },
+      },
+    ]);
+
+    const command = commands["salesforce:feed"];
+
+    expect(command).toBeDefined();
+
+    const result = await command.handler({
+      entity: "applications",
+      status: "screening",
+      "updated-since": "2026-03-01T10:00:00.000Z",
+      limit: "25",
+      offset: "50",
+    });
+
+    const args = mockGetSalesforceFeed.mock.calls[0]?.[0];
+
+    expect(args).toMatchObject({
+      entity: "applications",
+      status: "screening",
+      limit: 25,
+      offset: 50,
+    });
+    expect(args.updatedSince.toISOString()).toBe("2026-03-01T10:00:00.000Z");
+    expect(result).toMatchObject({
+      entity: "applications",
+      count: 1,
+    });
+    expect(result.xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(result.xml).toContain("<type>Application__c</type>");
+    expect(result.xml).toContain("<Name>R&amp;D &lt;Lead&gt;</Name>");
+  });
+
+  it("clamps CLI pagination to the same safe bounds as the API route", async () => {
+    const command = commands["salesforce:feed"];
+
+    expect(command).toBeDefined();
+
+    await command.handler({
+      entity: "jobs",
+      limit: "100000",
+      offset: "-5",
+    });
+
+    expect(mockGetSalesforceFeed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity: "jobs",
+        limit: 100,
+        offset: 0,
+      }),
+    );
+  });
+});

--- a/tests/salesforce-feed-mcp.test.ts
+++ b/tests/salesforce-feed-mcp.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetSalesforceFeed } = vi.hoisted(() => ({
+  mockGetSalesforceFeed: vi.fn(),
+}));
+
+vi.mock("../src/mcp/tools/advanced-matching.js", () => ({
+  handlers: {},
+  tools: [],
+}));
+
+vi.mock("../src/mcp/tools/analytics.js", () => ({
+  handlers: {},
+  tools: [],
+}));
+
+vi.mock("../src/mcp/tools/gdpr-ops.js", () => ({
+  handlers: {},
+  tools: [],
+}));
+
+vi.mock("../src/mcp/tools/kandidaten.js", () => ({
+  handlers: {},
+  tools: [],
+}));
+
+vi.mock("../src/mcp/tools/matches.js", () => ({
+  handlers: {},
+  tools: [],
+}));
+
+vi.mock("../src/mcp/tools/pipeline.js", () => ({
+  handlers: {},
+  tools: [],
+}));
+
+vi.mock("../src/mcp/tools/platforms.js", () => ({
+  handlers: {},
+  tools: [],
+}));
+
+vi.mock("../src/mcp/tools/vacatures.js", () => ({
+  handlers: {},
+  tools: [],
+}));
+
+vi.mock("../src/services/salesforce-feed", async () => {
+  const actual = await vi.importActual<typeof import("../src/services/salesforce-feed")>(
+    "../src/services/salesforce-feed",
+  );
+
+  return {
+    ...actual,
+    getSalesforceFeed: mockGetSalesforceFeed,
+  };
+});
+
+import { allHandlers, allTools } from "../src/mcp/tools/index";
+
+describe("salesforce MCP tool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSalesforceFeed.mockResolvedValue([]);
+  });
+
+  it("registers an MCP Salesforce feed tool that returns XML from the shared feed service", async () => {
+    mockGetSalesforceFeed.mockResolvedValue([
+      {
+        objectType: "Job__c",
+        fields: {
+          Id: "job-1",
+          Name: "Architect & Integratie",
+          LastModifiedDate: new Date("2026-03-02T12:00:00.000Z"),
+        },
+      },
+    ]);
+
+    const tool = allTools.find((entry) => entry.name === "salesforce_feed");
+    const handler = allHandlers.salesforce_feed;
+
+    expect(tool).toBeDefined();
+    expect(handler).toBeTypeOf("function");
+
+    const result = await handler({
+      entity: "jobs",
+      status: "open",
+      updatedSince: "2026-03-01T00:00:00.000Z",
+      limit: 10,
+      offset: 20,
+    });
+
+    const args = mockGetSalesforceFeed.mock.calls[0]?.[0];
+
+    expect(args).toMatchObject({
+      entity: "jobs",
+      status: "open",
+      limit: 10,
+      offset: 20,
+    });
+    expect(args.updatedSince.toISOString()).toBe("2026-03-01T00:00:00.000Z");
+    expect(result).toMatchObject({
+      entity: "jobs",
+      count: 1,
+    });
+    expect(result.xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(result.xml).toContain("<type>Job__c</type>");
+    expect(result.xml).toContain("<Name>Architect &amp; Integratie</Name>");
+  });
+});


### PR DESCRIPTION
## Summary
- add a `salesforce:feed` CLI command backed by the shared Salesforce feed service
- add a `salesforce_feed` MCP tool and register it in the MCP tool index
- document API, CLI, and MCP usage for the Salesforce XML stream in the READMEs and architecture docs

## Testing
- `pnpm test tests/salesforce-feed-cli.test.ts tests/salesforce-feed-mcp.test.ts tests/salesforce-feed-route.test.ts tests/salesforce-feed-auth.test.ts`
- `pnpm exec biome check src/cli/commands.ts src/mcp/tools/index.ts src/mcp/tools/salesforce-feed.ts tests/salesforce-feed-cli.test.ts tests/salesforce-feed-mcp.test.ts README.md README.en.md docs/architecture.md`

## Notes
- CLI pagination is clamped to the same safe bounds as the API route so the parity surface cannot pass negative offsets or oversized limits.
- Live CLI smoke against real data was not possible in this worktree because `DATABASE_URL` / `TURSO_DATABASE_URL` is not configured.
- `pnpm exec tsc --noEmit` did not produce a completed result in this session, so CI should remain the source of truth for the full repository typecheck.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI command `pnpm cli salesforce:feed` to access Salesforce feed with filtering options (entity, status, limit, offset, page, updated-since).
  * Added MCP tool support for Salesforce feed queries.

* **Documentation**
  * Updated documentation with concrete usage examples for accessing Salesforce feed across API, CLI, and MCP interfaces.

* **Tests**
  * Added test coverage for CLI and MCP Salesforce feed functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->