### PR TITLE
refactor: remove Turso fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,6 @@
 # Database primary (Neon PostgreSQL)
 DATABASE_URL=postgresql://user:password@host/database?sslmode=require
 
-# Database fallback (Turso / libSQL) - optional backup path
-TURSO_DATABASE_URL=libsql://your-database.turso.io
-TURSO_AUTH_TOKEN=your-token-here
-
 # Scraping - Browserbase (voor Striive + andere authenticated platforms)
 BROWSERBASE_API_KEY=bb-XXXXXXXXXXXXXXXXXXXXXXXX
 BROWSERBASE_PROJECT_ID=proj-XXXXXXXXXXXXXXXX

--- a/.factory/services.yaml
+++ b/.factory/services.yaml
@@ -12,10 +12,3 @@ services:
     healthcheck: curl -sf http://localhost:3002/api/gezondheid
     port: 3002
     depends_on: []
-
-  turso:
-    start: echo "Turso is managed externally"
-    stop: echo "No stop needed"
-    healthcheck: echo "N/A"
-    port: 0
-    depends_on: []

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,7 +11,6 @@
     "./pool-config": "./src/pool-config.ts"
   },
   "dependencies": {
-    "@libsql/client": "^0.14.0",
     "drizzle-orm": "^0.38.4",
     "pg": "^8.20.0"
   },

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,20 +1,10 @@
-import { createClient } from "@libsql/client";
-import { drizzle as drizzleLibsql } from "drizzle-orm/libsql";
 import { drizzle as drizzlePg } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 
-const MISSING_DATABASE_ENV_ERROR =
-  "DATABASE_URL is not set and TURSO_DATABASE_URL is not set. Set DATABASE_URL for Neon (primary), or TURSO_DATABASE_URL for Turso fallback.";
-
-const NEON_INIT_FAILED_PREFIX =
-  "Neon initialization failed, falling back to Turso when available.";
+const MISSING_DATABASE_ENV_ERROR = "DATABASE_URL is not set";
 
 const PUBLIC_DATABASE_URL_ERROR =
   "NEXT_PUBLIC_DATABASE_URL is set. Keep the Neon connection string server-only in DATABASE_URL.";
