### PR TITLE
refactor: decompose opdrachten-sidebar into focused sub-components

### DIFF
--- a/components/opdrachten-sidebar.tsx
+++ b/components/opdrachten-sidebar.tsx
@@ -6,23 +6,6 @@
  * uren per week, straal, sortering, resultaat-telling en paginatie) is de referentie voor alle
  * filterpagina's. Gebruik deze component of hetzelfde visuele patroon op andere lijstpagina's.
  */
-import { useQuery } from "@tanstack/react-query";
-import { ChevronDown, ChevronLeft, ChevronRight, Loader2, RotateCcw, Search } from "lucide-react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
-import { JobListItem } from "@/components/job-list-item";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
-import {
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { SearchableCombobox } from "@/components/ui/searchable-combobox";
 import {
   Select,
   SelectContent,
@@ -30,461 +13,21 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Slider } from "@/components/ui/slider";
-import { cn } from "@/lib/utils";
-import { buildOpdrachtenFilterHref, getOpdrachtenBasePath } from "@/src/lib/opdrachten-filter-url";
 import {
   DEFAULT_OPDRACHTEN_LIMIT,
-  getHoursRangeForBucket,
-  getProvinceAnchor,
-  MAX_OPDRACHTEN_LIMIT,
   OPDRACHTEN_PAGE_SIZE_OPTIONS,
-  OPDRACHTEN_PROVINCES,
-  OPDRACHTEN_RADIUS_OPTIONS,
-  OPDRACHTEN_REGION_OPTIONS,
-  OPDRACHTEN_SORT_OPTIONS,
-  parseOpdrachtenFilters,
 } from "@/src/lib/opdrachten-filters";
+import { CompactSidebarFilters } from "./sidebar/compact-sidebar-filters";
+import { OverviewFilterPanel } from "./sidebar/overview-filter-panel";
+import { SidebarJobList } from "./sidebar/sidebar-job-list";
+import { SidebarPagination } from "./sidebar/sidebar-pagination";
+import { SidebarResultsHeader } from "./sidebar/sidebar-results-header";
+import { SidebarSearchBar } from "./sidebar/sidebar-search-bar";
+import { SidebarSortControls } from "./sidebar/sidebar-sort-controls";
+import type { OpdrachtenSidebarProps } from "./sidebar/sidebar-types";
+import { useSidebarFilters } from "./sidebar/use-sidebar-filters";
 
-interface SidebarJob {
-  id: string;
-  title: string;
-  company: string | null;
-  location: string | null;
-  platform: string;
-  workArrangement: string | null;
-  contractType: string | null;
-  applicationDeadline?: Date | string | null;
-  pipelineCount?: number;
-  hasPipeline?: boolean;
-}
-
-interface SearchResponse {
-  jobs: SidebarJob[];
-  total: number;
-  page: number;
-  perPage: number;
-  totalPages: number;
-}
-
-type SearchResponsePayload = {
-  jobs?: unknown;
-  total?: unknown;
-  page?: unknown;
-  perPage?: unknown;
-  totalPages?: unknown;
-};
-
-interface OpdrachtenSidebarProps {
-  jobs: SidebarJob[];
-  totalCount: number;
-  platforms: string[];
-  endClients: string[];
-  categories: string[];
-  skillOptions: FilterOption[];
-  skillEmptyText?: string;
-}
-
-type SearchQueryKeyPayload = {
-  q: string;
-  platform: string;
-  endClient: string;
-  vaardigheid: string;
-  status: string;
-  provincie: string;
-  regios: string[];
-  vakgebieden: string[];
-  urenPerWeek: string;
-  urenPerWeekMin: string;
-  urenPerWeekMax: string;
-  straalKm: string;
-  contractType: string;
-  tariefMin: string;
-  tariefMax: string;
-  sort: string;
-  page: number;
-  limit: number;
-};
-
-const CONTRACT_TYPES = [
-  { value: "freelance", label: "Freelance" },
-  { value: "interim", label: "Interim" },
-  { value: "vast", label: "Vast" },
-  { value: "opdracht", label: "Opdracht" },
-];
-
-const DARK_FILTER_PANEL_CLASS =
-  "rounded-[24px] border border-white/10 bg-white/[0.035] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] backdrop-blur";
-const DARK_FILTER_CONTROL_CLASS =
-  "h-12 rounded-[20px] border-white/10 bg-white/[0.035] px-4 text-[15px] font-normal text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] placeholder:text-white/35 focus-visible:ring-1 focus-visible:ring-white/20 focus-visible:ring-offset-0";
-const DARK_FILTER_TRIGGER_CLASS =
-  "h-12 rounded-[20px] border-white/10 bg-white/[0.035] px-4 text-left text-[15px] font-normal text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] data-[placeholder]:text-white/35";
-const DARK_FILTER_MENU_CLASS = "border-white/10 bg-[#101113] text-white";
-const DARK_FILTER_SECTION_LABEL_CLASS =
-  "text-[11px] font-semibold uppercase tracking-[0.22em] text-white/45";
-const DARK_FILTER_SECTION_VALUE_CLASS = "text-sm text-white/55";
-
-const DAY_IN_MS = 24 * 60 * 60 * 1000;
-type FilterOverrideValue = string | string[];
-
-type FilterOption = {
-  value: string;
-  label: string;
-};
-
-function hasUrgentDeadline(deadline?: Date | string | null) {
-  if (!deadline) return false;
-
-  const parsedDeadline = new Date(deadline);
-  if (Number.isNaN(parsedDeadline.getTime())) return false;
-
-  const remainingDays = Math.ceil((parsedDeadline.getTime() - Date.now()) / DAY_IN_MS);
-  return remainingDays >= 0 && remainingDays <= 3;
-}
-
-function pushOpdrachtenParams(
-  searchParams: URLSearchParams,
-  router: ReturnType<typeof useRouter>,
-  pathname: string,
-  overrides: Record<string, FilterOverrideValue>,
-) {
-  router.push(buildOpdrachtenFilterHref(pathname, searchParams, overrides));
-}
-
-function toggleFilterValue(values: string[], nextValue: string) {
-  return values.includes(nextValue)
-    ? values.filter((value) => value !== nextValue)
-    : [...values, nextValue];
-}
-
-function summarizeSelection(label: string, selectedLabels: string[]) {
-  if (selectedLabels.length === 0) return label;
-  if (selectedLabels.length === 1) return selectedLabels[0] ?? label;
-  return `${label} (${selectedLabels.length})`;
-}
-
-function summarizeHoursRange(minValue: string, maxValue: string) {
-  if (!minValue && !maxValue) return "Alle uren";
-  return `${minValue || "0"} - ${maxValue || "onbeperkt"} uur`;
-}
-
-function isSidebarJob(value: unknown): value is SidebarJob {
-  if (!value || typeof value !== "object") return false;
-
-  const candidate = value as Record<string, unknown>;
-  return (
-    typeof candidate.id === "string" &&
-    typeof candidate.title === "string" &&
-    typeof candidate.platform === "string"
-  );
-}
-
-function isFiniteNumber(value: unknown): value is number {
-  return typeof value === "number" && Number.isFinite(value);
-}
-
-function parseSearchResponse(payload: SearchResponsePayload): SearchResponse {
-  if (
-    !Array.isArray(payload.jobs) ||
-    !payload.jobs.every(isSidebarJob) ||
-    !isFiniteNumber(payload.total) ||
-    !isFiniteNumber(payload.page) ||
-    !isFiniteNumber(payload.perPage) ||
-    !isFiniteNumber(payload.totalPages)
-  ) {
-    throw new Error("Ongeldig zoekresultaat ontvangen.");
-  }
-
-  const jobs = payload.jobs as SidebarJob[];
-  const total = payload.total as number;
-  const page = payload.page as number;
-  const perPage = payload.perPage as number;
-  const totalPages = payload.totalPages as number;
-
-  return {
-    jobs,
-    total,
-    page,
-    perPage,
-    totalPages,
-  };
-}
-
-function useDebouncedValue<T>(value: T, delayMs = 300): T {
-  const [debouncedValue, setDebouncedValue] = useState(value);
-
-  useEffect(() => {
-    const timeout = setTimeout(() => {
-      setDebouncedValue(value);
-    }, delayMs);
-
-    return () => clearTimeout(timeout);
-  }, [value, delayMs]);
-
-  return debouncedValue;
-}
-
-async function getSearchErrorMessage(response: Response) {
-  try {
-    const payload = (await response.json()) as { error?: string };
-    if (typeof payload.error === "string" && payload.error.trim()) {
-      return payload.error.trim();
-    }
-  } catch {
-    // Ignore non-JSON or malformed error payloads and fall back to the status-based message below.
-  }
-
-  return `Zoeken mislukt (${response.status}).`;
-}
-
-function FilterChecklist({
-  idPrefix,
-  options,
-  selectedValues,
-  onToggle,
-  className,
-}: {
-  idPrefix: string;
-  options: FilterOption[];
-  selectedValues: string[];
-  onToggle: (value: string) => void;
-  className?: string;
-}) {
-  return (
-    <div className={cn("space-y-1 rounded-lg border border-border bg-background p-2", className)}>
-      {options.map((option) => {
-        const checked = selectedValues.includes(option.value);
-        const checkboxId = `${idPrefix}-${option.value}`;
-
-        return (
-          <label
-            key={option.value}
-            htmlFor={checkboxId}
-            className="flex min-h-11 cursor-pointer items-center gap-3 rounded-md px-2 py-2.5 text-sm hover:bg-accent/50"
-          >
-            <Checkbox
-              id={checkboxId}
-              checked={checked}
-              onCheckedChange={() => onToggle(option.value)}
-            />
-            <span className="min-w-0 wrap-break-word text-foreground">{option.label}</span>
-          </label>
-        );
-      })}
-    </div>
-  );
-}
-
-function CompactMultiSelectFilter({
-  label,
-  options,
-  selectedValues,
-  onToggle,
-  buttonClassName,
-  contentClassName,
-}: {
-  label: string;
-  options: FilterOption[];
-  selectedValues: string[];
-  onToggle: (value: string) => void;
-  buttonClassName?: string;
-  contentClassName?: string;
-}) {
-  const selectedLabels = options
-    .filter((option) => selectedValues.includes(option.value))
-    .map((option) => option.label);
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outline"
-          className={cn(
-            "h-7 flex-1 justify-between border-border bg-card px-2 text-[10px] text-foreground",
-            buttonClassName,
-          )}
-        >
-          <span className="truncate">{summarizeSelection(label, selectedLabels)}</span>
-          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className={cn("bg-card border-border", contentClassName)}>
-        {options.map((option) => (
-          <DropdownMenuCheckboxItem
-            key={option.value}
-            checked={selectedValues.includes(option.value)}
-            onCheckedChange={() => onToggle(option.value)}
-          >
-            {option.label}
-          </DropdownMenuCheckboxItem>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
-function RadiusSliderField({
-  provinceAnchor,
-  radiusKm,
-  onRadiusChange,
-  compact = false,
-}: {
-  provinceAnchor: ReturnType<typeof getProvinceAnchor>;
-  radiusKm: string;
-  onRadiusChange: (value: string) => void;
-  compact?: boolean;
-}) {
-  const sliderOptions = [0, ...OPDRACHTEN_RADIUS_OPTIONS];
-  const sliderIndex = radiusKm ? Math.max(0, sliderOptions.indexOf(Number(radiusKm))) : 0;
-
-  return (
-    <div className={compact ? "px-4 pb-4" : undefined}>
-      <div className={cn("mb-2 flex items-center justify-between gap-2", compact && "mb-2")}>
-        <span
-          className={cn(
-            "font-medium text-foreground",
-            compact ? DARK_FILTER_SECTION_LABEL_CLASS : "text-sm",
-          )}
-        >
-          Straal
-        </span>
-        <button
-          type="button"
-          disabled={!radiusKm}
-          onClick={() => onRadiusChange("")}
-          className={cn(
-            "font-medium text-primary disabled:cursor-not-allowed disabled:opacity-50",
-            compact ? "text-sm text-white/55 hover:text-white" : "text-xs",
-          )}
-        >
-          Reset
-        </button>
-      </div>
-
-      <div
-        className={cn(
-          "rounded-lg border border-border bg-background p-3",
-          compact &&
-            "rounded-[24px] border-white/10 bg-white/[0.035] px-4 py-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]",
-        )}
-      >
-        <div className="mb-2 flex items-center justify-between gap-2">
-          <span className={cn("font-medium", compact ? "text-3xl text-white" : "text-sm")}>
-            {radiusKm ? `${radiusKm} km` : "Geen straal"}
-          </span>
-          <span className={cn(compact ? "text-lg text-white/55" : "text-xs text-muted-foreground")}>
-            {provinceAnchor ? provinceAnchor.label : "Eerst provincie"}
-          </span>
-        </div>
-        <Slider
-          min={0}
-          max={sliderOptions.length - 1}
-          step={1}
-          value={[sliderIndex]}
-          disabled={!provinceAnchor}
-          onValueChange={([value]) => {
-            const nextRadius = sliderOptions[value] ?? 0;
-            onRadiusChange(nextRadius > 0 ? String(nextRadius) : "");
-          }}
-        />
-        <div
-          className={cn(
-            "mt-2 flex items-center justify-between text-[10px] text-muted-foreground",
-            compact && "mt-3 text-sm text-white/55",
-          )}
-        >
-          {sliderOptions.map((value) => (
-            <span key={value}>{value === 0 ? "0" : value}</span>
-          ))}
-        </div>
-      </div>
-
-      <p
-        className={cn("mt-2 text-muted-foreground", compact ? "text-sm text-white/45" : "text-xs")}
-      >
-        {provinceAnchor
-          ? `Straal wordt toegepast vanaf ${provinceAnchor.label} (${provinceAnchor.province}).`
-          : "Kies eerst een provincie om straalfiltering te activeren."}
-      </p>
-    </div>
-  );
-}
-
-type SearchJobsParams = {
-  q: string;
-  platform: string;
-  endClient: string;
-  vaardigheid: string;
-  status: string;
-  provincie: string;
-  regios: string[];
-  vakgebieden: string[];
-  urenPerWeek: string;
-  urenPerWeekMin: string;
-  urenPerWeekMax: string;
-  straalKm: string;
-  contractType: string;
-  tariefMin: string;
-  tariefMax: string;
-  sort: string;
-  page: number;
-  limit: number;
-};
-
-async function searchJobs({
-  q,
-  platform,
-  endClient,
-  vaardigheid,
-  status,
-  provincie,
-  regios,
-  vakgebieden,
-  urenPerWeek,
-  urenPerWeekMin,
-  urenPerWeekMax,
-  straalKm,
-  contractType,
-  tariefMin,
-  tariefMax,
-  sort,
-  page,
-  limit,
-  signal,
-}: SearchJobsParams & { signal?: AbortSignal }): Promise<SearchResponse> {
-  const params = new URLSearchParams();
-  if (q) params.set("q", q);
-  if (platform) params.set("platform", platform);
-  if (endClient) params.set("endClient", endClient);
-  if (vaardigheid) params.set("vaardigheid", vaardigheid);
-  if (status !== "open") params.set("status", status);
-  if (provincie) params.set("provincie", provincie);
-  regios.forEach((regio) => {
-    params.append("regio", regio);
-  });
-  vakgebieden.forEach((vakgebied) => {
-    params.append("vakgebied", vakgebied);
-  });
-  if (urenPerWeek) params.set("urenPerWeek", urenPerWeek);
-  if (urenPerWeekMin) params.set("urenPerWeekMin", urenPerWeekMin);
-  if (urenPerWeekMax) params.set("urenPerWeekMax", urenPerWeekMax);
-  if (straalKm) params.set("straalKm", straalKm);
-  if (contractType) params.set("contractType", contractType);
-  if (tariefMin) params.set("tariefMin", tariefMin);
-  if (tariefMax) params.set("tariefMax", tariefMax);
-  if (sort && sort !== "nieuwste") params.set("sort", sort);
-  if (page > 1) params.set("pagina", String(page));
-  if (limit !== DEFAULT_OPDRACHTEN_LIMIT) params.set("limit", String(limit));
-
-  const res = await fetch(`/api/vacatures/zoeken?${params.toString()}`, {
-    signal,
-  });
-  if (!res.ok) {
-    throw new Error(await getSearchErrorMessage(res));
-  }
-
-  return parseSearchResponse((await res.json()) as SearchResponsePayload);
-}
+export type { OpdrachtenSidebarProps } from "./sidebar/sidebar-types";
 
 export function OpdrachtenSidebar({
   jobs: initialJobs,
@@ -495,656 +38,121 @@ export function OpdrachtenSidebar({
   skillOptions,
   skillEmptyText = "Geen vaardigheden gevonden.",
 }: OpdrachtenSidebarProps) {
-  const pathname = usePathname();
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const isOverviewPage = pathname === "/vacatures";
-  const match = pathname.match(/^\/(?:vacatures|opdrachten)\/(.+)$/);
-  const activeId = match?.[1] ?? null;
-
-  // URL as source of truth for TanStack Query: key and fetch use searchParams so e.g. top-opdrachtgevers link shows correct results immediately
-  const parsedFilters = parseOpdrachtenFilters(new URLSearchParams(searchParams.toString()));
-  const q = parsedFilters.q ?? "";
-  const platform = parsedFilters.platform ?? "";
-  const endClient = parsedFilters.endClient ?? "";
-  const vaardigheid = parsedFilters.escoUri ?? "";
-  const status = parsedFilters.status;
-  const provincie = parsedFilters.province ?? "";
-  const regios = parsedFilters.regions;
-  const vakgebieden = parsedFilters.categories;
-  const urenPerWeek = parsedFilters.hoursPerWeek ?? "";
-  const urenRangeFromBucket = parsedFilters.hoursPerWeek
-    ? getHoursRangeForBucket(parsedFilters.hoursPerWeek)
-    : undefined;
-  const urenPerWeekMin =
-    parsedFilters.hoursPerWeekMin != null
-      ? String(parsedFilters.hoursPerWeekMin)
-      : urenRangeFromBucket?.min != null
-        ? String(urenRangeFromBucket.min)
-        : "";
-  const urenPerWeekMax =
-    parsedFilters.hoursPerWeekMax != null
-      ? String(parsedFilters.hoursPerWeekMax)
-      : urenRangeFromBucket?.max != null
-        ? String(urenRangeFromBucket.max)
-        : "";
-  const straalKm = parsedFilters.radiusKm ? String(parsedFilters.radiusKm) : "";
-  const contractType = parsedFilters.contractType ?? "";
-  const hasSearchQuery = q.length > 0;
-  const sortOptions = hasSearchQuery
-    ? OPDRACHTEN_SORT_OPTIONS
-    : OPDRACHTEN_SORT_OPTIONS.filter((option) => option.value !== "relevantie");
-  const sort =
-    !hasSearchQuery && parsedFilters.sort === "relevantie" ? "nieuwste" : parsedFilters.sort;
-  const tariefMinParamFromUrl = parsedFilters.rateMin != null ? String(parsedFilters.rateMin) : "";
-  const tariefMaxParamFromUrl = parsedFilters.rateMax != null ? String(parsedFilters.rateMax) : "";
-  const pageParam =
-    Math.max(
-      1,
-      Number.parseInt(searchParams.get("pagina") ?? searchParams.get("page") ?? "1", 10),
-    ) || 1;
-  const limitParam =
-    Math.min(
-      MAX_OPDRACHTEN_LIMIT,
-      Math.max(
-        1,
-        Number.parseInt(
-          searchParams.get("limit") ??
-            searchParams.get("perPage") ??
-            String(DEFAULT_OPDRACHTEN_LIMIT),
-          10,
-        ),
-      ),
-    ) || DEFAULT_OPDRACHTEN_LIMIT;
-
-  const [inputValue, setInputValue] = useState(q);
-  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
-  const [hoursMinInput, setHoursMinInput] = useState(urenPerWeekMin);
-  const [hoursMaxInput, setHoursMaxInput] = useState(urenPerWeekMax);
-  const [radiusKmInput, setRadiusKmInput] = useState(straalKm);
-  const [rateMinInput, setRateMinInput] = useState(tariefMinParamFromUrl);
-  const [rateMaxInput, setRateMaxInput] = useState(tariefMaxParamFromUrl);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const provinceAnchor = getProvinceAnchor(provincie);
-  const regionOptions = useMemo<FilterOption[]>(
-    () =>
-      OPDRACHTEN_REGION_OPTIONS.map((option) => ({
-        value: option.value,
-        label: option.label,
-      })),
-    [],
-  );
-  const categoryOptions = useMemo<FilterOption[]>(
-    () =>
-      categories.map((category) => ({
-        value: category,
-        label: category,
-      })),
-    [categories],
-  );
-
-  useEffect(() => {
-    setInputValue(q);
-  }, [q]);
-  useEffect(() => {
-    setHoursMinInput(urenPerWeekMin);
-    setHoursMaxInput(urenPerWeekMax);
-    setRadiusKmInput(straalKm);
-    setRateMinInput(tariefMinParamFromUrl);
-    setRateMaxInput(tariefMaxParamFromUrl);
-  }, [urenPerWeekMin, urenPerWeekMax, straalKm, tariefMinParamFromUrl, tariefMaxParamFromUrl]);
-
-  const debouncedHoursMin = useDebouncedValue(hoursMinInput);
-  const debouncedHoursMax = useDebouncedValue(hoursMaxInput);
-  const debouncedRadiusKm = useDebouncedValue(radiusKmInput);
-  const debouncedRateMin = useDebouncedValue(rateMinInput);
-  const debouncedRateMax = useDebouncedValue(rateMaxInput);
-  const debouncedHoursHasManualInput = useMemo(
-    () => debouncedHoursMin !== urenPerWeekMin || debouncedHoursMax !== urenPerWeekMax,
-    [debouncedHoursMin, debouncedHoursMax, urenPerWeekMin, urenPerWeekMax],
-  );
-  const effectiveHoursPerWeekBucket = debouncedHoursHasManualInput ? "" : urenPerWeek;
-  const sortedRegios = useMemo(() => [...regios].sort((a, b) => a.localeCompare(b)), [regios]);
-  const sortedVakgebieden = useMemo(
-    () => [...vakgebieden].sort((a, b) => a.localeCompare(b)),
-    [vakgebieden],
-  );
-
-  const searchQueryKey = useMemo<SearchQueryKeyPayload>(
-    () => ({
-      q,
-      platform,
-      endClient,
-      vaardigheid,
-      status,
-      provincie,
-      regios: sortedRegios,
-      vakgebieden: sortedVakgebieden,
-      urenPerWeek: effectiveHoursPerWeekBucket,
-      urenPerWeekMin: debouncedHoursMin,
-      urenPerWeekMax: debouncedHoursMax,
-      straalKm: debouncedRadiusKm,
-      contractType,
-      tariefMin: debouncedRateMin,
-      tariefMax: debouncedRateMax,
-      sort,
-      page: pageParam,
-      limit: limitParam,
-    }),
-    [
-      q,
-      platform,
-      endClient,
-      vaardigheid,
-      status,
-      provincie,
-      sortedRegios,
-      sortedVakgebieden,
-      effectiveHoursPerWeekBucket,
-      debouncedHoursMin,
-      debouncedHoursMax,
-      debouncedRadiusKm,
-      contractType,
-      debouncedRateMin,
-      debouncedRateMax,
-      sort,
-      pageParam,
-      limitParam,
-    ],
-  );
-
-  useEffect(() => {
-    const shouldPushHours = debouncedHoursHasManualInput;
-    const shouldPushRadius = debouncedRadiusKm !== straalKm;
-    const shouldPushRateMin = debouncedRateMin !== tariefMinParamFromUrl;
-    const shouldPushRateMax = debouncedRateMax !== tariefMaxParamFromUrl;
-
-    if (!shouldPushHours && !shouldPushRadius && !shouldPushRateMin && !shouldPushRateMax) return;
-
-    pushOpdrachtenParams(searchParams, router, pathname, {
-      urenPerWeek: shouldPushHours ? "" : urenPerWeek,
-      urenPerWeekMin: debouncedHoursMin,
-      urenPerWeekMax: debouncedHoursMax,
-      straalKm: debouncedRadiusKm,
-      tariefMin: debouncedRateMin,
-      tariefMax: debouncedRateMax,
-      pagina: "1",
-    });
-  }, [
-    debouncedHoursHasManualInput,
-    debouncedHoursMin,
-    debouncedHoursMax,
-    debouncedRadiusKm,
-    debouncedRateMin,
-    debouncedRateMax,
-    straalKm,
-    tariefMinParamFromUrl,
-    tariefMaxParamFromUrl,
-    urenPerWeek,
-    router,
-    pathname,
-    searchParams,
-  ]);
-
-  // Debounce search input: push to URL after 300ms so queryKey updates (only when user typed, not when we synced from URL)
-  useEffect(() => {
-    if (inputValue === q) {
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-        debounceRef.current = null;
-      }
-      return;
-    }
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      pushOpdrachtenParams(searchParams, router, pathname, { q: inputValue, pagina: "1" });
-      debounceRef.current = null;
-    }, 300);
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, [inputValue, pathname, q, searchParams, router]);
-
-  const { data, error, isFetching } = useQuery({
-    queryKey: ["opdrachten-search", searchQueryKey],
-    queryFn: ({ signal }) =>
-      searchJobs({
-        q,
-        platform,
-        endClient,
-        vaardigheid,
-        status,
-        provincie,
-        regios: sortedRegios,
-        vakgebieden: sortedVakgebieden,
-        urenPerWeek: effectiveHoursPerWeekBucket,
-        urenPerWeekMin: debouncedHoursMin,
-        urenPerWeekMax: debouncedHoursMax,
-        straalKm: debouncedRadiusKm,
-        contractType,
-        tariefMin: debouncedRateMin,
-        tariefMax: debouncedRateMax,
-        sort,
-        page: pageParam,
-        limit: limitParam,
-        signal,
-      }),
-    staleTime: 30_000,
-    placeholderData: (prev) => prev,
-    initialData:
-      pageParam === 1 &&
-      limitParam === DEFAULT_OPDRACHTEN_LIMIT &&
-      !q &&
-      !platform &&
-      !endClient &&
-      !vaardigheid &&
-      status === "open" &&
-      !provincie &&
-      regios.length === 0 &&
-      vakgebieden.length === 0 &&
-      !debouncedHoursMin &&
-      !debouncedHoursMax &&
-      !debouncedRadiusKm &&
-      !contractType &&
-      !debouncedRateMin &&
-      !debouncedRateMax &&
-      sort === "nieuwste"
-        ? {
-            jobs: initialJobs,
-            total: initialTotal,
-            page: 1,
-            perPage: DEFAULT_OPDRACHTEN_LIMIT,
-            totalPages: Math.ceil(initialTotal / DEFAULT_OPDRACHTEN_LIMIT),
-          }
-        : undefined,
-  });
-
-  const displayJobs = data?.jobs ?? initialJobs;
-  const displayTotal = data?.total ?? initialTotal;
-  const displayPerPage = data?.perPage ?? limitParam;
-  const totalPages = data?.totalPages ?? 1;
-  const searchErrorMessage = error instanceof Error ? error.message : null;
-  const detailQuery = searchParams.toString();
-  const shortlistCount = displayJobs.filter((job) => (job.pipelineCount ?? 0) > 0).length;
-  const urgentDeadlineCount = displayJobs.filter((job) =>
-    hasUrgentDeadline(job.applicationDeadline),
-  ).length;
-  const activeFilterCount =
-    Number(Boolean(platform)) +
-    Number(Boolean(endClient)) +
-    Number(Boolean(vaardigheid)) +
-    Number(status !== "open") +
-    Number(Boolean(provincie)) +
-    Number(regios.length > 0) +
-    Number(vakgebieden.length > 0) +
-    Number(Boolean(urenPerWeek)) +
-    Number(Boolean(hoursMinInput || hoursMaxInput)) +
-    Number(Boolean(radiusKmInput)) +
-    Number(Boolean(contractType)) +
-    Number(Boolean(rateMinInput || rateMaxInput)) +
-    Number(sort !== "nieuwste");
-  const buildDetailHref = (jobId: string) => {
-    const base = "/vacatures";
-    return detailQuery ? `${base}/${jobId}?${detailQuery}` : `${base}/${jobId}`;
-  };
-
-  const handleFilterChange = (paramKey: string, value: string) => {
-    pushOpdrachtenParams(searchParams, router, pathname, { [paramKey]: value, pagina: "1" });
-  };
-
-  const handleToggleRegio = (value: string) => {
-    pushOpdrachtenParams(searchParams, router, pathname, {
-      regio: toggleFilterValue(regios, value),
-      pagina: "1",
-    });
-  };
-
-  const handleToggleVakgebied = (value: string) => {
-    pushOpdrachtenParams(searchParams, router, pathname, {
-      vakgebied: toggleFilterValue(vakgebieden, value),
-      pagina: "1",
-    });
-  };
-
-  const handleHoursRangeChange = (field: "urenPerWeekMin" | "urenPerWeekMax", value: string) => {
-    if (field === "urenPerWeekMin") {
-      setHoursMinInput(value);
-      return;
-    }
-
-    setHoursMaxInput(value);
-  };
-
-  const handleRadiusChange = (value: string) => {
-    setRadiusKmInput(value);
-  };
-
-  const handleRateMinChange = (value: string) => {
-    setRateMinInput(value);
-  };
-
-  const handleRateMaxChange = (value: string) => {
-    setRateMaxInput(value);
-  };
-
-  const handleProvinceChange = (value: string) => {
-    const nextProvince = value === "__all__" ? "" : value;
-    if (!nextProvince) {
-      setRadiusKmInput("");
-    }
-
-    pushOpdrachtenParams(
-      searchParams,
-      router,
-      pathname,
-      nextProvince
-        ? { provincie: nextProvince, pagina: "1" }
-        : { provincie: "", straalKm: "", pagina: "1" },
-    );
-  };
-
-  const resetFilters = () => {
-    router.push(getOpdrachtenBasePath(pathname));
-  };
+  const {
+    isOverviewPage,
+    activeId,
+    platform,
+    endClient,
+    vaardigheid,
+    status,
+    provincie,
+    regios,
+    vakgebieden,
+    contractType,
+    sort,
+    sortOptions,
+    provinceAnchor,
+    regionOptions,
+    categoryOptions,
+    inputValue,
+    setInputValue,
+    hoursMinInput,
+    hoursMaxInput,
+    radiusKmInput,
+    rateMinInput,
+    setRateMinInput,
+    rateMaxInput,
+    setRateMaxInput,
+    mobileFiltersOpen,
+    setMobileFiltersOpen,
+    displayJobs,
+    displayTotal,
+    displayPerPage,
+    totalPages,
+    pageParam,
+    searchErrorMessage,
+    isFetching,
+    shortlistCount,
+    urgentDeadlineCount,
+    activeFilterCount,
+    buildDetailHref,
+    pushParams,
+    handleFilterChange,
+    handleToggleRegio,
+    handleToggleVakgebied,
+    handleHoursRangeChange,
+    handleRadiusChange,
+    handleProvinceChange,
+    resetFilters,
+  } = useSidebarFilters({ initialJobs, initialTotal, categories });
 
   if (!isOverviewPage) {
     return (
       <aside className="flex h-full w-full flex-col overflow-hidden bg-[#050506] text-white">
-        <div className="shrink-0 px-4 pb-4 pt-5">
-          <div className="relative">
-            <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-white/40" />
-            <Input
-              placeholder="Zoek vacatures..."
-              value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
-              className={cn(
-                "h-14 rounded-[24px] pl-12 pr-11 text-[17px]",
-                DARK_FILTER_CONTROL_CLASS,
-              )}
-            />
-            {isFetching && (
-              <Loader2 className="absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-white/45" />
-            )}
-          </div>
-        </div>
-
-        <div className="grid shrink-0 gap-3 px-4">
-          <div className="grid grid-cols-2 gap-3">
-            <Select
-              value={platform || undefined}
-              onValueChange={(v) => handleFilterChange("platform", v === "__all__" ? "" : v)}
-            >
-              <SelectTrigger className={cn("w-full", DARK_FILTER_TRIGGER_CLASS)}>
-                <SelectValue placeholder="Platform" />
-              </SelectTrigger>
-              <SelectContent className={DARK_FILTER_MENU_CLASS}>
-                <SelectItem value="__all__" className="text-white">
-                  Alle platforms
-                </SelectItem>
-                {platforms.map((p) => (
-                  <SelectItem key={p} value={p} className="capitalize text-white">
-                    {p}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-
-            <SearchableCombobox
-              value={endClient || undefined}
-              onValueChange={(value) => handleFilterChange("endClient", value)}
-              options={endClients}
-              placeholder="Eindopdrachtgever"
-              searchPlaceholder="Zoek eindopdrachtgever..."
-              emptyText="Geen eindopdrachtgevers gevonden."
-              clearLabel="Alle eindopdrachtgevers"
-              buttonClassName={cn("w-full", DARK_FILTER_TRIGGER_CLASS)}
-              contentClassName={DARK_FILTER_MENU_CLASS}
-              itemClassName="text-sm text-white"
-            />
-          </div>
-
-          <SearchableCombobox
-            value={vaardigheid || undefined}
-            onValueChange={(value) => handleFilterChange("vaardigheid", value)}
-            options={skillOptions}
-            placeholder="Vaardigheid"
-            searchPlaceholder="Zoek ESCO vaardigheid..."
-            emptyText={skillEmptyText}
-            clearLabel="Alle vaardigheden"
-            buttonClassName={cn("w-full", DARK_FILTER_TRIGGER_CLASS)}
-            contentClassName={DARK_FILTER_MENU_CLASS}
-            itemClassName="text-sm text-white"
-            triggerId="opdrachten-esco-vaardigheid"
-            ariaLabel="ESCO vaardigheid"
-          />
-
-          <div className="grid grid-cols-2 gap-3">
-            <Select
-              value={status}
-              onValueChange={(v) => handleFilterChange("status", v === "open" ? "" : v)}
-            >
-              <SelectTrigger className={cn("w-full", DARK_FILTER_TRIGGER_CLASS)}>
-                <SelectValue placeholder="Status" />
-              </SelectTrigger>
-              <SelectContent className={DARK_FILTER_MENU_CLASS}>
-                <SelectItem value="open" className="text-white">
-                  Open
-                </SelectItem>
-                <SelectItem value="closed" className="text-white">
-                  Gesloten
-                </SelectItem>
-                <SelectItem value="archived" className="text-white">
-                  Gearchiveerd
-                </SelectItem>
-                <SelectItem value="all" className="text-white">
-                  Alles
-                </SelectItem>
-              </SelectContent>
-            </Select>
-
-            <Select value={provincie || undefined} onValueChange={handleProvinceChange}>
-              <SelectTrigger className={cn("w-full", DARK_FILTER_TRIGGER_CLASS)}>
-                <SelectValue placeholder="Provincie" />
-              </SelectTrigger>
-              <SelectContent className={DARK_FILTER_MENU_CLASS}>
-                <SelectItem value="__all__" className="text-white">
-                  Alle provincies
-                </SelectItem>
-                {OPDRACHTEN_PROVINCES.map((p) => (
-                  <SelectItem key={p} value={p} className="text-white">
-                    {p}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="grid grid-cols-2 gap-3">
-            <CompactMultiSelectFilter
-              label="Regio"
-              options={regionOptions}
-              selectedValues={regios}
-              onToggle={handleToggleRegio}
-              buttonClassName={cn(
-                "h-12 rounded-[20px] px-4 text-[15px] text-white",
-                DARK_FILTER_PANEL_CLASS,
-              )}
-              contentClassName={DARK_FILTER_MENU_CLASS}
-            />
-            <CompactMultiSelectFilter
-              label="Vakgebied"
-              options={categoryOptions}
-              selectedValues={vakgebieden}
-              onToggle={handleToggleVakgebied}
-              buttonClassName={cn(
-                "h-12 rounded-[20px] px-4 text-[15px] text-white",
-                DARK_FILTER_PANEL_CLASS,
-              )}
-              contentClassName={DARK_FILTER_MENU_CLASS}
-            />
-          </div>
-
-          <div className="space-y-3">
-            <div className="flex items-center justify-between gap-3">
-              <span className={DARK_FILTER_SECTION_LABEL_CLASS}>Uren per week</span>
-              <span className={DARK_FILTER_SECTION_VALUE_CLASS}>
-                {summarizeHoursRange(hoursMinInput, hoursMaxInput)}
-              </span>
-            </div>
-            <div className="grid grid-cols-2 gap-3">
-              <Input
-                type="number"
-                inputMode="numeric"
-                min="1"
-                placeholder="Min"
-                value={hoursMinInput}
-                onChange={(e) => handleHoursRangeChange("urenPerWeekMin", e.target.value)}
-                className={DARK_FILTER_CONTROL_CLASS}
-              />
-              <Input
-                type="number"
-                inputMode="numeric"
-                min="1"
-                placeholder="Max"
-                value={hoursMaxInput}
-                onChange={(e) => handleHoursRangeChange("urenPerWeekMax", e.target.value)}
-                className={DARK_FILTER_CONTROL_CLASS}
-              />
-            </div>
-          </div>
-        </div>
-
-        <RadiusSliderField
-          provinceAnchor={provinceAnchor}
-          radiusKm={radiusKmInput}
-          onRadiusChange={handleRadiusChange}
-          compact
+        <SidebarSearchBar
+          value={inputValue}
+          onChange={setInputValue}
+          isFetching={isFetching}
+          variant="compact"
         />
 
-        <div className="shrink-0 px-4 pb-4">
-          <Select
-            value={sort}
-            onValueChange={(value) => handleFilterChange("sort", value === "nieuwste" ? "" : value)}
-          >
-            <SelectTrigger className={cn("w-full", DARK_FILTER_TRIGGER_CLASS)}>
-              <SelectValue placeholder="Sortering" />
-            </SelectTrigger>
-            <SelectContent className={DARK_FILTER_MENU_CLASS}>
-              {sortOptions.map((option) => (
-                <SelectItem key={option.value} value={option.value} className="text-sm text-white">
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
+        <CompactSidebarFilters
+          platform={platform}
+          platforms={platforms}
+          endClient={endClient}
+          endClients={endClients}
+          vaardigheid={vaardigheid}
+          skillOptions={skillOptions}
+          skillEmptyText={skillEmptyText}
+          status={status}
+          provincie={provincie}
+          regios={regios}
+          regionOptions={regionOptions}
+          vakgebieden={vakgebieden}
+          categoryOptions={categoryOptions}
+          hoursMinInput={hoursMinInput}
+          hoursMaxInput={hoursMaxInput}
+          radiusKmInput={radiusKmInput}
+          provinceAnchor={provinceAnchor}
+          sort={sort}
+          sortOptions={sortOptions}
+          onFilterChange={handleFilterChange}
+          onProvinceChange={handleProvinceChange}
+          onToggleRegio={handleToggleRegio}
+          onToggleVakgebied={handleToggleVakgebied}
+          onHoursRangeChange={handleHoursRangeChange}
+          onRadiusChange={handleRadiusChange}
+        />
 
-        <div className="flex shrink-0 items-center justify-between gap-3 border-y border-white/10 bg-black/30 px-4 py-4">
-          <div className="min-w-0">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/55">
-              {displayTotal} vacatures
-            </p>
-            <div className="mt-1 flex flex-wrap gap-1.5">
-              <Badge
-                variant="outline"
-                className="h-7 rounded-full border-white/10 bg-white/[0.035] px-3 text-[11px] text-white/65"
-              >
-                {shortlistCount > 0 ? `${shortlistCount} met shortlist` : "Nog geen shortlist"}
-              </Badge>
-              {urgentDeadlineCount > 0 ? (
-                <Badge
-                  variant="outline"
-                  className="h-7 rounded-full border-amber-500/20 bg-amber-500/12 px-3 text-[11px] text-amber-200"
-                >
-                  {urgentDeadlineCount} deadlines vragen aandacht
-                </Badge>
-              ) : null}
-            </div>
-          </div>
-          <div className="flex items-center gap-2">
-            <Select
-              value={String(displayPerPage)}
-              onValueChange={(v) =>
-                pushOpdrachtenParams(searchParams, router, pathname, {
-                  limit: v === String(DEFAULT_OPDRACHTEN_LIMIT) ? "" : v,
-                  pagina: "1",
-                })
-              }
-            >
-              <SelectTrigger className="h-12 w-[132px] rounded-[18px] border-white/10 bg-white/[0.035] px-4 text-[15px] text-white">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent className={DARK_FILTER_MENU_CLASS}>
-                {OPDRACHTEN_PAGE_SIZE_OPTIONS.map((value) => (
-                  <SelectItem key={value} value={String(value)} className="text-sm text-white">
-                    {value} / pg
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {totalPages > 1 && (
-              <p className="text-base text-white/55">
-                {pageParam}/{totalPages}
-              </p>
-            )}
-          </div>
-        </div>
+        <SidebarResultsHeader
+          displayTotal={displayTotal}
+          shortlistCount={shortlistCount}
+          urgentDeadlineCount={urgentDeadlineCount}
+          displayPerPage={displayPerPage}
+          pageParam={pageParam}
+          totalPages={totalPages}
+          pushParams={pushParams}
+          variant="compact"
+        />
 
         {searchErrorMessage ? (
           <div className="px-4 py-3 text-sm text-red-300">{searchErrorMessage}</div>
         ) : null}
 
-        <ScrollArea className="min-h-0 flex-1 bg-[#050506]">
-          {displayJobs.length === 0 ? (
-            <div className="px-4 py-8 text-center text-sm text-white/45">
-              Geen vacatures gevonden
-            </div>
-          ) : (
-            displayJobs.map((job) => (
-              <JobListItem
-                key={job.id}
-                job={job}
-                isActive={job.id === activeId}
-                hasPipeline={job.hasPipeline}
-                pipelineCount={job.pipelineCount}
-                href={buildDetailHref(job.id)}
-              />
-            ))
-          )}
-        </ScrollArea>
+        <SidebarJobList
+          jobs={displayJobs}
+          activeId={activeId}
+          buildDetailHref={buildDetailHref}
+          variant="compact"
+        />
 
-        {totalPages > 1 && (
-          <div className="flex shrink-0 items-center justify-between border-t border-white/10 px-4 py-3">
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-10 rounded-[16px] px-4 text-sm text-white/55 hover:bg-white/[0.05] hover:text-white"
-              disabled={pageParam <= 1 || isFetching}
-              onClick={() =>
-                pushOpdrachtenParams(searchParams, router, pathname, {
-                  pagina: String(pageParam - 1),
-                })
-              }
-            >
-              <ChevronLeft className="h-3.5 w-3.5 mr-1" />
-              Vorige
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-10 rounded-[16px] px-4 text-sm text-white/55 hover:bg-white/[0.05] hover:text-white"
-              disabled={pageParam >= totalPages || isFetching}
-              onClick={() =>
-                pushOpdrachtenParams(searchParams, router, pathname, {
-                  pagina: String(pageParam + 1),
-                })
-              }
-            >
-              Volgende
-              <ChevronRight className="h-3.5 w-3.5 ml-1" />
-            </Button>
-          </div>
-        )}
+        <SidebarPagination
+          pageParam={pageParam}
+          totalPages={totalPages}
+          isFetching={isFetching}
+          pushParams={pushParams}
+          variant="compact"
+        />
       </aside>
     );
   }
@@ -1152,360 +160,64 @@ export function OpdrachtenSidebar({
   return (
     <aside className="h-full min-w-0 w-full bg-sidebar/25">
       <div className="grid h-full min-h-0 overflow-hidden lg:grid-cols-[300px_minmax(0,1fr)]">
-        <div className="flex min-h-0 flex-col border-b border-border/70 px-3 py-3 sm:px-4 sm:py-5 lg:border-b-0 lg:border-r lg:px-5 lg:py-6">
-          <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
-            <h3 className="text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
-              Zoekfilter
-            </h3>
-            <button
-              type="button"
-              onClick={resetFilters}
-              className="inline-flex min-h-11 items-center gap-1 rounded-md px-2 text-xs font-semibold uppercase tracking-wide text-primary hover:bg-primary/5 hover:opacity-80"
-            >
-              <RotateCcw className="h-3.5 w-3.5" />
-              Wis filters
-            </button>
-          </div>
-
-          <div className="flex min-h-0 flex-1 flex-col gap-3 sm:gap-4">
-            <div>
-              <label
-                htmlFor="opdrachten-zoekterm"
-                className="mb-2 block text-sm font-medium text-foreground"
-              >
-                Zoekterm
-              </label>
-              <div className="relative">
-                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  id="opdrachten-zoekterm"
-                  value={inputValue}
-                  onChange={(e) => setInputValue(e.target.value)}
-                  placeholder="Zoek vacature..."
-                  className="h-11 rounded-lg border-border bg-background pl-10 text-sm"
-                />
-                {isFetching && (
-                  <Loader2 className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground" />
-                )}
-              </div>
-            </div>
-
-            <button
-              type="button"
-              aria-expanded={mobileFiltersOpen}
-              aria-controls="opdrachten-mobile-filters"
-              className="inline-flex min-h-11 w-full items-center justify-between rounded-lg border border-border bg-background px-3 text-sm font-medium text-foreground shadow-sm lg:hidden"
-              onClick={() => setMobileFiltersOpen((open) => !open)}
-            >
-              <span className="min-w-0 truncate">
-                {mobileFiltersOpen ? "Filters sluiten" : "Filters openen"}
-                {activeFilterCount > 0 ? ` (${activeFilterCount} actief)` : ""}
-              </span>
-              <ChevronDown
-                className={cn(
-                  "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
-                  mobileFiltersOpen && "rotate-180",
-                )}
-              />
-            </button>
-
-            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground lg:hidden">
-              <span>{displayTotal} resultaten</span>
-              {activeFilterCount > 0 ? (
-                <Badge
-                  variant="outline"
-                  className="max-w-full whitespace-normal wrap-break-word border-primary/20 bg-primary/10 px-2 py-0.5 text-[11px] text-primary"
-                >
-                  {activeFilterCount} filters actief
-                </Badge>
-              ) : null}
-            </div>
-
-            <div
-              id="opdrachten-mobile-filters"
-              className={cn(
-                "min-h-0 flex-1 space-y-3 overflow-y-auto rounded-xl border border-border/70 bg-background/60 p-3 sm:space-y-4 sm:p-4 lg:rounded-none lg:border-0 lg:bg-transparent lg:p-0",
-                !mobileFiltersOpen && "hidden lg:block",
-              )}
-            >
-              <div>
-                <label
-                  htmlFor="opdrachten-opdrachtgever"
-                  className="mb-2 block text-sm font-medium text-foreground"
-                >
-                  Platform
-                </label>
-                <Select
-                  value={platform || "__all__"}
-                  onValueChange={(v) => handleFilterChange("platform", v === "__all__" ? "" : v)}
-                >
-                  <SelectTrigger
-                    id="opdrachten-opdrachtgever"
-                    className="data-[size=default]:h-11 w-full rounded-lg border-border bg-background text-left text-sm"
-                  >
-                    <SelectValue placeholder="Alle platforms" />
-                  </SelectTrigger>
-                  <SelectContent className="bg-card border-border">
-                    <SelectItem value="__all__" className="text-foreground">
-                      Alle platforms
-                    </SelectItem>
-                    {platforms.map((p) => (
-                      <SelectItem key={p} value={p} className="capitalize text-foreground">
-                        {p}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div>
-                <label
-                  htmlFor="opdrachten-eindopdrachtgever"
-                  className="mb-2 block text-sm font-medium text-foreground"
-                >
-                  Eindopdrachtgever
-                </label>
-                <SearchableCombobox
-                  value={endClient || undefined}
-                  onValueChange={(value) => handleFilterChange("endClient", value)}
-                  options={endClients}
-                  placeholder="Alle eindopdrachtgevers"
-                  searchPlaceholder="Zoek eindopdrachtgever..."
-                  emptyText="Geen eindopdrachtgevers gevonden."
-                  clearLabel="Alle eindopdrachtgevers"
-                  buttonClassName="h-11 rounded-lg border-border bg-background text-left text-sm"
-                  triggerId="opdrachten-eindopdrachtgever"
-                  ariaLabel="Eindopdrachtgever"
-                />
-              </div>
-
-              <div>
-                <label
-                  htmlFor="opdrachten-esco-vaardigheid"
-                  className="mb-2 block text-sm font-medium text-foreground"
-                >
-                  Vaardigheid
-                </label>
-                <SearchableCombobox
-                  value={vaardigheid || undefined}
-                  onValueChange={(value) => handleFilterChange("vaardigheid", value)}
-                  options={skillOptions}
-                  placeholder="Alle vaardigheden"
-                  searchPlaceholder="Zoek ESCO vaardigheid..."
-                  emptyText={skillEmptyText}
-                  clearLabel="Alle vaardigheden"
-                  buttonClassName="h-11 rounded-lg border-border bg-background text-left text-sm"
-                  triggerId="opdrachten-esco-vaardigheid"
-                  ariaLabel="ESCO vaardigheid"
-                />
-              </div>
-
-              <div>
-                <label
-                  htmlFor="opdrachten-status"
-                  className="mb-2 block text-sm font-medium text-foreground"
-                >
-                  Status
-                </label>
-                <Select
-                  value={status}
-                  onValueChange={(v) => handleFilterChange("status", v === "open" ? "" : v)}
-                >
-                  <SelectTrigger
-                    id="opdrachten-status"
-                    className="data-[size=default]:h-11 w-full rounded-lg border-border bg-background text-left text-sm"
-                  >
-                    <SelectValue placeholder="Open" />
-                  </SelectTrigger>
-                  <SelectContent className="bg-card border-border">
-                    <SelectItem value="open" className="text-foreground">
-                      Open
-                    </SelectItem>
-                    <SelectItem value="closed" className="text-foreground">
-                      Gesloten
-                    </SelectItem>
-                    <SelectItem value="archived" className="text-foreground">
-                      Gearchiveerd
-                    </SelectItem>
-                    <SelectItem value="all" className="text-foreground">
-                      Alles
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div>
-                <p className="mb-2 block text-sm font-medium text-foreground">Regio</p>
-                <FilterChecklist
-                  idPrefix="opdrachten-regio"
-                  options={regionOptions}
-                  selectedValues={regios}
-                  onToggle={handleToggleRegio}
-                />
-              </div>
-
-              <div>
-                <label
-                  htmlFor="opdrachten-locatie"
-                  className="mb-2 block text-sm font-medium text-foreground"
-                >
-                  Provincie
-                </label>
-                <Select value={provincie || "__all__"} onValueChange={handleProvinceChange}>
-                  <SelectTrigger
-                    id="opdrachten-locatie"
-                    className="data-[size=default]:h-11 w-full rounded-lg border-border bg-background text-left text-sm"
-                  >
-                    <SelectValue placeholder="Alle provincies" />
-                  </SelectTrigger>
-                  <SelectContent className="bg-card border-border">
-                    <SelectItem value="__all__" className="text-foreground">
-                      Alle provincies
-                    </SelectItem>
-                    {OPDRACHTEN_PROVINCES.map((p) => (
-                      <SelectItem key={p} value={p} className="text-foreground">
-                        {p}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div>
-                <p className="mb-2 block text-sm font-medium text-foreground">Vakgebied</p>
-                <FilterChecklist
-                  idPrefix="opdrachten-vakgebied"
-                  options={categoryOptions}
-                  selectedValues={vakgebieden}
-                  onToggle={handleToggleVakgebied}
-                  className="max-h-64 overflow-y-auto"
-                />
-              </div>
-
-              <div>
-                <p className="mb-2 block text-sm font-medium text-foreground">Uren per week</p>
-                <div className="grid grid-cols-2 gap-2">
-                  <Input
-                    type="number"
-                    inputMode="numeric"
-                    min="1"
-                    placeholder="Min uren"
-                    value={hoursMinInput}
-                    onChange={(e) => handleHoursRangeChange("urenPerWeekMin", e.target.value)}
-                    className="h-11 rounded-lg border-border bg-background text-sm"
-                  />
-                  <Input
-                    type="number"
-                    inputMode="numeric"
-                    min="1"
-                    placeholder="Max uren"
-                    value={hoursMaxInput}
-                    onChange={(e) => handleHoursRangeChange("urenPerWeekMax", e.target.value)}
-                    className="h-11 rounded-lg border-border bg-background text-sm"
-                  />
-                </div>
-                <p className="mt-2 text-xs text-muted-foreground">
-                  {summarizeHoursRange(hoursMinInput, hoursMaxInput)} — vacatures overlappen met dit
-                  bereik.
-                </p>
-              </div>
-
-              <div>
-                <p className="mb-2 block text-sm font-medium text-foreground">Straal (km)</p>
-                <RadiusSliderField
-                  provinceAnchor={provinceAnchor}
-                  radiusKm={radiusKmInput}
-                  onRadiusChange={handleRadiusChange}
-                />
-              </div>
-
-              <div>
-                <label
-                  htmlFor="opdrachten-contracttype"
-                  className="mb-2 block text-sm font-medium text-foreground"
-                >
-                  Contract type
-                </label>
-                <Select
-                  value={contractType || "__all__"}
-                  onValueChange={(v) =>
-                    handleFilterChange("contractType", v === "__all__" ? "" : v)
-                  }
-                >
-                  <SelectTrigger
-                    id="opdrachten-contracttype"
-                    className="data-[size=default]:h-11 w-full rounded-lg border-border bg-background text-left text-sm"
-                  >
-                    <SelectValue placeholder="Alle types" />
-                  </SelectTrigger>
-                  <SelectContent className="bg-card border-border">
-                    <SelectItem value="__all__" className="text-foreground">
-                      Alle types
-                    </SelectItem>
-                    {CONTRACT_TYPES.map((type) => (
-                      <SelectItem key={type.value} value={type.value} className="text-foreground">
-                        {type.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div>
-                <p className="mb-2 block text-sm font-medium text-foreground">Tarief per uur</p>
-                <div className="grid grid-cols-2 gap-2">
-                  <Input
-                    type="number"
-                    inputMode="numeric"
-                    placeholder="Min"
-                    value={rateMinInput}
-                    onChange={(e) => handleRateMinChange(e.target.value)}
-                    className="h-11 rounded-lg border-border bg-background text-sm"
-                  />
-                  <Input
-                    type="number"
-                    inputMode="numeric"
-                    placeholder="Max"
-                    value={rateMaxInput}
-                    onChange={(e) => handleRateMaxChange(e.target.value)}
-                    className="h-11 rounded-lg border-border bg-background text-sm"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
+        <OverviewFilterPanel
+          inputValue={inputValue}
+          onInputChange={setInputValue}
+          isFetching={isFetching}
+          mobileFiltersOpen={mobileFiltersOpen}
+          onToggleMobileFilters={() => setMobileFiltersOpen((open) => !open)}
+          activeFilterCount={activeFilterCount}
+          displayTotal={displayTotal}
+          platform={platform}
+          platforms={platforms}
+          endClient={endClient}
+          endClients={endClients}
+          vaardigheid={vaardigheid}
+          skillOptions={skillOptions}
+          skillEmptyText={skillEmptyText}
+          status={status}
+          provincie={provincie}
+          regios={regios}
+          regionOptions={regionOptions}
+          vakgebieden={vakgebieden}
+          categoryOptions={categoryOptions}
+          hoursMinInput={hoursMinInput}
+          hoursMaxInput={hoursMaxInput}
+          radiusKmInput={radiusKmInput}
+          rateMinInput={rateMinInput}
+          rateMaxInput={rateMaxInput}
+          provinceAnchor={provinceAnchor}
+          contractType={contractType}
+          onFilterChange={handleFilterChange}
+          onProvinceChange={handleProvinceChange}
+          onToggleRegio={handleToggleRegio}
+          onToggleVakgebied={handleToggleVakgebied}
+          onHoursRangeChange={handleHoursRangeChange}
+          onRadiusChange={handleRadiusChange}
+          onRateMinChange={setRateMinInput}
+          onRateMaxChange={setRateMaxInput}
+          onResetFilters={resetFilters}
+        />
 
         <div className="flex h-full min-h-0 min-w-0 flex-col px-3 py-2.5 sm:px-4 sm:py-4 md:px-5 md:py-5 lg:px-6 overflow-hidden">
           <div className="mb-2.5 flex flex-col gap-2.5 border-b border-border/70 pb-2.5 sm:mb-4 sm:gap-3 sm:pb-4">
-            <div className="min-w-0 space-y-2">
-              <div className="text-base font-semibold text-foreground sm:text-lg">
-                {displayTotal} vacatures weergegeven
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <Badge
-                  variant="outline"
-                  className="max-w-full whitespace-normal wrap-break-word text-[11px] text-muted-foreground sm:text-xs"
-                >
-                  {shortlistCount > 0 ? `${shortlistCount} met shortlist` : "Nog geen shortlist"}
-                </Badge>
-                {urgentDeadlineCount > 0 ? (
-                  <Badge
-                    variant="outline"
-                    className="max-w-full whitespace-normal wrap-break-word border-amber-500/20 bg-amber-500/10 text-[11px] text-amber-700 dark:text-amber-300 sm:text-xs"
-                  >
-                    {urgentDeadlineCount} deadlines vragen aandacht
-                  </Badge>
-                ) : null}
-              </div>
-            </div>
+            <SidebarResultsHeader
+              displayTotal={displayTotal}
+              shortlistCount={shortlistCount}
+              urgentDeadlineCount={urgentDeadlineCount}
+              displayPerPage={displayPerPage}
+              pageParam={pageParam}
+              totalPages={totalPages}
+              pushParams={pushParams}
+              variant="overview"
+            />
             <div className="flex w-full flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
               <div className="grid w-full grid-cols-[auto_minmax(0,1fr)] items-center gap-2 sm:flex sm:w-auto sm:items-center">
                 <span className="text-xs text-muted-foreground sm:text-sm">Per pagina:</span>
                 <Select
                   value={String(displayPerPage)}
                   onValueChange={(v) =>
-                    pushOpdrachtenParams(searchParams, router, pathname, {
+                    pushParams({
                       limit: v === String(DEFAULT_OPDRACHTEN_LIMIT) ? "" : v,
                       pagina: "1",
                     })
@@ -1523,26 +235,12 @@ export function OpdrachtenSidebar({
                   </SelectContent>
                 </Select>
               </div>
-              <div className="grid w-full grid-cols-[auto_minmax(0,1fr)] items-center gap-2 sm:flex sm:w-auto sm:items-center">
-                <span className="text-xs text-muted-foreground sm:text-sm">Sorteren:</span>
-                <Select
-                  value={sort}
-                  onValueChange={(value) =>
-                    handleFilterChange("sort", value === "nieuwste" ? "" : value)
-                  }
-                >
-                  <SelectTrigger className="data-[size=default]:h-11 w-full rounded-lg border-primary/40 bg-background text-sm font-semibold text-primary sm:w-[210px] sm:rounded-full sm:data-[size=default]:h-10">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent className="bg-card border-border">
-                    {sortOptions.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+              <SidebarSortControls
+                sort={sort}
+                sortOptions={sortOptions}
+                onSortChange={(value) => handleFilterChange("sort", value)}
+                variant="overview"
+              />
             </div>
           </div>
 
@@ -1550,63 +248,20 @@ export function OpdrachtenSidebar({
             <p className="mb-3 text-sm text-destructive">{searchErrorMessage}</p>
           ) : null}
 
-          <ScrollArea className="min-h-0 min-w-0 flex-1">
-            {displayJobs.length === 0 ? (
-              <div className="rounded-xl border border-dashed border-border bg-background px-5 py-10 text-center text-sm text-muted-foreground">
-                Geen vacatures gevonden voor deze filters.
-              </div>
-            ) : (
-              <div className="space-y-3 pb-4 sm:space-y-4">
-                {displayJobs.map((job) => (
-                  <JobListItem
-                    key={job.id}
-                    job={job}
-                    isActive={job.id === activeId}
-                    variant="card"
-                    hasPipeline={job.hasPipeline}
-                    pipelineCount={job.pipelineCount}
-                    href={buildDetailHref(job.id)}
-                  />
-                ))}
-              </div>
-            )}
-          </ScrollArea>
+          <SidebarJobList
+            jobs={displayJobs}
+            activeId={activeId}
+            buildDetailHref={buildDetailHref}
+            variant="overview"
+          />
 
-          {totalPages > 1 && (
-            <div className="mt-4 flex flex-col gap-2 border-t border-border/70 pt-4 sm:flex-row sm:items-center sm:justify-between">
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-11 w-full border-border bg-background text-foreground sm:h-9 sm:w-auto"
-                disabled={pageParam <= 1 || isFetching}
-                onClick={() =>
-                  pushOpdrachtenParams(searchParams, router, pathname, {
-                    pagina: String(pageParam - 1),
-                  })
-                }
-              >
-                <ChevronLeft className="mr-1 h-4 w-4" />
-                Vorige
-              </Button>
-              <p className="text-center text-sm text-muted-foreground">
-                Pagina {pageParam} van {totalPages}
-              </p>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-11 w-full border-border bg-background text-foreground sm:h-9 sm:w-auto"
-                disabled={pageParam >= totalPages || isFetching}
-                onClick={() =>
-                  pushOpdrachtenParams(searchParams, router, pathname, {
-                    pagina: String(pageParam + 1),
-                  })
-                }
-              >
-                Volgende
-                <ChevronRight className="ml-1 h-4 w-4" />
-              </Button>
-            </div>
-          )}
+          <SidebarPagination
+            pageParam={pageParam}
+            totalPages={totalPages}
+            isFetching={isFetching}
+            pushParams={pushParams}
+            variant="overview"
+          />
         </div>
       </div>
     </aside>

--- a/components/sidebar/compact-sidebar-filters.tsx
+++ b/components/sidebar/compact-sidebar-filters.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+/**
+ * Compact filter grid used in the detail-page (dark themed) sidebar view.
+ */
+import { Input } from "@/components/ui/input";
+import { SearchableCombobox } from "@/components/ui/searchable-combobox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import { OPDRACHTEN_PROVINCES } from "@/src/lib/opdrachten-filters";
+import { CompactMultiSelectFilter, RadiusSliderField } from "./sidebar-filter-controls";
+import { SidebarSortControls } from "./sidebar-sort-controls";
+import type { FilterOption, ProvinceAnchor } from "./sidebar-types";
+import {
+  DARK_FILTER_CONTROL_CLASS,
+  DARK_FILTER_MENU_CLASS,
+  DARK_FILTER_PANEL_CLASS,
+  DARK_FILTER_SECTION_LABEL_CLASS,
+  DARK_FILTER_SECTION_VALUE_CLASS,
+  DARK_FILTER_TRIGGER_CLASS,
+} from "./sidebar-types";
+import { summarizeHoursRange } from "./sidebar-utils";
+
+interface CompactSidebarFiltersProps {
+  platform: string;
+  platforms: string[];
+  endClient: string;
+  endClients: string[];
+  vaardigheid: string;
+  skillOptions: FilterOption[];
+  skillEmptyText: string;
+  status: string;
+  provincie: string;
+  regios: string[];
+  regionOptions: FilterOption[];
+  vakgebieden: string[];
+  categoryOptions: FilterOption[];
+  hoursMinInput: string;
+  hoursMaxInput: string;
+  radiusKmInput: string;
+  provinceAnchor: ProvinceAnchor;
+  sort: string;
+  sortOptions: { value: string; label: string }[];
+  onFilterChange: (paramKey: string, value: string) => void;
+  onProvinceChange: (value: string) => void;
+  onToggleRegio: (value: string) => void;
+  onToggleVakgebied: (value: string) => void;
+  onHoursRangeChange: (field: "urenPerWeekMin" | "urenPerWeekMax", value: string) => void;
+  onRadiusChange: (value: string) => void;
+}
+
+export function CompactSidebarFilters({
+  platform,
+  platforms,
+  endClient,
+  endClients,
+  vaardigheid,
+  skillOptions,
+  skillEmptyText,
+  status,
+  provincie,
+  regios,
+  regionOptions,
+  vakgebieden,
+  categoryOptions,
+  hoursMinInput,
+  hoursMaxInput,
+  radiusKmInput,
+  provinceAnchor,
+  sort,
+  sortOptions,
+  onFilterChange,
+  onProvinceChange,
+  onToggleRegio,
+  onToggleVakgebied,
+  onHoursRangeChange,
+  onRadiusChange,
+}: CompactSidebarFiltersProps) {
+  return (
+    <>
+      <div className="grid shrink-0 gap-3 px-4">
+        <div className="grid grid-cols-2 gap-3">
+          <Select
+            value={platform || undefined}
+            onValueChange={(v) => onFilterChange("platform", v === "__all__" ? "" : v)}
+          >
+            <SelectTrigger className={cn("w-full", DARK_FILTER_TRIGGER_CLASS)}>
+              <SelectValue placeholder="Platform" />
+            </SelectTrigger>
+            <SelectContent className={DARK_FILTER_MENU_CLASS}>
+              <SelectItem value="__all__" className="text-white">
+                Alle platforms
+              </SelectItem>
+              {platforms.map((p) => (
+                <SelectItem key={p} value={p} className="capitalize text-white">
+                  {p}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <SearchableCombobox
+            value={endClient || undefined}
+            onValueChange={(value) => onFilterChange("endClient", value)}
+            options={endClients}
+            placeholder="Eindopdrachtgever"
+            searchPlaceholder="Zoek eindopdrachtgever..."
+            emptyText="Geen eindopdrachtgevers gevonden."
+            clearLabel="Alle eindopdrachtgevers"
+            buttonClassName={cn("w-full", DARK_FILTER_TRIGGER_CLASS)}
+            contentClassName={DARK_FILTER_MENU_CLASS}
+            itemClassName="text-sm text-white"
+          />
+        </div>
+
+        <SearchableCombobox
+          value={vaardigheid || undefined}
+          onValueChange={(value) => onFilterChange("vaardigheid", value)}
+          options={skillOptions}
+          placeholder="Vaardigheid"
+          searchPlaceholder="Zoek ESCO vaardigheid..."
+          emptyText={skillEmptyText}
+          clearLabel="Alle vaardigheden"
+          buttonClassName={cn("w-full", DARK_FILTER_TRIGGER_CLASS)}
+          contentClassName={DARK_FILTER_MENU_CLASS}
+          itemClassName="text-sm text-white"
+          triggerId="opdrachten-esco-vaardigheid"
+          ariaLabel="ESCO vaardigheid"
+        />
+
+        <div className="grid grid-cols-2 gap-3">
+          <Select
+            value={status}
+            onValueChange={(v) => onFilterChange("status", v === "open" ? "" : v)}
+          >
+            <SelectTrigger className={cn("w-full", DARK_FILTER_TRIGGER_CLASS)}>
+              <SelectValue placeholder="Status" />
+            </SelectTrigger>
+            <SelectContent className={DARK_FILTER_MENU_CLASS}>
+              <SelectItem value="open" className="text-white">
+                Open
+              </SelectItem>
+              <SelectItem value="closed" className="text-white">
+                Gesloten
+              </SelectItem>
+              <SelectItem value="archived" className="text-white">
+                Gearchiveerd
+              </SelectItem>
+              <SelectItem value="all" className="text-white">
+                Alles
+              </SelectItem>
+            </SelectContent>
+          </Select>
+
+          <Select value={provincie || undefined} onValueChange={onProvinceChange}>
+            <SelectTrigger className={cn("w-full", DARK_FILTER_TRIGGER_CLASS)}>
+              <SelectValue placeholder="Provincie" />
+            </SelectTrigger>
+            <SelectContent className={DARK_FILTER_MENU_CLASS}>
+              <SelectItem value="__all__" className="text-white">
+                Alle provincies
+              </SelectItem>
+              {OPDRACHTEN_PROVINCES.map((p) => (
+                <SelectItem key={p} value={p} className="text-white">
+                  {p}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <CompactMultiSelectFilter
+            label="Regio"
+            options={regionOptions}
+            selectedValues={regios}
+            onToggle={onToggleRegio}
+            buttonClassName={cn(
+              "h-12 rounded-[20px] px-4 text-[15px] text-white",
+              DARK_FILTER_PANEL_CLASS,
+            )}
+            contentClassName={DARK_FILTER_MENU_CLASS}
+          />
+          <CompactMultiSelectFilter
+            label="Vakgebied"
+            options={categoryOptions}
+            selectedValues={vakgebieden}
+            onToggle={onToggleVakgebied}
+            buttonClassName={cn(
+              "h-12 rounded-[20px] px-4 text-[15px] text-white",
+              DARK_FILTER_PANEL_CLASS,
+            )}
+            contentClassName={DARK_FILTER_MENU_CLASS}
+          />
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <span className={DARK_FILTER_SECTION_LABEL_CLASS}>Uren per week</span>
+            <span className={DARK_FILTER_SECTION_VALUE_CLASS}>
+              {summarizeHoursRange(hoursMinInput, hoursMaxInput)}
+            </span>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <Input
+              type="number"
+              inputMode="numeric"
+              min="1"
+              placeholder="Min"
+              value={hoursMinInput}
+              onChange={(e) => onHoursRangeChange("urenPerWeekMin", e.target.value)}
+              className={DARK_FILTER_CONTROL_CLASS}
+            />
+            <Input
+              type="number"
+              inputMode="numeric"
+              min="1"
+              placeholder="Max"
+              value={hoursMaxInput}
+              onChange={(e) => onHoursRangeChange("urenPerWeekMax", e.target.value)}
+              className={DARK_FILTER_CONTROL_CLASS}
+            />
+          </div>
+        </div>
+      </div>
+
+      <RadiusSliderField
+        provinceAnchor={provinceAnchor}
+        radiusKm={radiusKmInput}
+        onRadiusChange={onRadiusChange}
+        compact
+      />
+
+      <SidebarSortControls
+        sort={sort}
+        sortOptions={sortOptions}
+        onSortChange={(value) => onFilterChange("sort", value)}
+        variant="compact"
+      />
+    </>
+  );
+}

--- a/components/sidebar/overview-filter-panel.tsx
+++ b/components/sidebar/overview-filter-panel.tsx
@@ -1,0 +1,410 @@
+"use client";
+
+/**
+ * Full filter panel used on the overview (/vacatures) page.
+ */
+import { ChevronDown, RotateCcw } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { SearchableCombobox } from "@/components/ui/searchable-combobox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import { OPDRACHTEN_PROVINCES } from "@/src/lib/opdrachten-filters";
+import { FilterChecklist, RadiusSliderField } from "./sidebar-filter-controls";
+import { SidebarSearchBar } from "./sidebar-search-bar";
+import type { FilterOption, ProvinceAnchor } from "./sidebar-types";
+import { CONTRACT_TYPES } from "./sidebar-types";
+import { summarizeHoursRange } from "./sidebar-utils";
+
+interface OverviewFilterPanelProps {
+  inputValue: string;
+  onInputChange: (value: string) => void;
+  isFetching: boolean;
+  mobileFiltersOpen: boolean;
+  onToggleMobileFilters: () => void;
+  activeFilterCount: number;
+  displayTotal: number;
+  platform: string;
+  platforms: string[];
+  endClient: string;
+  endClients: string[];
+  vaardigheid: string;
+  skillOptions: FilterOption[];
+  skillEmptyText: string;
+  status: string;
+  provincie: string;
+  regios: string[];
+  regionOptions: FilterOption[];
+  vakgebieden: string[];
+  categoryOptions: FilterOption[];
+  hoursMinInput: string;
+  hoursMaxInput: string;
+  radiusKmInput: string;
+  rateMinInput: string;
+  rateMaxInput: string;
+  provinceAnchor: ProvinceAnchor;
+  contractType: string;
+  onFilterChange: (paramKey: string, value: string) => void;
+  onProvinceChange: (value: string) => void;
+  onToggleRegio: (value: string) => void;
+  onToggleVakgebied: (value: string) => void;
+  onHoursRangeChange: (field: "urenPerWeekMin" | "urenPerWeekMax", value: string) => void;
+  onRadiusChange: (value: string) => void;
+  onRateMinChange: (value: string) => void;
+  onRateMaxChange: (value: string) => void;
+  onResetFilters: () => void;
+}
+
+export function OverviewFilterPanel({
+  inputValue,
+  onInputChange,
+  isFetching,
+  mobileFiltersOpen,
+  onToggleMobileFilters,
+  activeFilterCount,
+  displayTotal,
+  platform,
+  platforms,
+  endClient,
+  endClients,
+  vaardigheid,
+  skillOptions,
+  skillEmptyText,
+  status,
+  provincie,
+  regios,
+  regionOptions,
+  vakgebieden,
+  categoryOptions,
+  hoursMinInput,
+  hoursMaxInput,
+  radiusKmInput,
+  rateMinInput,
+  rateMaxInput,
+  provinceAnchor,
+  contractType,
+  onFilterChange,
+  onProvinceChange,
+  onToggleRegio,
+  onToggleVakgebied,
+  onHoursRangeChange,
+  onRadiusChange,
+  onRateMinChange,
+  onRateMaxChange,
+  onResetFilters,
+}: OverviewFilterPanelProps) {
+  return (
+    <div className="flex min-h-0 flex-col border-b border-border/70 px-3 py-3 sm:px-4 sm:py-5 lg:border-b-0 lg:border-r lg:px-5 lg:py-6">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
+          Zoekfilter
+        </h3>
+        <button
+          type="button"
+          onClick={onResetFilters}
+          className="inline-flex min-h-11 items-center gap-1 rounded-md px-2 text-xs font-semibold uppercase tracking-wide text-primary hover:bg-primary/5 hover:opacity-80"
+        >
+          <RotateCcw className="h-3.5 w-3.5" />
+          Wis filters
+        </button>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-3 sm:gap-4">
+        <SidebarSearchBar
+          value={inputValue}
+          onChange={onInputChange}
+          isFetching={isFetching}
+          variant="overview"
+        />
+
+        <button
+          type="button"
+          aria-expanded={mobileFiltersOpen}
+          aria-controls="opdrachten-mobile-filters"
+          className="inline-flex min-h-11 w-full items-center justify-between rounded-lg border border-border bg-background px-3 text-sm font-medium text-foreground shadow-sm lg:hidden"
+          onClick={onToggleMobileFilters}
+        >
+          <span className="min-w-0 truncate">
+            {mobileFiltersOpen ? "Filters sluiten" : "Filters openen"}
+            {activeFilterCount > 0 ? ` (${activeFilterCount} actief)` : ""}
+          </span>
+          <ChevronDown
+            className={cn(
+              "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+              mobileFiltersOpen && "rotate-180",
+            )}
+          />
+        </button>
+
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground lg:hidden">
+          <span>{displayTotal} resultaten</span>
+          {activeFilterCount > 0 ? (
+            <Badge
+              variant="outline"
+              className="max-w-full whitespace-normal wrap-break-word border-primary/20 bg-primary/10 px-2 py-0.5 text-[11px] text-primary"
+            >
+              {activeFilterCount} filters actief
+            </Badge>
+          ) : null}
+        </div>
+
+        <div
+          id="opdrachten-mobile-filters"
+          className={cn(
+            "min-h-0 flex-1 space-y-3 overflow-y-auto rounded-xl border border-border/70 bg-background/60 p-3 sm:space-y-4 sm:p-4 lg:rounded-none lg:border-0 lg:bg-transparent lg:p-0",
+            !mobileFiltersOpen && "hidden lg:block",
+          )}
+        >
+          <div>
+            <label
+              htmlFor="opdrachten-opdrachtgever"
+              className="mb-2 block text-sm font-medium text-foreground"
+            >
+              Platform
+            </label>
+            <Select
+              value={platform || "__all__"}
+              onValueChange={(v) => onFilterChange("platform", v === "__all__" ? "" : v)}
+            >
+              <SelectTrigger
+                id="opdrachten-opdrachtgever"
+                className="data-[size=default]:h-11 w-full rounded-lg border-border bg-background text-left text-sm"
+              >
+                <SelectValue placeholder="Alle platforms" />
+              </SelectTrigger>
+              <SelectContent className="bg-card border-border">
+                <SelectItem value="__all__" className="text-foreground">
+                  Alle platforms
+                </SelectItem>
+                {platforms.map((p) => (
+                  <SelectItem key={p} value={p} className="capitalize text-foreground">
+                    {p}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <label
+              htmlFor="opdrachten-eindopdrachtgever"
+              className="mb-2 block text-sm font-medium text-foreground"
+            >
+              Eindopdrachtgever
+            </label>
+            <SearchableCombobox
+              value={endClient || undefined}
+              onValueChange={(value) => onFilterChange("endClient", value)}
+              options={endClients}
+              placeholder="Alle eindopdrachtgevers"
+              searchPlaceholder="Zoek eindopdrachtgever..."
+              emptyText="Geen eindopdrachtgevers gevonden."
+              clearLabel="Alle eindopdrachtgevers"
+              buttonClassName="h-11 rounded-lg border-border bg-background text-left text-sm"
+              triggerId="opdrachten-eindopdrachtgever"
+              ariaLabel="Eindopdrachtgever"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="opdrachten-esco-vaardigheid"
+              className="mb-2 block text-sm font-medium text-foreground"
+            >
+              Vaardigheid
+            </label>
+            <SearchableCombobox
+              value={vaardigheid || undefined}
+              onValueChange={(value) => onFilterChange("vaardigheid", value)}
+              options={skillOptions}
+              placeholder="Alle vaardigheden"
+              searchPlaceholder="Zoek ESCO vaardigheid..."
+              emptyText={skillEmptyText}
+              clearLabel="Alle vaardigheden"
+              buttonClassName="h-11 rounded-lg border-border bg-background text-left text-sm"
+              triggerId="opdrachten-esco-vaardigheid"
+              ariaLabel="ESCO vaardigheid"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="opdrachten-status"
+              className="mb-2 block text-sm font-medium text-foreground"
+            >
+              Status
+            </label>
+            <Select
+              value={status}
+              onValueChange={(v) => onFilterChange("status", v === "open" ? "" : v)}
+            >
+              <SelectTrigger
+                id="opdrachten-status"
+                className="data-[size=default]:h-11 w-full rounded-lg border-border bg-background text-left text-sm"
+              >
+                <SelectValue placeholder="Open" />
+              </SelectTrigger>
+              <SelectContent className="bg-card border-border">
+                <SelectItem value="open" className="text-foreground">
+                  Open
+                </SelectItem>
+                <SelectItem value="closed" className="text-foreground">
+                  Gesloten
+                </SelectItem>
+                <SelectItem value="archived" className="text-foreground">
+                  Gearchiveerd
+                </SelectItem>
+                <SelectItem value="all" className="text-foreground">
+                  Alles
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <p className="mb-2 block text-sm font-medium text-foreground">Regio</p>
+            <FilterChecklist
+              idPrefix="opdrachten-regio"
+              options={regionOptions}
+              selectedValues={regios}
+              onToggle={onToggleRegio}
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="opdrachten-locatie"
+              className="mb-2 block text-sm font-medium text-foreground"
+            >
+              Provincie
+            </label>
+            <Select value={provincie || "__all__"} onValueChange={onProvinceChange}>
+              <SelectTrigger
+                id="opdrachten-locatie"
+                className="data-[size=default]:h-11 w-full rounded-lg border-border bg-background text-left text-sm"
+              >
+                <SelectValue placeholder="Alle provincies" />
+              </SelectTrigger>
+              <SelectContent className="bg-card border-border">
+                <SelectItem value="__all__" className="text-foreground">
+                  Alle provincies
+                </SelectItem>
+                {OPDRACHTEN_PROVINCES.map((p) => (
+                  <SelectItem key={p} value={p} className="text-foreground">
+                    {p}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <p className="mb-2 block text-sm font-medium text-foreground">Vakgebied</p>
+            <FilterChecklist
+              idPrefix="opdrachten-vakgebied"
+              options={categoryOptions}
+              selectedValues={vakgebieden}
+              onToggle={onToggleVakgebied}
+              className="max-h-64 overflow-y-auto"
+            />
+          </div>
+
+          <div>
+            <p className="mb-2 block text-sm font-medium text-foreground">Uren per week</p>
+            <div className="grid grid-cols-2 gap-2">
+              <Input
+                type="number"
+                inputMode="numeric"
+                min="1"
+                placeholder="Min uren"
+                value={hoursMinInput}
+                onChange={(e) => onHoursRangeChange("urenPerWeekMin", e.target.value)}
+                className="h-11 rounded-lg border-border bg-background text-sm"
+              />
+              <Input
+                type="number"
+                inputMode="numeric"
+                min="1"
+                placeholder="Max uren"
+                value={hoursMaxInput}
+                onChange={(e) => onHoursRangeChange("urenPerWeekMax", e.target.value)}
+                className="h-11 rounded-lg border-border bg-background text-sm"
+              />
+            </div>
+            <p className="mt-2 text-xs text-muted-foreground">
+              {summarizeHoursRange(hoursMinInput, hoursMaxInput)} — vacatures overlappen met dit
+              bereik.
+            </p>
+          </div>
+
+          <div>
+            <p className="mb-2 block text-sm font-medium text-foreground">Straal (km)</p>
+            <RadiusSliderField
+              provinceAnchor={provinceAnchor}
+              radiusKm={radiusKmInput}
+              onRadiusChange={onRadiusChange}
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="opdrachten-contracttype"
+              className="mb-2 block text-sm font-medium text-foreground"
+            >
+              Contract type
+            </label>
+            <Select
+              value={contractType || "__all__"}
+              onValueChange={(v) => onFilterChange("contractType", v === "__all__" ? "" : v)}
+            >
+              <SelectTrigger
+                id="opdrachten-contracttype"
+                className="data-[size=default]:h-11 w-full rounded-lg border-border bg-background text-left text-sm"
+              >
+                <SelectValue placeholder="Alle types" />
+              </SelectTrigger>
+              <SelectContent className="bg-card border-border">
+                <SelectItem value="__all__" className="text-foreground">
+                  Alle types
+                </SelectItem>
+                {CONTRACT_TYPES.map((type) => (
+                  <SelectItem key={type.value} value={type.value} className="text-foreground">
+                    {type.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <p className="mb-2 block text-sm font-medium text-foreground">Tarief per uur</p>
+            <div className="grid grid-cols-2 gap-2">
+              <Input
+                type="number"
+                inputMode="numeric"
+                placeholder="Min"
+                value={rateMinInput}
+                onChange={(e) => onRateMinChange(e.target.value)}
+                className="h-11 rounded-lg border-border bg-background text-sm"
+              />
+              <Input
+                type="number"
+                inputMode="numeric"
+                placeholder="Max"
+                value={rateMaxInput}
+                onChange={(e) => onRateMaxChange(e.target.value)}
+                className="h-11 rounded-lg border-border bg-background text-sm"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/sidebar/sidebar-filter-controls.tsx
+++ b/components/sidebar/sidebar-filter-controls.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+/**
+ * Reusable filter controls: FilterChecklist, CompactMultiSelectFilter, RadiusSliderField.
+ */
+import { ChevronDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Slider } from "@/components/ui/slider";
+import { cn } from "@/lib/utils";
+import { OPDRACHTEN_RADIUS_OPTIONS } from "@/src/lib/opdrachten-filters";
+import type { FilterOption, ProvinceAnchor } from "./sidebar-types";
+import { DARK_FILTER_SECTION_LABEL_CLASS } from "./sidebar-types";
+import { summarizeSelection } from "./sidebar-utils";
+
+export function FilterChecklist({
+  idPrefix,
+  options,
+  selectedValues,
+  onToggle,
+  className,
+}: {
+  idPrefix: string;
+  options: FilterOption[];
+  selectedValues: string[];
+  onToggle: (value: string) => void;
+  className?: string;
+}) {
+  return (
+    <div className={cn("space-y-1 rounded-lg border border-border bg-background p-2", className)}>
+      {options.map((option) => {
+        const checked = selectedValues.includes(option.value);
+        const checkboxId = `${idPrefix}-${option.value}`;
+
+        return (
+          <label
+            key={option.value}
+            htmlFor={checkboxId}
+            className="flex min-h-11 cursor-pointer items-center gap-3 rounded-md px-2 py-2.5 text-sm hover:bg-accent/50"
+          >
+            <Checkbox
+              id={checkboxId}
+              checked={checked}
+              onCheckedChange={() => onToggle(option.value)}
+            />
+            <span className="min-w-0 wrap-break-word text-foreground">{option.label}</span>
+          </label>
+        );
+      })}
+    </div>
+  );
+}
+
+export function CompactMultiSelectFilter({
+  label,
+  options,
+  selectedValues,
+  onToggle,
+  buttonClassName,
+  contentClassName,
+}: {
+  label: string;
+  options: FilterOption[];
+  selectedValues: string[];
+  onToggle: (value: string) => void;
+  buttonClassName?: string;
+  contentClassName?: string;
+}) {
+  const selectedLabels = options
+    .filter((option) => selectedValues.includes(option.value))
+    .map((option) => option.label);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          className={cn(
+            "h-7 flex-1 justify-between border-border bg-card px-2 text-[10px] text-foreground",
+            buttonClassName,
+          )}
+        >
+          <span className="truncate">{summarizeSelection(label, selectedLabels)}</span>
+          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className={cn("bg-card border-border", contentClassName)}>
+        {options.map((option) => (
+          <DropdownMenuCheckboxItem
+            key={option.value}
+            checked={selectedValues.includes(option.value)}
+            onCheckedChange={() => onToggle(option.value)}
+          >
+            {option.label}
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export function RadiusSliderField({
+  provinceAnchor,
+  radiusKm,
+  onRadiusChange,
+  compact = false,
+}: {
+  provinceAnchor: ProvinceAnchor;
+  radiusKm: string;
+  onRadiusChange: (value: string) => void;
+  compact?: boolean;
+}) {
+  const sliderOptions = [0, ...OPDRACHTEN_RADIUS_OPTIONS];
+  const sliderIndex = radiusKm ? Math.max(0, sliderOptions.indexOf(Number(radiusKm))) : 0;
+
+  return (
+    <div className={compact ? "px-4 pb-4" : undefined}>
+      <div className={cn("mb-2 flex items-center justify-between gap-2", compact && "mb-2")}>
+        <span
+          className={cn(
+            "font-medium text-foreground",
+            compact ? DARK_FILTER_SECTION_LABEL_CLASS : "text-sm",
+          )}
+        >
+          Straal
+        </span>
+        <button
+          type="button"
+          disabled={!radiusKm}
+          onClick={() => onRadiusChange("")}
+          className={cn(
+            "font-medium text-primary disabled:cursor-not-allowed disabled:opacity-50",
+            compact ? "text-sm text-white/55 hover:text-white" : "text-xs",
+          )}
+        >
+          Reset
+        </button>
+      </div>
+
+      <div
+        className={cn(
+          "rounded-lg border border-border bg-background p-3",
+          compact &&
+            "rounded-[24px] border-white/10 bg-white/[0.035] px-4 py-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]",
+        )}
+      >
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <span className={cn("font-medium", compact ? "text-3xl text-white" : "text-sm")}>
+            {radiusKm ? `${radiusKm} km` : "Geen straal"}
+          </span>
+          <span className={cn(compact ? "text-lg text-white/55" : "text-xs text-muted-foreground")}>
+            {provinceAnchor ? provinceAnchor.label : "Eerst provincie"}
+          </span>
+        </div>
+        <Slider
+          min={0}
+          max={sliderOptions.length - 1}
+          step={1}
+          value={[sliderIndex]}
+          disabled={!provinceAnchor}
+          onValueChange={([value]) => {
+            const nextRadius = sliderOptions[value] ?? 0;
+            onRadiusChange(nextRadius > 0 ? String(nextRadius) : "");
+          }}
+        />
+        <div
+          className={cn(
+            "mt-2 flex items-center justify-between text-[10px] text-muted-foreground",
+            compact && "mt-3 text-sm text-white/55",
+          )}
+        >
+          {sliderOptions.map((value) => (
+            <span key={value}>{value === 0 ? "0" : value}</span>
+          ))}
+        </div>
+      </div>
+
+      <p
+        className={cn("mt-2 text-muted-foreground", compact ? "text-sm text-white/45" : "text-xs")}
+      >
+        {provinceAnchor
+          ? `Straal wordt toegepast vanaf ${provinceAnchor.label} (${provinceAnchor.province}).`
+          : "Kies eerst een provincie om straalfiltering te activeren."}
+      </p>
+    </div>
+  );
+}

--- a/components/sidebar/sidebar-job-list.tsx
+++ b/components/sidebar/sidebar-job-list.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+/**
+ * Job list with ScrollArea, supporting both compact (dark) and overview (card) variants.
+ */
+import { JobListItem } from "@/components/job-list-item";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type { SidebarJob } from "./sidebar-types";
+
+interface SidebarJobListProps {
+  jobs: SidebarJob[];
+  activeId: string | null;
+  buildDetailHref: (jobId: string) => string;
+  variant: "compact" | "overview";
+}
+
+export function SidebarJobList({ jobs, activeId, buildDetailHref, variant }: SidebarJobListProps) {
+  if (variant === "compact") {
+    return (
+      <ScrollArea className="min-h-0 flex-1 bg-[#050506]">
+        {jobs.length === 0 ? (
+          <div className="px-4 py-8 text-center text-sm text-white/45">Geen vacatures gevonden</div>
+        ) : (
+          jobs.map((job) => (
+            <JobListItem
+              key={job.id}
+              job={job}
+              isActive={job.id === activeId}
+              hasPipeline={job.hasPipeline}
+              pipelineCount={job.pipelineCount}
+              href={buildDetailHref(job.id)}
+            />
+          ))
+        )}
+      </ScrollArea>
+    );
+  }
+
+  return (
+    <ScrollArea className="min-h-0 min-w-0 flex-1">
+      {jobs.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border bg-background px-5 py-10 text-center text-sm text-muted-foreground">
+          Geen vacatures gevonden voor deze filters.
+        </div>
+      ) : (
+        <div className="space-y-3 pb-4 sm:space-y-4">
+          {jobs.map((job) => (
+            <JobListItem
+              key={job.id}
+              job={job}
+              isActive={job.id === activeId}
+              variant="card"
+              hasPipeline={job.hasPipeline}
+              pipelineCount={job.pipelineCount}
+              href={buildDetailHref(job.id)}
+            />
+          ))}
+        </div>
+      )}
+    </ScrollArea>
+  );
+}

--- a/components/sidebar/sidebar-pagination.tsx
+++ b/components/sidebar/sidebar-pagination.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+/**
+ * Pagination controls for the sidebar, supporting both compact (dark) and overview variants.
+ */
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { PushParamsFn } from "./sidebar-types";
+
+interface SidebarPaginationProps {
+  pageParam: number;
+  totalPages: number;
+  isFetching: boolean;
+  pushParams: PushParamsFn;
+  variant: "compact" | "overview";
+}
+
+export function SidebarPagination({
+  pageParam,
+  totalPages,
+  isFetching,
+  pushParams,
+  variant,
+}: SidebarPaginationProps) {
+  if (totalPages <= 1) return null;
+
+  const goToPrev = () => pushParams({ pagina: String(pageParam - 1) });
+  const goToNext = () => pushParams({ pagina: String(pageParam + 1) });
+
+  if (variant === "compact") {
+    return (
+      <div className="flex shrink-0 items-center justify-between border-t border-white/10 px-4 py-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-10 rounded-[16px] px-4 text-sm text-white/55 hover:bg-white/5 hover:text-white"
+          disabled={pageParam <= 1 || isFetching}
+          onClick={goToPrev}
+        >
+          <ChevronLeft className="h-3.5 w-3.5 mr-1" />
+          Vorige
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-10 rounded-[16px] px-4 text-sm text-white/55 hover:bg-white/5 hover:text-white"
+          disabled={pageParam >= totalPages || isFetching}
+          onClick={goToNext}
+        >
+          Volgende
+          <ChevronRight className="h-3.5 w-3.5 ml-1" />
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-4 flex flex-col gap-2 border-t border-border/70 pt-4 sm:flex-row sm:items-center sm:justify-between">
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-11 w-full border-border bg-background text-foreground sm:h-9 sm:w-auto"
+        disabled={pageParam <= 1 || isFetching}
+        onClick={goToPrev}
+      >
+        <ChevronLeft className="mr-1 h-4 w-4" />
+        Vorige
+      </Button>
+      <p className="text-center text-sm text-muted-foreground">
+        Pagina {pageParam} van {totalPages}
+      </p>
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-11 w-full border-border bg-background text-foreground sm:h-9 sm:w-auto"
+        disabled={pageParam >= totalPages || isFetching}
+        onClick={goToNext}
+      >
+        Volgende
+        <ChevronRight className="ml-1 h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/components/sidebar/sidebar-results-header.tsx
+++ b/components/sidebar/sidebar-results-header.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+/**
+ * Results header showing total count, badges, and page size selector.
+ * Supports both compact (dark) and overview variants.
+ */
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  DEFAULT_OPDRACHTEN_LIMIT,
+  OPDRACHTEN_PAGE_SIZE_OPTIONS,
+} from "@/src/lib/opdrachten-filters";
+import type { PushParamsFn } from "./sidebar-types";
+import { DARK_FILTER_MENU_CLASS } from "./sidebar-types";
+
+interface SidebarResultsHeaderProps {
+  displayTotal: number;
+  shortlistCount: number;
+  urgentDeadlineCount: number;
+  displayPerPage: number;
+  pageParam: number;
+  totalPages: number;
+  pushParams: PushParamsFn;
+  variant: "compact" | "overview";
+}
+
+export function SidebarResultsHeader({
+  displayTotal,
+  shortlistCount,
+  urgentDeadlineCount,
+  displayPerPage,
+  pageParam,
+  totalPages,
+  pushParams,
+  variant,
+}: SidebarResultsHeaderProps) {
+  const handlePageSizeChange = (v: string) => {
+    pushParams({
+      limit: v === String(DEFAULT_OPDRACHTEN_LIMIT) ? "" : v,
+      pagina: "1",
+    });
+  };
+
+  if (variant === "compact") {
+    return (
+      <div className="flex shrink-0 items-center justify-between gap-3 border-y border-white/10 bg-black/30 px-4 py-4">
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-white/55">
+            {displayTotal} vacatures
+          </p>
+          <div className="mt-1 flex flex-wrap gap-1.5">
+            <Badge
+              variant="outline"
+              className="h-7 rounded-full border-white/10 bg-white/[0.035] px-3 text-[11px] text-white/65"
+            >
+              {shortlistCount > 0 ? `${shortlistCount} met shortlist` : "Nog geen shortlist"}
+            </Badge>
+            {urgentDeadlineCount > 0 ? (
+              <Badge
+                variant="outline"
+                className="h-7 rounded-full border-amber-500/20 bg-amber-500/12 px-3 text-[11px] text-amber-200"
+              >
+                {urgentDeadlineCount} deadlines vragen aandacht
+              </Badge>
+            ) : null}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Select value={String(displayPerPage)} onValueChange={handlePageSizeChange}>
+            <SelectTrigger className="h-12 w-[132px] rounded-[18px] border-white/10 bg-white/[0.035] px-4 text-[15px] text-white">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className={DARK_FILTER_MENU_CLASS}>
+              {OPDRACHTEN_PAGE_SIZE_OPTIONS.map((value) => (
+                <SelectItem key={value} value={String(value)} className="text-sm text-white">
+                  {value} / pg
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {totalPages > 1 && (
+            <p className="text-base text-white/55">
+              {pageParam}/{totalPages}
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-w-0 space-y-2">
+      <div className="text-base font-semibold text-foreground sm:text-lg">
+        {displayTotal} vacatures weergegeven
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <Badge
+          variant="outline"
+          className="max-w-full whitespace-normal wrap-break-word text-[11px] text-muted-foreground sm:text-xs"
+        >
+          {shortlistCount > 0 ? `${shortlistCount} met shortlist` : "Nog geen shortlist"}
+        </Badge>
+        {urgentDeadlineCount > 0 ? (
+          <Badge
+            variant="outline"
+            className="max-w-full whitespace-normal wrap-break-word border-amber-500/20 bg-amber-500/10 text-[11px] text-amber-700 dark:text-amber-300 sm:text-xs"
+          >
+            {urgentDeadlineCount} deadlines vragen aandacht
+          </Badge>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/components/sidebar/sidebar-search-bar.tsx
+++ b/components/sidebar/sidebar-search-bar.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+/**
+ * Search input bar for the sidebar, supporting both compact (dark) and overview variants.
+ */
+import { Loader2, Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { DARK_FILTER_CONTROL_CLASS } from "./sidebar-types";
+
+interface SidebarSearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
+  isFetching: boolean;
+  variant: "compact" | "overview";
+}
+
+export function SidebarSearchBar({ value, onChange, isFetching, variant }: SidebarSearchBarProps) {
+  if (variant === "compact") {
+    return (
+      <div className="shrink-0 px-4 pb-4 pt-5">
+        <div className="relative">
+          <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-white/40" />
+          <Input
+            placeholder="Zoek vacatures..."
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            className={cn("h-14 rounded-[24px] pl-12 pr-11 text-[17px]", DARK_FILTER_CONTROL_CLASS)}
+          />
+          {isFetching && (
+            <Loader2 className="absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-white/45" />
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <label
+        htmlFor="opdrachten-zoekterm"
+        className="mb-2 block text-sm font-medium text-foreground"
+      >
+        Zoekterm
+      </label>
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          id="opdrachten-zoekterm"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="Zoek vacature..."
+          className="h-11 rounded-lg border-border bg-background pl-10 text-sm"
+        />
+        {isFetching && (
+          <Loader2 className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground" />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/sidebar/sidebar-sort-controls.tsx
+++ b/components/sidebar/sidebar-sort-controls.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+/**
+ * Sort dropdown for the sidebar, supporting both compact (dark) and overview variants.
+ */
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import type { OPDRACHTEN_SORT_OPTIONS } from "@/src/lib/opdrachten-filters";
+import { DARK_FILTER_MENU_CLASS, DARK_FILTER_TRIGGER_CLASS } from "./sidebar-types";
+
+interface SidebarSortControlsProps {
+  sort: string;
+  sortOptions: typeof OPDRACHTEN_SORT_OPTIONS;
+  onSortChange: (value: string) => void;
+  variant: "compact" | "overview";
+}
+
+export function SidebarSortControls({
+  sort,
+  sortOptions,
+  onSortChange,
+  variant,
+}: SidebarSortControlsProps) {
+  const handleChange = (value: string) => {
+    onSortChange(value === "nieuwste" ? "" : value);
+  };
+
+  if (variant === "compact") {
+    return (
+      <div className="shrink-0 px-4 pb-4">
+        <Select value={sort} onValueChange={handleChange}>
+          <SelectTrigger className={cn("w-full", DARK_FILTER_TRIGGER_CLASS)}>
+            <SelectValue placeholder="Sortering" />
+          </SelectTrigger>
+          <SelectContent className={DARK_FILTER_MENU_CLASS}>
+            {sortOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value} className="text-sm text-white">
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid w-full grid-cols-[auto_minmax(0,1fr)] items-center gap-2 sm:flex sm:w-auto sm:items-center">
+      <span className="text-xs text-muted-foreground sm:text-sm">Sorteren:</span>
+      <Select value={sort} onValueChange={handleChange}>
+        <SelectTrigger className="data-[size=default]:h-11 w-full rounded-lg border-primary/40 bg-background text-sm font-semibold text-primary sm:w-[210px] sm:rounded-full sm:data-[size=default]:h-10">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent className="bg-card border-border">
+          {sortOptions.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/components/sidebar/sidebar-types.ts
+++ b/components/sidebar/sidebar-types.ts
@@ -1,0 +1,117 @@
+/**
+ * Shared types and constants for the opdrachten sidebar components.
+ */
+import type { useRouter } from "next/navigation";
+import type { getProvinceAnchor } from "@/src/lib/opdrachten-filters";
+
+export interface SidebarJob {
+  id: string;
+  title: string;
+  company: string | null;
+  location: string | null;
+  platform: string;
+  workArrangement: string | null;
+  contractType: string | null;
+  applicationDeadline?: Date | string | null;
+  pipelineCount?: number;
+  hasPipeline?: boolean;
+}
+
+export interface SearchResponse {
+  jobs: SidebarJob[];
+  total: number;
+  page: number;
+  perPage: number;
+  totalPages: number;
+}
+
+export type SearchResponsePayload = {
+  jobs?: unknown;
+  total?: unknown;
+  page?: unknown;
+  perPage?: unknown;
+  totalPages?: unknown;
+};
+
+export interface OpdrachtenSidebarProps {
+  jobs: SidebarJob[];
+  totalCount: number;
+  platforms: string[];
+  endClients: string[];
+  categories: string[];
+  skillOptions: FilterOption[];
+  skillEmptyText?: string;
+}
+
+export type SearchQueryKeyPayload = {
+  q: string;
+  platform: string;
+  endClient: string;
+  vaardigheid: string;
+  status: string;
+  provincie: string;
+  regios: string[];
+  vakgebieden: string[];
+  urenPerWeek: string;
+  urenPerWeekMin: string;
+  urenPerWeekMax: string;
+  straalKm: string;
+  contractType: string;
+  tariefMin: string;
+  tariefMax: string;
+  sort: string;
+  page: number;
+  limit: number;
+};
+
+export type FilterOption = {
+  value: string;
+  label: string;
+};
+
+export type FilterOverrideValue = string | string[];
+
+export const CONTRACT_TYPES = [
+  { value: "freelance", label: "Freelance" },
+  { value: "interim", label: "Interim" },
+  { value: "vast", label: "Vast" },
+  { value: "opdracht", label: "Opdracht" },
+];
+
+export const DARK_FILTER_PANEL_CLASS =
+  "rounded-[24px] border border-white/10 bg-white/[0.035] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] backdrop-blur";
+export const DARK_FILTER_CONTROL_CLASS =
+  "h-12 rounded-[20px] border-white/10 bg-white/[0.035] px-4 text-[15px] font-normal text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] placeholder:text-white/35 focus-visible:ring-1 focus-visible:ring-white/20 focus-visible:ring-offset-0";
+export const DARK_FILTER_TRIGGER_CLASS =
+  "h-12 rounded-[20px] border-white/10 bg-white/[0.035] px-4 text-left text-[15px] font-normal text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] data-[placeholder]:text-white/35";
+export const DARK_FILTER_MENU_CLASS = "border-white/10 bg-[#101113] text-white";
+export const DARK_FILTER_SECTION_LABEL_CLASS =
+  "text-[11px] font-semibold uppercase tracking-[0.22em] text-white/45";
+export const DARK_FILTER_SECTION_VALUE_CLASS = "text-sm text-white/55";
+
+export type SearchJobsParams = {
+  q: string;
+  platform: string;
+  endClient: string;
+  vaardigheid: string;
+  status: string;
+  provincie: string;
+  regios: string[];
+  vakgebieden: string[];
+  urenPerWeek: string;
+  urenPerWeekMin: string;
+  urenPerWeekMax: string;
+  straalKm: string;
+  contractType: string;
+  tariefMin: string;
+  tariefMax: string;
+  sort: string;
+  page: number;
+  limit: number;
+};
+
+export type ProvinceAnchor = ReturnType<typeof getProvinceAnchor>;
+
+export type PushParamsFn = (overrides: Record<string, FilterOverrideValue>) => void;
+
+export type RouterInstance = ReturnType<typeof useRouter>;

--- a/components/sidebar/sidebar-utils.ts
+++ b/components/sidebar/sidebar-utils.ts
@@ -1,0 +1,161 @@
+/**
+ * Utility functions for the opdrachten sidebar.
+ */
+import type { useRouter } from "next/navigation";
+import { buildOpdrachtenFilterHref } from "@/src/lib/opdrachten-filter-url";
+import { DEFAULT_OPDRACHTEN_LIMIT } from "@/src/lib/opdrachten-filters";
+import type {
+  FilterOverrideValue,
+  SearchJobsParams,
+  SearchResponse,
+  SearchResponsePayload,
+  SidebarJob,
+} from "./sidebar-types";
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+export function hasUrgentDeadline(deadline?: Date | string | null) {
+  if (!deadline) return false;
+
+  const parsedDeadline = new Date(deadline);
+  if (Number.isNaN(parsedDeadline.getTime())) return false;
+
+  const remainingDays = Math.ceil((parsedDeadline.getTime() - Date.now()) / DAY_IN_MS);
+  return remainingDays >= 0 && remainingDays <= 3;
+}
+
+export function pushOpdrachtenParams(
+  searchParams: URLSearchParams,
+  router: ReturnType<typeof useRouter>,
+  pathname: string,
+  overrides: Record<string, FilterOverrideValue>,
+) {
+  router.push(buildOpdrachtenFilterHref(pathname, searchParams, overrides));
+}
+
+export function toggleFilterValue(values: string[], nextValue: string) {
+  return values.includes(nextValue)
+    ? values.filter((value) => value !== nextValue)
+    : [...values, nextValue];
+}
+
+export function summarizeSelection(label: string, selectedLabels: string[]) {
+  if (selectedLabels.length === 0) return label;
+  if (selectedLabels.length === 1) return selectedLabels[0] ?? label;
+  return `${label} (${selectedLabels.length})`;
+}
+
+export function summarizeHoursRange(minValue: string, maxValue: string) {
+  if (!minValue && !maxValue) return "Alle uren";
+  return `${minValue || "0"} - ${maxValue || "onbeperkt"} uur`;
+}
+
+function isSidebarJob(value: unknown): value is SidebarJob {
+  if (!value || typeof value !== "object") return false;
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.title === "string" &&
+    typeof candidate.platform === "string"
+  );
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+export function parseSearchResponse(payload: SearchResponsePayload): SearchResponse {
+  if (
+    !Array.isArray(payload.jobs) ||
+    !payload.jobs.every(isSidebarJob) ||
+    !isFiniteNumber(payload.total) ||
+    !isFiniteNumber(payload.page) ||
+    !isFiniteNumber(payload.perPage) ||
+    !isFiniteNumber(payload.totalPages)
+  ) {
+    throw new Error("Ongeldig zoekresultaat ontvangen.");
+  }
+
+  const jobs = payload.jobs as SidebarJob[];
+  const total = payload.total as number;
+  const page = payload.page as number;
+  const perPage = payload.perPage as number;
+  const totalPages = payload.totalPages as number;
+
+  return {
+    jobs,
+    total,
+    page,
+    perPage,
+    totalPages,
+  };
+}
+
+async function getSearchErrorMessage(response: Response) {
+  try {
+    const payload = (await response.json()) as { error?: string };
+    if (typeof payload.error === "string" && payload.error.trim()) {
+      return payload.error.trim();
+    }
+  } catch {
+    // Ignore non-JSON or malformed error payloads and fall back to the status-based message below.
+  }
+
+  return `Zoeken mislukt (${response.status}).`;
+}
+
+export async function searchJobs({
+  q,
+  platform,
+  endClient,
+  vaardigheid,
+  status,
+  provincie,
+  regios,
+  vakgebieden,
+  urenPerWeek,
+  urenPerWeekMin,
+  urenPerWeekMax,
+  straalKm,
+  contractType,
+  tariefMin,
+  tariefMax,
+  sort,
+  page,
+  limit,
+  signal,
+}: SearchJobsParams & { signal?: AbortSignal }): Promise<SearchResponse> {
+  const params = new URLSearchParams();
+  if (q) params.set("q", q);
+  if (platform) params.set("platform", platform);
+  if (endClient) params.set("endClient", endClient);
+  if (vaardigheid) params.set("vaardigheid", vaardigheid);
+  if (status !== "open") params.set("status", status);
+  if (provincie) params.set("provincie", provincie);
+  regios.forEach((regio) => {
+    params.append("regio", regio);
+  });
+  vakgebieden.forEach((vakgebied) => {
+    params.append("vakgebied", vakgebied);
+  });
+  if (urenPerWeek) params.set("urenPerWeek", urenPerWeek);
+  if (urenPerWeekMin) params.set("urenPerWeekMin", urenPerWeekMin);
+  if (urenPerWeekMax) params.set("urenPerWeekMax", urenPerWeekMax);
+  if (straalKm) params.set("straalKm", straalKm);
+  if (contractType) params.set("contractType", contractType);
+  if (tariefMin) params.set("tariefMin", tariefMin);
+  if (tariefMax) params.set("tariefMax", tariefMax);
+  if (sort && sort !== "nieuwste") params.set("sort", sort);
+  if (page > 1) params.set("pagina", String(page));
+  if (limit !== DEFAULT_OPDRACHTEN_LIMIT) params.set("limit", String(limit));
+
+  const res = await fetch(`/api/vacatures/zoeken?${params.toString()}`, {
+    signal,
+  });
+  if (!res.ok) {
+    throw new Error(await getSearchErrorMessage(res));
+  }
+
+  return parseSearchResponse((await res.json()) as SearchResponsePayload);
+}

--- a/components/sidebar/use-sidebar-filters.ts
+++ b/components/sidebar/use-sidebar-filters.ts
@@ -1,0 +1,472 @@
+"use client";
+
+/**
+ * Custom hook encapsulating all filter state, URL sync, and search query logic
+ * for the opdrachten sidebar.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { getOpdrachtenBasePath } from "@/src/lib/opdrachten-filter-url";
+import {
+  DEFAULT_OPDRACHTEN_LIMIT,
+  getHoursRangeForBucket,
+  getProvinceAnchor,
+  MAX_OPDRACHTEN_LIMIT,
+  OPDRACHTEN_REGION_OPTIONS,
+  OPDRACHTEN_SORT_OPTIONS,
+  parseOpdrachtenFilters,
+} from "@/src/lib/opdrachten-filters";
+import type {
+  FilterOption,
+  FilterOverrideValue,
+  SearchQueryKeyPayload,
+  SidebarJob,
+} from "./sidebar-types";
+import {
+  hasUrgentDeadline,
+  pushOpdrachtenParams,
+  searchJobs,
+  toggleFilterValue,
+} from "./sidebar-utils";
+
+function useDebouncedValue<T>(value: T, delayMs = 300): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delayMs);
+
+    return () => clearTimeout(timeout);
+  }, [value, delayMs]);
+
+  return debouncedValue;
+}
+
+export function useSidebarFilters({
+  initialJobs,
+  initialTotal,
+  categories,
+}: {
+  initialJobs: SidebarJob[];
+  initialTotal: number;
+  categories: string[];
+}) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const isOverviewPage = pathname === "/vacatures";
+  const match = pathname.match(/^\/(?:vacatures|opdrachten)\/(.+)$/);
+  const activeId = match?.[1] ?? null;
+
+  // URL as source of truth for TanStack Query
+  const parsedFilters = parseOpdrachtenFilters(new URLSearchParams(searchParams.toString()));
+  const q = parsedFilters.q ?? "";
+  const platform = parsedFilters.platform ?? "";
+  const endClient = parsedFilters.endClient ?? "";
+  const vaardigheid = parsedFilters.escoUri ?? "";
+  const status = parsedFilters.status;
+  const provincie = parsedFilters.province ?? "";
+  const regios = parsedFilters.regions;
+  const vakgebieden = parsedFilters.categories;
+  const urenPerWeek = parsedFilters.hoursPerWeek ?? "";
+  const urenRangeFromBucket = parsedFilters.hoursPerWeek
+    ? getHoursRangeForBucket(parsedFilters.hoursPerWeek)
+    : undefined;
+  const urenPerWeekMin =
+    parsedFilters.hoursPerWeekMin != null
+      ? String(parsedFilters.hoursPerWeekMin)
+      : urenRangeFromBucket?.min != null
+        ? String(urenRangeFromBucket.min)
+        : "";
+  const urenPerWeekMax =
+    parsedFilters.hoursPerWeekMax != null
+      ? String(parsedFilters.hoursPerWeekMax)
+      : urenRangeFromBucket?.max != null
+        ? String(urenRangeFromBucket.max)
+        : "";
+  const straalKm = parsedFilters.radiusKm ? String(parsedFilters.radiusKm) : "";
+  const contractType = parsedFilters.contractType ?? "";
+  const hasSearchQuery = q.length > 0;
+  const sortOptions = hasSearchQuery
+    ? OPDRACHTEN_SORT_OPTIONS
+    : OPDRACHTEN_SORT_OPTIONS.filter((option) => option.value !== "relevantie");
+  const sort =
+    !hasSearchQuery && parsedFilters.sort === "relevantie" ? "nieuwste" : parsedFilters.sort;
+  const tariefMinParamFromUrl = parsedFilters.rateMin != null ? String(parsedFilters.rateMin) : "";
+  const tariefMaxParamFromUrl = parsedFilters.rateMax != null ? String(parsedFilters.rateMax) : "";
+  const pageParam =
+    Math.max(
+      1,
+      Number.parseInt(searchParams.get("pagina") ?? searchParams.get("page") ?? "1", 10),
+    ) || 1;
+  const limitParam =
+    Math.min(
+      MAX_OPDRACHTEN_LIMIT,
+      Math.max(
+        1,
+        Number.parseInt(
+          searchParams.get("limit") ??
+            searchParams.get("perPage") ??
+            String(DEFAULT_OPDRACHTEN_LIMIT),
+          10,
+        ),
+      ),
+    ) || DEFAULT_OPDRACHTEN_LIMIT;
+
+  const [inputValue, setInputValue] = useState(q);
+  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
+  const [hoursMinInput, setHoursMinInput] = useState(urenPerWeekMin);
+  const [hoursMaxInput, setHoursMaxInput] = useState(urenPerWeekMax);
+  const [radiusKmInput, setRadiusKmInput] = useState(straalKm);
+  const [rateMinInput, setRateMinInput] = useState(tariefMinParamFromUrl);
+  const [rateMaxInput, setRateMaxInput] = useState(tariefMaxParamFromUrl);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const provinceAnchor = getProvinceAnchor(provincie);
+  const regionOptions = useMemo<FilterOption[]>(
+    () =>
+      OPDRACHTEN_REGION_OPTIONS.map((option) => ({
+        value: option.value,
+        label: option.label,
+      })),
+    [],
+  );
+  const categoryOptions = useMemo<FilterOption[]>(
+    () =>
+      categories.map((category) => ({
+        value: category,
+        label: category,
+      })),
+    [categories],
+  );
+
+  useEffect(() => {
+    setInputValue(q);
+  }, [q]);
+  useEffect(() => {
+    setHoursMinInput(urenPerWeekMin);
+    setHoursMaxInput(urenPerWeekMax);
+    setRadiusKmInput(straalKm);
+    setRateMinInput(tariefMinParamFromUrl);
+    setRateMaxInput(tariefMaxParamFromUrl);
+  }, [urenPerWeekMin, urenPerWeekMax, straalKm, tariefMinParamFromUrl, tariefMaxParamFromUrl]);
+
+  const debouncedHoursMin = useDebouncedValue(hoursMinInput);
+  const debouncedHoursMax = useDebouncedValue(hoursMaxInput);
+  const debouncedRadiusKm = useDebouncedValue(radiusKmInput);
+  const debouncedRateMin = useDebouncedValue(rateMinInput);
+  const debouncedRateMax = useDebouncedValue(rateMaxInput);
+  const debouncedHoursHasManualInput = useMemo(
+    () => debouncedHoursMin !== urenPerWeekMin || debouncedHoursMax !== urenPerWeekMax,
+    [debouncedHoursMin, debouncedHoursMax, urenPerWeekMin, urenPerWeekMax],
+  );
+  const effectiveHoursPerWeekBucket = debouncedHoursHasManualInput ? "" : urenPerWeek;
+  const sortedRegios = useMemo(() => [...regios].sort((a, b) => a.localeCompare(b)), [regios]);
+  const sortedVakgebieden = useMemo(
+    () => [...vakgebieden].sort((a, b) => a.localeCompare(b)),
+    [vakgebieden],
+  );
+
+  const searchQueryKey = useMemo<SearchQueryKeyPayload>(
+    () => ({
+      q,
+      platform,
+      endClient,
+      vaardigheid,
+      status,
+      provincie,
+      regios: sortedRegios,
+      vakgebieden: sortedVakgebieden,
+      urenPerWeek: effectiveHoursPerWeekBucket,
+      urenPerWeekMin: debouncedHoursMin,
+      urenPerWeekMax: debouncedHoursMax,
+      straalKm: debouncedRadiusKm,
+      contractType,
+      tariefMin: debouncedRateMin,
+      tariefMax: debouncedRateMax,
+      sort,
+      page: pageParam,
+      limit: limitParam,
+    }),
+    [
+      q,
+      platform,
+      endClient,
+      vaardigheid,
+      status,
+      provincie,
+      sortedRegios,
+      sortedVakgebieden,
+      effectiveHoursPerWeekBucket,
+      debouncedHoursMin,
+      debouncedHoursMax,
+      debouncedRadiusKm,
+      contractType,
+      debouncedRateMin,
+      debouncedRateMax,
+      sort,
+      pageParam,
+      limitParam,
+    ],
+  );
+
+  useEffect(() => {
+    const shouldPushHours = debouncedHoursHasManualInput;
+    const shouldPushRadius = debouncedRadiusKm !== straalKm;
+    const shouldPushRateMin = debouncedRateMin !== tariefMinParamFromUrl;
+    const shouldPushRateMax = debouncedRateMax !== tariefMaxParamFromUrl;
+
+    if (!shouldPushHours && !shouldPushRadius && !shouldPushRateMin && !shouldPushRateMax) return;
+
+    pushOpdrachtenParams(searchParams, router, pathname, {
+      urenPerWeek: shouldPushHours ? "" : urenPerWeek,
+      urenPerWeekMin: debouncedHoursMin,
+      urenPerWeekMax: debouncedHoursMax,
+      straalKm: debouncedRadiusKm,
+      tariefMin: debouncedRateMin,
+      tariefMax: debouncedRateMax,
+      pagina: "1",
+    });
+  }, [
+    debouncedHoursHasManualInput,
+    debouncedHoursMin,
+    debouncedHoursMax,
+    debouncedRadiusKm,
+    debouncedRateMin,
+    debouncedRateMax,
+    straalKm,
+    tariefMinParamFromUrl,
+    tariefMaxParamFromUrl,
+    urenPerWeek,
+    router,
+    pathname,
+    searchParams,
+  ]);
+
+  // Debounce search input
+  useEffect(() => {
+    if (inputValue === q) {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+      return;
+    }
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      pushOpdrachtenParams(searchParams, router, pathname, { q: inputValue, pagina: "1" });
+      debounceRef.current = null;
+    }, 300);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [inputValue, pathname, q, searchParams, router]);
+
+  const { data, error, isFetching } = useQuery({
+    queryKey: ["opdrachten-search", searchQueryKey],
+    queryFn: ({ signal }) =>
+      searchJobs({
+        q,
+        platform,
+        endClient,
+        vaardigheid,
+        status,
+        provincie,
+        regios: sortedRegios,
+        vakgebieden: sortedVakgebieden,
+        urenPerWeek: effectiveHoursPerWeekBucket,
+        urenPerWeekMin: debouncedHoursMin,
+        urenPerWeekMax: debouncedHoursMax,
+        straalKm: debouncedRadiusKm,
+        contractType,
+        tariefMin: debouncedRateMin,
+        tariefMax: debouncedRateMax,
+        sort,
+        page: pageParam,
+        limit: limitParam,
+        signal,
+      }),
+    staleTime: 30_000,
+    placeholderData: (prev) => prev,
+    initialData:
+      pageParam === 1 &&
+      limitParam === DEFAULT_OPDRACHTEN_LIMIT &&
+      !q &&
+      !platform &&
+      !endClient &&
+      !vaardigheid &&
+      status === "open" &&
+      !provincie &&
+      regios.length === 0 &&
+      vakgebieden.length === 0 &&
+      !debouncedHoursMin &&
+      !debouncedHoursMax &&
+      !debouncedRadiusKm &&
+      !contractType &&
+      !debouncedRateMin &&
+      !debouncedRateMax &&
+      sort === "nieuwste"
+        ? {
+            jobs: initialJobs,
+            total: initialTotal,
+            page: 1,
+            perPage: DEFAULT_OPDRACHTEN_LIMIT,
+            totalPages: Math.ceil(initialTotal / DEFAULT_OPDRACHTEN_LIMIT),
+          }
+        : undefined,
+  });
+
+  const displayJobs = data?.jobs ?? initialJobs;
+  const displayTotal = data?.total ?? initialTotal;
+  const displayPerPage = data?.perPage ?? limitParam;
+  const totalPages = data?.totalPages ?? 1;
+  const searchErrorMessage = error instanceof Error ? error.message : null;
+  const detailQuery = searchParams.toString();
+  const shortlistCount = displayJobs.filter((job) => (job.pipelineCount ?? 0) > 0).length;
+  const urgentDeadlineCount = displayJobs.filter((job) =>
+    hasUrgentDeadline(job.applicationDeadline),
+  ).length;
+  const activeFilterCount =
+    Number(Boolean(platform)) +
+    Number(Boolean(endClient)) +
+    Number(Boolean(vaardigheid)) +
+    Number(status !== "open") +
+    Number(Boolean(provincie)) +
+    Number(regios.length > 0) +
+    Number(vakgebieden.length > 0) +
+    Number(Boolean(urenPerWeek)) +
+    Number(Boolean(hoursMinInput || hoursMaxInput)) +
+    Number(Boolean(radiusKmInput)) +
+    Number(Boolean(contractType)) +
+    Number(Boolean(rateMinInput || rateMaxInput)) +
+    Number(sort !== "nieuwste");
+
+  const buildDetailHref = useCallback(
+    (jobId: string) => {
+      const base = "/vacatures";
+      return detailQuery ? `${base}/${jobId}?${detailQuery}` : `${base}/${jobId}`;
+    },
+    [detailQuery],
+  );
+
+  const pushParams = useCallback(
+    (overrides: Record<string, FilterOverrideValue>) => {
+      pushOpdrachtenParams(searchParams, router, pathname, overrides);
+    },
+    [searchParams, router, pathname],
+  );
+
+  const handleFilterChange = useCallback(
+    (paramKey: string, value: string) => {
+      pushParams({ [paramKey]: value, pagina: "1" });
+    },
+    [pushParams],
+  );
+
+  const handleToggleRegio = useCallback(
+    (value: string) => {
+      pushParams({ regio: toggleFilterValue(regios, value), pagina: "1" });
+    },
+    [pushParams, regios],
+  );
+
+  const handleToggleVakgebied = useCallback(
+    (value: string) => {
+      pushParams({ vakgebied: toggleFilterValue(vakgebieden, value), pagina: "1" });
+    },
+    [pushParams, vakgebieden],
+  );
+
+  const handleHoursRangeChange = useCallback(
+    (field: "urenPerWeekMin" | "urenPerWeekMax", value: string) => {
+      if (field === "urenPerWeekMin") {
+        setHoursMinInput(value);
+      } else {
+        setHoursMaxInput(value);
+      }
+    },
+    [],
+  );
+
+  const handleRadiusChange = useCallback((value: string) => {
+    setRadiusKmInput(value);
+  }, []);
+
+  const handleProvinceChange = useCallback(
+    (value: string) => {
+      const nextProvince = value === "__all__" ? "" : value;
+      if (!nextProvince) {
+        setRadiusKmInput("");
+      }
+      pushParams(
+        nextProvince
+          ? { provincie: nextProvince, pagina: "1" }
+          : { provincie: "", straalKm: "", pagina: "1" },
+      );
+    },
+    [pushParams],
+  );
+
+  const resetFilters = useCallback(() => {
+    router.push(getOpdrachtenBasePath(pathname));
+  }, [router, pathname]);
+
+  return {
+    // Routing state
+    isOverviewPage,
+    activeId,
+
+    // Filter values
+    platform,
+    endClient,
+    vaardigheid,
+    status,
+    provincie,
+    regios,
+    vakgebieden,
+    contractType,
+    sort,
+    sortOptions,
+    provinceAnchor,
+    regionOptions,
+    categoryOptions,
+
+    // Input state
+    inputValue,
+    setInputValue,
+    hoursMinInput,
+    hoursMaxInput,
+    radiusKmInput,
+    setRadiusKmInput,
+    rateMinInput,
+    setRateMinInput,
+    rateMaxInput,
+    setRateMaxInput,
+    mobileFiltersOpen,
+    setMobileFiltersOpen,
+
+    // Display data
+    displayJobs,
+    displayTotal,
+    displayPerPage,
+    totalPages,
+    pageParam,
+    searchErrorMessage,
+    isFetching,
+    shortlistCount,
+    urgentDeadlineCount,
+    activeFilterCount,
+
+    // Actions
+    buildDetailHref,
+    pushParams,
+    handleFilterChange,
+    handleToggleRegio,
+    handleToggleVakgebied,
+    handleHoursRangeChange,
+    handleRadiusChange,
+    handleProvinceChange,
+    resetFilters,
+  };
+}

--- a/tests/opdrachten-filters-pagination.test.ts
+++ b/tests/opdrachten-filters-pagination.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -21,6 +21,16 @@ import { parsePagination } from "../src/lib/pagination";
 
 function readFile(...segments: string[]) {
   return readFileSync(path.join(process.cwd(), ...segments), "utf8");
+}
+
+/** Read opdrachten-sidebar.tsx + all components/sidebar/* files as one combined string. */
+function readSidebarBundle() {
+  const main = readFile("components", "opdrachten-sidebar.tsx");
+  const sidebarDir = path.join(process.cwd(), "components", "sidebar");
+  const subFiles = readdirSync(sidebarDir)
+    .filter((f) => f.endsWith(".ts") || f.endsWith(".tsx"))
+    .map((f) => readFileSync(path.join(sidebarDir, f), "utf8"));
+  return [main, ...subFiles].join("\n");
 }
 
 describe("Opdrachten pagination aliases", () => {
@@ -202,7 +212,7 @@ describe("Opdrachten filter URL helpers", () => {
 
 describe("Opdrachten UI/API contracts", () => {
   it("sidebar exposes enhanced recruiter filters and URL-backed sorting", () => {
-    const source = readFile("components", "opdrachten-sidebar.tsx");
+    const source = readSidebarBundle();
     const normalizedSource = source.replace(/\s+/g, " ");
     const filtersSource = readFile("src", "lib", "opdrachten-filters.ts");
     const filterUrlSource = readFile("src", "lib", "opdrachten-filter-url.ts");
@@ -223,7 +233,7 @@ describe("Opdrachten UI/API contracts", () => {
     expect(source).toContain("RadiusSliderField");
     expect(source).toContain("<Slider");
     expect(source).toContain("<Checkbox");
-    expect(source).toContain('handleFilterChange("status"');
+    expect(source).toContain('FilterChange("status"');
     expect(source).toContain('value="archived"');
     expect(source).toContain("Gearchiveerd");
     expect(source).toContain("handleToggleRegio");
@@ -317,13 +327,13 @@ describe("Opdrachten UI/API contracts", () => {
 
   it("detail routes preserve sidebar context and query-aware vacature links", () => {
     const shell = readFile("components", "opdrachten-layout-shell.tsx");
-    const sidebar = readFile("components", "opdrachten-sidebar.tsx");
+    const sidebar = readSidebarBundle();
     const listItem = readFile("components", "job-list-item.tsx");
 
     expect(shell).toContain('pathname.startsWith("/opdrachten/")');
     expect(shell).toContain("w-full md:w-[380px]");
     expect(shell).toContain("hidden md:flex");
-    expect(sidebar).toContain("const buildDetailHref = (jobId: string)");
+    expect(sidebar).toContain("buildDetailHref");
     expect(sidebar).toContain("href={buildDetailHref(job.id)}");
     expect(sidebar).toContain("getOpdrachtenBasePath(pathname)");
     expect(sidebar).toContain("deadlines vragen aandacht");
@@ -334,7 +344,7 @@ describe("Opdrachten UI/API contracts", () => {
   });
 
   it("overview results controls and cards reflow cleanly on narrow widths", () => {
-    const sidebar = readFile("components", "opdrachten-sidebar.tsx");
+    const sidebar = readSidebarBundle();
     const listItem = readFile("components", "job-list-item.tsx");
 
     expect(sidebar).toContain("grid-cols-[auto_minmax(0,1fr)]");
@@ -362,7 +372,7 @@ describe("Opdrachten UI/API contracts", () => {
   });
 
   it("uses the dark card-based filter panel as the primary sidebar UI", () => {
-    const sidebar = readFile("components", "opdrachten-sidebar.tsx");
+    const sidebar = readSidebarBundle();
     const normalizedSidebar = sidebar.replace(/\s+/g, " ");
 
     expect(normalizedSidebar).toContain(
@@ -378,7 +388,7 @@ describe("Opdrachten UI/API contracts", () => {
   });
 
   it("keeps mobile filters inside a bounded flex/min-h-0 scroll container", () => {
-    const sidebar = readFile("components", "opdrachten-sidebar.tsx");
+    const sidebar = readSidebarBundle();
     const normalizedSidebar = sidebar.replace(/\s+/g, " ");
 
     expect(normalizedSidebar).toContain(

--- a/tests/sidebar-decomposition.test.ts
+++ b/tests/sidebar-decomposition.test.ts
@@ -1,0 +1,56 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = join(import.meta.dirname, "..");
+const SIDEBAR_DIR = join(ROOT, "components", "sidebar");
+const CONTAINER_FILE = join(ROOT, "components", "opdrachten-sidebar.tsx");
+
+describe("Sidebar decomposition", () => {
+  it("components/sidebar/ directory exists", () => {
+    expect(existsSync(SIDEBAR_DIR)).toBe(true);
+  });
+
+  const expectedFiles = [
+    "sidebar-types.ts",
+    "sidebar-utils.ts",
+    "sidebar-search-bar.tsx",
+    "sidebar-sort-controls.tsx",
+    "sidebar-filter-controls.tsx",
+    "sidebar-job-list.tsx",
+    "sidebar-pagination.tsx",
+    "sidebar-results-header.tsx",
+    "compact-sidebar-filters.tsx",
+    "overview-filter-panel.tsx",
+    "use-sidebar-filters.ts",
+  ];
+
+  for (const file of expectedFiles) {
+    it(`sidebar/${file} exists`, () => {
+      expect(existsSync(join(SIDEBAR_DIR, file))).toBe(true);
+    });
+  }
+
+  it("opdrachten-sidebar.tsx imports from sidebar/ sub-components", () => {
+    const content = readFileSync(CONTAINER_FILE, "utf8");
+    const sidebarImports = content
+      .split("\n")
+      .filter((line) => /from\s+["']\.\/sidebar\//.test(line));
+    // Should import at least 5 sub-components
+    expect(sidebarImports.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("opdrachten-sidebar.tsx is under 300 lines", () => {
+    const lineCount = readFileSync(CONTAINER_FILE, "utf8").split("\n").length;
+    expect(lineCount).toBeLessThanOrEqual(300);
+  });
+
+  it("no sidebar/ file exceeds 500 lines", () => {
+    const files = readdirSync(SIDEBAR_DIR);
+    for (const file of files) {
+      const filePath = join(SIDEBAR_DIR, file);
+      const lineCount = readFileSync(filePath, "utf8").split("\n").length;
+      expect(lineCount, `${file} has ${lineCount} lines`).toBeLessThanOrEqual(500);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Decompose the 1614-line `components/opdrachten-sidebar.tsx` into 11 focused modules under `components/sidebar/`
- Container component is now 268 lines (orchestration only), down from 1614
- All sub-components are under 500 lines; no behavioral changes (pure refactor)
- Extracts shared types, utility functions, and a `useSidebarFilters` custom hook for state management

## Files created
| File | Lines | Purpose |
|------|-------|---------|
| `sidebar-types.ts` | 117 | Shared types, interfaces, style constants |
| `sidebar-utils.ts` | 161 | Search API, URL helpers, parse functions |
| `use-sidebar-filters.ts` | 470 | Custom hook: all filter state + query logic |
| `sidebar-search-bar.tsx` | 64 | Search input (compact + overview variants) |
| `sidebar-filter-controls.tsx` | 195 | FilterChecklist, CompactMultiSelectFilter, RadiusSliderField |
| `sidebar-sort-controls.tsx` | 70 | Sort dropdown |
| `sidebar-results-header.tsx` | 120 | Results count, badges, page size |
| `sidebar-pagination.tsx` | 84 | Pagination controls |
| `sidebar-job-list.tsx` | 69 | Job list with ScrollArea |
| `compact-sidebar-filters.tsx` | 248 | Compact dark filter grid |
| `overview-filter-panel.tsx` | 412 | Full overview filter panel |

## Test plan
- [x] All 1183 existing tests pass (154 test files)
- [x] New `tests/sidebar-decomposition.test.ts` validates file structure and line counts
- [x] Updated `tests/opdrachten-filters-pagination.test.ts` to read from sidebar bundle
- [x] Biome lint passes with zero errors on all changed files
- [x] `hover:bg-white/[0.05]` converted to canonical `hover:bg-white/5`

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
