### PR TITLE
feat: deploy MCP server to Vercel with @vercel/mcp-adapter

### DIFF
--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -1,0 +1,21 @@
+import { createMcpHandler } from "@vercel/mcp-adapter";
+import { initializeMotianTools } from "@/src/mcp/create-server";
+
+const handler = createMcpHandler(
+  (server) => {
+    initializeMotianTools(server);
+  },
+  {
+    serverInfo: {
+      name: "motian-recruitment",
+      version: "0.1.0",
+    },
+    capabilities: { tools: {} },
+  },
+  {
+    basePath: "/api/mcp",
+    maxDuration: 60,
+  },
+);
+
+export { handler as GET, handler as POST, handler as DELETE };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vercel/blob": "^2.3.0",
+    "@vercel/mcp-adapter": "1.0.0",
     "@visual-json/core": "^0.1.1",
     "@visual-json/react": "^0.1.1",
     "@whiskeysockets/baileys": "7.0.0-rc.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       '@vercel/blob':
         specifier: ^2.3.0
         version: 2.3.0
+      '@vercel/mcp-adapter':
+        specifier: 1.0.0
+        version: 1.0.0(@modelcontextprotocol/sdk@1.27.0(zod@3.25.76))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@visual-json/core':
         specifier: ^0.1.1
         version: 0.1.1
@@ -2931,6 +2934,35 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@redis/bloom@1.2.0':
+    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/client@1.6.1':
+    resolution: {integrity: sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==}
+    engines: {node: '>=14'}
+
+  '@redis/graph@1.1.1':
+    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/json@1.0.7':
+    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/search@1.2.0':
+    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
+  '@redis/time-series@1.1.0':
+    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
+    peerDependencies:
+      '@redis/client': ^1.0.0
+
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
     peerDependencies:
@@ -3819,6 +3851,16 @@ packages:
     resolution: {integrity: sha512-oYWiJbWRQ7gz9Mj0X/NHFJ3OcLMOBzq/2b3j6zeNrQmtFo6dHwU8FAwNpxVIYddVMd+g8eqEi7iRueYx8FtM0Q==}
     engines: {node: '>=20.0.0'}
 
+  '@vercel/mcp-adapter@1.0.0':
+    resolution: {integrity: sha512-o/QA4LhYCJvuL7/i8CfKPpOm29u25/L4m1LWH44EQZ8cfYJlc4B7Bu+YzDHl23m8A3hDxCJQmlgZEGmsPAQ0vQ==}
+    hasBin: true
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.12.0
+      next: '>=13.0.0'
+    peerDependenciesMeta:
+      next:
+        optional: true
+
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
@@ -4479,6 +4521,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   cmdk@1.1.1:
     resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
     peerDependencies:
@@ -4512,6 +4558,10 @@ packages:
   command-line-usage@7.0.4:
     resolution: {integrity: sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==}
     engines: {node: '>=12.20.0'}
+
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
 
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
@@ -5630,6 +5680,10 @@ packages:
     engines: {node: '>= 18.0.0'}
     hasBin: true
 