-
-export type DatabaseDialect = "postgres" | "sqlite";
-
-let selectedDatabaseDialect: DatabaseDialect | undefined;
 
 function getNeonUrl(): string | undefined {
   return process.env.DATABASE_URL?.trim();
@@ -24,18 +14,6 @@ function assertNoPublicDatabaseUrl(): void {
   if (process.env.NEXT_PUBLIC_DATABASE_URL?.trim()) {
     throw new Error(PUBLIC_DATABASE_URL_ERROR);
   }
-}
-
-function getTursoConfig(): { url: string; authToken: string | undefined } | undefined {
-  const url = process.env.TURSO_DATABASE_URL?.trim();
-  if (!url) {
-    return undefined;
-  }
-
-  return {
-    url,
-    authToken: process.env.TURSO_AUTH_TOKEN?.trim() || undefined,
-  };
 }
 
 function createNeonDatabaseClient(url: string): DatabaseClient {
@@ -49,56 +27,16 @@ function createNeonDatabaseClient(url: string): DatabaseClient {
   return drizzlePg(pool);
 }
 
-function createTursoDatabaseClient(config: {
-  url: string;
-  authToken: string | undefined;
-}): DatabaseClient {
-  const isRemote =
-    config.url.startsWith("libsql://") ||
-    config.url.startsWith("https://") ||
-    config.url.startsWith("wss://");
-  if (isRemote && !config.authToken) {
-    throw new Error(
-      "TURSO_AUTH_TOKEN ontbreekt voor een remote TURSO_DATABASE_URL. Stel TURSO_AUTH_TOKEN in.",
-    );
-  }
-
-  const client = createClient(config);
-  return drizzleLibsql(client) as unknown as DatabaseClient;
-}
-
 function createDatabaseClient(): DatabaseClient {
   assertNoPublicDatabaseUrl();
 
   const neonUrl = getNeonUrl();
-  const tursoConfig = getTursoConfig();
 
-  if (!neonUrl && !tursoConfig) {
+  if (!neonUrl) {
     throw new Error(MISSING_DATABASE_ENV_ERROR);
   }
 
-  if (neonUrl) {
-    try {
-      const client = createNeonDatabaseClient(neonUrl);
-      selectedDatabaseDialect = "postgres";
-      return client;
-    } catch (error) {
-      console.warn(
-        `${NEON_INIT_FAILED_PREFIX} ${error instanceof Error ? error.message : String(error)}`,
-      );
-      selectedDatabaseDialect = undefined;
-    }
-  }
-
-  if (tursoConfig) {
-    const client = createTursoDatabaseClient(tursoConfig);
-    selectedDatabaseDialect = "sqlite";
-    return client;
-  }
-
-  throw new Error(
-    "DATABASE_URL is set but Neon failed to initialize, and TURSO_DATABASE_URL is not set for fallback.",
-  );
+  return createNeonDatabaseClient(neonUrl);
 }
 
 type DatabaseClient = ReturnType<typeof drizzlePg>;
@@ -110,16 +48,9 @@ function getDatabaseClient(): DatabaseClient {
   return databaseClient;
 }
 
-export function getDatabaseDialect(): DatabaseDialect {
-  if (!selectedDatabaseDialect) {
-    getDatabaseClient();
-  }
-
-  if (!selectedDatabaseDialect) {
-    throw new Error("Database dialect not initialized—ensure getDatabaseClient succeeded.");
-  }
-
-  return selectedDatabaseDialect;
+export function getDatabaseDialect(): "postgres" {
+  getDatabaseClient();
+  return "postgres";
 }
 
 export function isPostgresDatabase(): boolean {
@@ -132,17 +63,6 @@ export const db = new Proxy({} as DatabaseClient, {
     const value = Reflect.get(client, prop, receiver);
     if (typeof value === "function") {
       return value.bind(client);
-    }
-
-    if (prop === "execute") {
-      const all = Reflect.get(client, "all", receiver);
-      if (typeof all === "function") {
-        const boundAll = all.bind(client);
-        return async (query: unknown) => {
-          const rows = await boundAll(query);
-          return { rows };
-        };
-      }
     }
 
     return value;

--- a/scripts/verify-db-connection.ts
+++ b/scripts/verify-db-connection.ts
@@ -2,10 +2,10 @@
 /**
  * Database Connection Health Check
  *
- * Verifies that Neon (DATABASE_URL) is correctly configured, with optional Turso fallback.
+ * Verifies that Neon (DATABASE_URL) is correctly configured.
  * Checks:
- * - Primary environment variable is set (DATABASE_URL), or fallback Turso variables
- * - Primary connection string has valid format (when DATABASE_URL is set)
+ * - DATABASE_URL environment variable is set
+ * - Connection string has valid format
  * - Database connection can be established
  * - Basic query execution works
  *
@@ -21,44 +21,37 @@ const { db, sql } = await import("../src/db");
 async function verifyDatabaseConnection() {
   console.log("🔍 Verifying database connection...\n");
 
-  // Check 1: Primary/fallback env is set
+  // Check 1: DATABASE_URL is set
   const databaseUrl = process.env.DATABASE_URL;
-  const tursoUrl = process.env.TURSO_DATABASE_URL;
-  if (!databaseUrl && !tursoUrl) {
-    console.error("❌ DATABASE_URL and TURSO_DATABASE_URL are both missing");
-    console.error(
-      "   Set DATABASE_URL (Neon primary) and optionally TURSO_DATABASE_URL (fallback)",
-    );
+  if (!databaseUrl) {
+    console.error("❌ DATABASE_URL is not set");
+    console.error("   Set DATABASE_URL to your Neon PostgreSQL connection string");
     process.exit(1);
   }
-  console.log(
-    `✓ Primary/fallback env present (${databaseUrl ? "Neon primary" : "Turso fallback"})`,
-  );
+  console.log("✓ DATABASE_URL is present");
 
-  // Check 2: Primary connection string format (only when DATABASE_URL is set)
-  if (databaseUrl) {
-    try {
-      const parsed = new URL(databaseUrl);
-      const sslMode = parsed.searchParams.get("sslmode");
+  // Check 2: Connection string format
+  try {
+    const parsed = new URL(databaseUrl);
+    const sslMode = parsed.searchParams.get("sslmode");
 
-      console.log(`✓ Primary connection string format is valid`);
-      console.log(`  Protocol: ${parsed.protocol}`);
-      console.log(`  Host: ${parsed.hostname}`);
-      console.log(`  Database: ${parsed.pathname.slice(1)}`);
-      console.log(`  SSL Mode: ${sslMode || "(not specified)"}`);
+    console.log("✓ Connection string format is valid");
+    console.log(`  Protocol: ${parsed.protocol}`);
+    console.log(`  Host: ${parsed.hostname}`);
+    console.log(`  Database: ${parsed.pathname.slice(1)}`);
+    console.log(`  SSL Mode: ${sslMode || "(not specified)"}`);
 
-      // Check 3: SSL configuration
-      if (sslMode && sslMode !== "verify-full" && sslMode !== "disable" && sslMode !== "require") {
-        console.warn(`⚠️  Unexpected sslmode "${sslMode}" in DATABASE_URL`);
-      }
-      if (!sslMode) {
-        console.log(`  ℹ️  SSL mode not specified in DATABASE_URL`);
-      }
-    } catch (error) {
-      console.error("❌ Invalid DATABASE_URL connection string format");
-      console.error(`   ${error instanceof Error ? error.message : String(error)}`);
-      process.exit(1);
+    // Check 3: SSL configuration
+    if (sslMode && sslMode !== "verify-full" && sslMode !== "disable" && sslMode !== "require") {
+      console.warn(`⚠️  Unexpected sslmode "${sslMode}" in DATABASE_URL`);
     }
+    if (!sslMode) {
+      console.log("  ℹ️  SSL mode not specified in DATABASE_URL");
+    }
+  } catch (error) {
+    console.error("❌ Invalid DATABASE_URL connection string format");
+    console.error(`   ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
   }
 
   // Check 4: Database connection
@@ -99,7 +92,7 @@ async function verifyDatabaseConnection() {
     const result = await db.execute(sql`SELECT 1 as ok, CURRENT_TIMESTAMP as ts`);
 
     if (result.rows && result.rows.length > 0) {
-      console.log(`✓ Query execution successful`);
+      console.log("✓ Query execution successful");
     }
   } catch (error) {
     console.error("❌ Query execution failed");

--- a/tests/db-env-guard.test.ts
+++ b/tests/db-env-guard.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("@motian/db build safety", () => {
   const originalDatabaseUrl = process.env.DATABASE_URL;
-  const originalTursoDatabaseUrl = process.env.TURSO_DATABASE_URL;
 
   beforeEach(() => {
     vi.resetModules();
@@ -17,23 +16,14 @@ describe("@motian/db build safety", () => {
     } else {
       process.env.DATABASE_URL = originalDatabaseUrl;
     }
-
-    if (originalTursoDatabaseUrl === undefined) {
-      delete process.env.TURSO_DATABASE_URL;
-    } else {
-      process.env.TURSO_DATABASE_URL = originalTursoDatabaseUrl;
-    }
   });
 
   it("allows module import without DATABASE_URL until the db client is used", async () => {
     delete process.env.DATABASE_URL;
-    delete process.env.TURSO_DATABASE_URL;
     const dbModule = await import("../packages/db/src/index");
 
     expect(dbModule).toHaveProperty("db");
-    expect(() => dbModule.getDatabaseDialect()).toThrowError(
-      /DATABASE_URL is not set and TURSO_DATABASE_URL is not set/,
-    );
+    expect(() => dbModule.getDatabaseDialect()).toThrowError(/DATABASE_URL is not set/);
   }, 120_000);
 
   it("reports postgres as the active dialect when DATABASE_URL is configured", async () => {
@@ -53,17 +43,5 @@ describe("@motian/db build safety", () => {
     expect(() => dbModule.getDatabaseDialect()).toThrowError(
       /NEXT_PUBLIC_DATABASE_URL is set\. Keep the Neon connection string server-only in DATABASE_URL\./,
     );
-  }, 120_000);
-
-  it("exposes execute on the Turso fallback client", async () => {
-    vi.stubEnv("TURSO_DATABASE_URL", "file::memory:");
-
-    const dbModule = await import("../packages/db/src/index");
-    const tursoDb = dbModule.db as typeof dbModule.db & {
-      execute(query: unknown): Promise<{ rows: Array<{ x: number }> }>;
-    };
-    const result = await tursoDb.execute(dbModule.sql`select 1 as x`);
-
-    expect(result.rows).toEqual([{ x: 1 }]);
   }, 120_000);
 });

--- a/trigger.config.ts
+++ b/trigger.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
   // Externalize pg and drizzle-orm to avoid bundling native modules
   build: {
     extensions: [
-      additionalPackages({ packages: ["@libsql/client", "puppeteer-core"] }),
+      additionalPackages({ packages: ["puppeteer-core"] }),
       syncEnvVars(async () => {
         const keys = [
           "DATABASE_URL",
@@ -54,7 +54,6 @@ export default defineConfig({
       "pg",
       "pg-native", // Optional native bindings
       "drizzle-orm/pg-core",
-      "@libsql/client",
       "playwright",
       "playwright-core",
       "puppeteer-core",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,10 @@
 import path from "node:path";
 import { defineConfig } from "vitest/config";
 
-process.env.TURSO_DATABASE_URL ??= "file::memory:";
+// Provide a fallback DATABASE_URL so unit tests that call isPostgresDatabase() can
+// initialise the Drizzle client without a real database connection.
+process.env.DATABASE_URL ??= "postgres://test:test@localhost:5432/motian_test";
+
 const coverageThreshold = Number(process.env.COVERAGE_THRESHOLD ?? "24");
 const normalizedCoverageThreshold = Number.isFinite(coverageThreshold)
   ? Math.min(Math.max(Math.trunc(coverageThreshold), 1), 100)


### PR DESCRIPTION
## Summary
- Remove `@libsql/client` dependency and all Turso/libSQL fallback code from `packages/db/src/index.ts`
- Simplify `createDatabaseClient()` to only support Neon PostgreSQL via `DATABASE_URL`
- Remove Turso references from `vitest.config.ts`, `.env.example`, `scripts/verify-db-connection.ts`, `.factory/services.yaml`, `trigger.config.ts`, and `packages/db/package.json`
- Update `tests/db-env-guard.test.ts` to remove Turso-specific test cases

## Test plan
- [x] All 1134 tests pass (149 test files)
- [x] Lint errors are pre-existing (not introduced by this PR)
- [x] Verified no remaining Turso/libsql references in source files

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated database support to PostgreSQL exclusively, removing Turso/libSQL as an alternative database option.
  * Simplified environment variable configuration and removed related service definitions and dependencies.
  * Updated test setup to use PostgreSQL test database when not already configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->