+  generic-pool@3.9.0:
+    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
+    engines: {node: '>= 4'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -6539,6 +6593,16 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mcp-handler@1.1.0:
+    resolution: {integrity: sha512-MVCES7g18gcoZy+R/3v5nadkUMzMAWdos8jRl6DyljOKvd2/ZKDmwlCjL6zp4vo+7FeCXOYL1uWinHWlkKAAUg==}
+    hasBin: true
+    peerDependencies:
+      '@modelcontextprotocol/sdk': 1.26.0
+      next: '>=13.0.0'
+    peerDependenciesMeta:
+      next:
+        optional: true
 
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
@@ -7673,6 +7737,9 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
+
+  redis@4.7.1:
+    resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
 
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
@@ -8953,6 +9020,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
@@ -11698,6 +11768,32 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@redis/bloom@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/client@1.6.1':
+    dependencies:
+      cluster-key-slot: 1.1.2
+      generic-pool: 3.9.0
+      yallist: 4.0.0
+
+  '@redis/graph@1.1.1(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/json@1.0.7(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/search@1.2.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
+  '@redis/time-series@1.1.0(@redis/client@1.6.1)':
+    dependencies:
+      '@redis/client': 1.6.1
+
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -12759,6 +12855,13 @@ snapshots:
       throttleit: 2.1.0
       undici: 6.23.0
 
+  '@vercel/mcp-adapter@1.0.0(@modelcontextprotocol/sdk@1.27.0(zod@3.25.76))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.27.0(zod@3.25.76)
+      mcp-handler: 1.1.0(@modelcontextprotocol/sdk@1.27.0(zod@3.25.76))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+    optionalDependencies:
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+
   '@vercel/oidc@3.1.0': {}
 
   '@visual-json/core@0.1.1': {}
@@ -13492,6 +13595,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
@@ -13533,6 +13638,8 @@ snapshots:
       chalk-template: 0.4.0
       table-layout: 4.1.1
       typical: 7.3.0
+
+  commander@11.1.0: {}
 
   commander@12.1.0: {}
 
@@ -14624,6 +14731,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  generic-pool@3.9.0: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -15598,6 +15707,15 @@ snapshots:
       escape-string-regexp: 4.0.0
 
   math-intrinsics@1.1.0: {}
+
+  mcp-handler@1.1.0(@modelcontextprotocol/sdk@1.27.0(zod@3.25.76))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.27.0(zod@3.25.76)
+      chalk: 5.6.2
+      commander: 11.1.0
+      redis: 4.7.1
+    optionalDependencies:
+      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   mdast-util-find-and-replace@3.0.2:
     dependencies:
@@ -17233,6 +17351,15 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  redis@4.7.1:
+    dependencies:
+      '@redis/bloom': 1.2.0(@redis/client@1.6.1)
+      '@redis/client': 1.6.1
+      '@redis/graph': 1.1.1(@redis/client@1.6.1)
+      '@redis/json': 1.0.7(@redis/client@1.6.1)
+      '@redis/search': 1.2.0(@redis/client@1.6.1)
+      '@redis/time-series': 1.1.0(@redis/client@1.6.1)
+
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
       redux: 5.0.1
@@ -18806,6 +18933,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
 
   yallist@5.0.0: {}
 

--- a/src/mcp/create-server.ts
+++ b/src/mcp/create-server.ts
@@ -1,0 +1,69 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import * as Sentry from "@sentry/node";
+import { allHandlers, allTools } from "./tools/index.js";
+
+const SENTRY_DSN = process.env.SENTRY_DSN;
+
+/**
+ * Registers ListTools and CallTool request handlers on a raw MCP Server.
+ * Shared between the stdio entrypoint and the Vercel HTTP adapter.
+ */
+function registerToolHandlers(server: Server): void {
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: allTools,
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    const handler = allHandlers[name];
+    if (!handler) {
+      return {
+        content: [{ type: "text" as const, text: `Onbekende tool: ${name}` }],
+        isError: true,
+      };
+    }
+    try {
+      const result = await handler(args ?? {});
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (err) {
+      if (SENTRY_DSN) Sentry.captureException(err);
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: "text" as const, text: `Fout: ${message}` }],
+        isError: true,
+      };
+    }
+  });
+}
+
+/**
+ * Creates a configured MCP Server with all Motian recruitment tools registered.
+ * Used by the stdio transport entrypoint (`server.ts`).
+ */
+export function createMotianMCPServer(): Server {
+  if (SENTRY_DSN) {
+    Sentry.init({ dsn: SENTRY_DSN, tracesSampleRate: 0.2 });
+  }
+
+  const server = new Server(
+    { name: "motian-recruitment", version: "0.1.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  registerToolHandlers(server);
+  return server;
+}
+
+/**
+ * Initializes Motian tools on an McpServer instance (high-level API).
+ * Used by the Vercel MCP adapter which provides its own McpServer.
+ *
+ * Registers tools via the underlying raw Server to reuse existing
+ * tool definitions without converting to the McpServer.tool() format.
+ */
+export function initializeMotianTools(mcpServer: { server: Server }): void {
+  registerToolHandlers(mcpServer.server);
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,53 +1,12 @@
 #!/usr/bin/env node
 import { config } from "dotenv";
+
 config({ path: ".env.local" });
 config();
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
-import * as Sentry from "@sentry/node";
-import { allHandlers, allTools } from "./tools/index.js";
+import { createMotianMCPServer } from "./create-server.js";
 
-const SENTRY_DSN = process.env.SENTRY_DSN;
-if (SENTRY_DSN) {
-  Sentry.init({
-    dsn: SENTRY_DSN,
-    tracesSampleRate: 0.2,
-  });
-}
-
-const server = new Server(
-  { name: "motian-recruitment", version: "0.1.0" },
-  { capabilities: { tools: {} } },
-);
-
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: allTools,
-}));
-
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
-  const handler = allHandlers[name];
-  if (!handler) {
-    return {
-      content: [{ type: "text", text: `Onbekende tool: ${name}` }],
-      isError: true,
-    };
-  }
-  try {
-    const result = await handler(args ?? {});
-    return {
-      content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-    };
-  } catch (err) {
-    if (SENTRY_DSN) Sentry.captureException(err);
-    const message = err instanceof Error ? err.message : String(err);
-    return {
-      content: [{ type: "text", text: `Fout: ${message}` }],
-      isError: true,
-    };
-  }
-});
-
+const server = createMotianMCPServer();
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/tests/mcp-server-setup.test.ts
+++ b/tests/mcp-server-setup.test.ts
@@ -1,0 +1,83 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { describe, expect, it } from "vitest";
+import { createMotianMCPServer, initializeMotianTools } from "@/src/mcp/create-server";
+import { allTools } from "@/src/mcp/tools/index";
+
+type HandlerFn = (...args: never[]) => unknown;
+
+/**
+ * Helper: invoke a registered request handler on a Server instance
+ * by iterating the internal _requestHandlers map keyed by schema method string.
+ */
+async function invokeHandler(
+  server: Server,
+  method: string,
+  // biome-ignore lint/suspicious/noExplicitAny: test helper needs dynamic request shape
+  request: any,
+) {
+  // biome-ignore lint/suspicious/noExplicitAny: accessing SDK private API for testing
+  const handlers = (server as any)._requestHandlers as Map<string, HandlerFn>;
+  const handler = handlers.get(method);
+  if (!handler) throw new Error(`No handler for ${method}`);
+  return handler(request, {});
+}
+
+describe("createMotianMCPServer", () => {
+  it("returns a Server instance with connect and close methods", () => {
+    const server = createMotianMCPServer();
+    expect(server).toBeDefined();
+    expect(server).toBeInstanceOf(Server);
+    expect(typeof server.connect).toBe("function");
+    expect(typeof server.close).toBe("function");
+  });
+
+  it("registers all expected tool names from allTools", async () => {
+    const server = createMotianMCPServer();
+
+    const listResult = await invokeHandler(server, "tools/list", {
+      method: "tools/list",
+    });
+
+    expect(listResult).toBeDefined();
+    expect(listResult.tools).toBeDefined();
+    expect(Array.isArray(listResult.tools)).toBe(true);
+
+    const registeredNames = listResult.tools.map((t: { name: string }) => t.name);
+    const expectedNames = allTools.map((t) => t.name);
+
+    expect(registeredNames).toEqual(expectedNames);
+    expect(registeredNames.length).toBeGreaterThan(0);
+  });
+
+  it("returns error for unknown tool name", async () => {
+    const server = createMotianMCPServer();
+
+    const result = await invokeHandler(server, "tools/call", {
+      method: "tools/call",
+      params: { name: "nonexistent_tool_xyz", arguments: {} },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Onbekende tool");
+  });
+});
+
+describe("initializeMotianTools", () => {
+  it("is a function that accepts an McpServer-like object", () => {
+    expect(typeof initializeMotianTools).toBe("function");
+  });
+
+  it("registers handlers on the underlying raw Server", () => {
+    const rawServer = new Server(
+      { name: "test", version: "0.0.1" },
+      { capabilities: { tools: {} } },
+    );
+
+    initializeMotianTools({ server: rawServer });
+
+    // biome-ignore lint/suspicious/noExplicitAny: accessing SDK private API for testing
+    const handlers = (rawServer as any)._requestHandlers as Map<string, HandlerFn>;
+    expect(handlers.has("tools/list")).toBe(true);
+    expect(handlers.has("tools/call")).toBe(true);
+  });
+});

--- a/tests/runtime-config-hardening.test.ts
+++ b/tests/runtime-config-hardening.test.ts
@@ -14,7 +14,7 @@ describe("runtime config hardening regressions", () => {
     const serverSource = readFile("instrumentation.ts");
     const clientSource = readFile("instrumentation-client.ts");
     const triggerSource = readFile("trigger.config.ts");
-    const mcpSource = readFile("src", "mcp", "server.ts");
+    const mcpSource = readFile("src", "mcp", "create-server.ts");
 
     expect(serverSource).toContain("process.env.SENTRY_DSN");
     expect(clientSource).toContain("process.env.NEXT_PUBLIC_SENTRY_DSN");


### PR DESCRIPTION
## Summary
- Extract shared MCP server setup into `src/mcp/create-server.ts` with `createMotianMCPServer()` and `initializeMotianTools()` functions
- Add Vercel HTTP route at `app/api/mcp/route.ts` using `@vercel/mcp-adapter` v1.0.0 for SSE/Streamable HTTP transport
- Simplify `src/mcp/server.ts` to a thin stdio entrypoint that delegates to the shared factory

## Test plan
- [x] `createMotianMCPServer()` returns a Server with connect/close methods
- [x] All expected tool names are registered via ListTools handler
- [x] Unknown tool name returns `isError: true` with "Onbekende tool" message
- [x] `initializeMotianTools()` registers handlers on underlying raw Server
- [x] Full test suite passes (150 files, 1140 tests)
- [x] Biome lint clean on all changed files
- [ ] Verify `/api/mcp` endpoint responds after Vercel deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
