### PR TITLE
feat: make vacatures search feel instant

### DIFF
--- a/components/sidebar/use-sidebar-filters.ts
+++ b/components/sidebar/use-sidebar-filters.ts
@@ -6,13 +6,14 @@
  */
 import { useQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { getOpdrachtenBasePath } from "@/src/lib/opdrachten-filter-url";
 import {
   DEFAULT_OPDRACHTEN_LIMIT,
   getHoursRangeForBucket,
   getProvinceAnchor,
   MAX_OPDRACHTEN_LIMIT,
+  normalizeOpdrachtenSearchQuery,
   OPDRACHTEN_REGION_OPTIONS,
   OPDRACHTEN_SORT_OPTIONS,
   parseOpdrachtenFilters,
@@ -63,6 +64,7 @@ export function useSidebarFilters({
   // URL as source of truth for TanStack Query
   const parsedFilters = parseOpdrachtenFilters(new URLSearchParams(searchParams.toString()));
   const q = parsedFilters.q ?? "";
+  const committedSearchQuery = normalizeOpdrachtenSearchQuery(q) ?? "";
   const platform = parsedFilters.platform ?? "";
   const endClient = parsedFilters.endClient ?? "";
   const vaardigheid = parsedFilters.escoUri ?? "";
@@ -88,7 +90,7 @@ export function useSidebarFilters({
         : "";
   const straalKm = parsedFilters.radiusKm ? String(parsedFilters.radiusKm) : "";
   const contractType = parsedFilters.contractType ?? "";
-  const hasSearchQuery = q.length > 0;
+  const hasSearchQuery = committedSearchQuery.length > 0;
   const sortOptions = hasSearchQuery
     ? OPDRACHTEN_SORT_OPTIONS
     : OPDRACHTEN_SORT_OPTIONS.filter((option) => option.value !== "relevantie");
@@ -122,7 +124,6 @@ export function useSidebarFilters({
   const [radiusKmInput, setRadiusKmInput] = useState(straalKm);
   const [rateMinInput, setRateMinInput] = useState(tariefMinParamFromUrl);
   const [rateMaxInput, setRateMaxInput] = useState(tariefMaxParamFromUrl);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const provinceAnchor = getProvinceAnchor(provincie);
   const regionOptions = useMemo<FilterOption[]>(
     () =>
@@ -142,8 +143,11 @@ export function useSidebarFilters({
   );
 
   useEffect(() => {
+    if (!q && inputValue && !normalizeOpdrachtenSearchQuery(inputValue)) {
+      return;
+    }
     setInputValue(q);
-  }, [q]);
+  }, [q, inputValue]);
   useEffect(() => {
     setHoursMinInput(urenPerWeekMin);
     setHoursMaxInput(urenPerWeekMax);
@@ -157,6 +161,8 @@ export function useSidebarFilters({
   const debouncedRadiusKm = useDebouncedValue(radiusKmInput);
   const debouncedRateMin = useDebouncedValue(rateMinInput);
   const debouncedRateMax = useDebouncedValue(rateMaxInput);
+  const debouncedSearchInput = useDebouncedValue(inputValue);
+  const debouncedSearchQuery = normalizeOpdrachtenSearchQuery(debouncedSearchInput) ?? "";
   const debouncedHoursHasManualInput = useMemo(
     () => debouncedHoursMin !== urenPerWeekMin || debouncedHoursMax !== urenPerWeekMax,
     [debouncedHoursMin, debouncedHoursMax, urenPerWeekMin, urenPerWeekMax],
@@ -170,7 +176,7 @@ export function useSidebarFilters({
 
   const searchQueryKey = useMemo<SearchQueryKeyPayload>(
     () => ({
-      q,
+      q: committedSearchQuery,
       platform,
       endClient,
       vaardigheid,
@@ -190,7 +196,7 @@ export function useSidebarFilters({
       limit: limitParam,
     }),
     [
-      q,
+      committedSearchQuery,
       platform,
       endClient,
       vaardigheid,
@@ -244,30 +250,20 @@ export function useSidebarFilters({
     searchParams,
   ]);
 
-  // Debounce search input
   useEffect(() => {
-    if (inputValue === q) {
-      if (debounceRef.current) {
-        clearTimeout(debounceRef.current);
-        debounceRef.current = null;
-      }
-      return;
-    }
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      pushOpdrachtenParams(searchParams, router, pathname, { q: inputValue, pagina: "1" });
-      debounceRef.current = null;
-    }, 300);
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, [inputValue, pathname, q, searchParams, router]);
+    if (debouncedSearchQuery === committedSearchQuery) return;
+
+    pushOpdrachtenParams(searchParams, router, pathname, {
+      q: debouncedSearchQuery,
+      pagina: "1",
+    });
+  }, [debouncedSearchQuery, committedSearchQuery, pathname, searchParams, router]);
 
   const { data, error, isFetching } = useQuery({
     queryKey: ["opdrachten-search", searchQueryKey],
     queryFn: ({ signal }) =>
       searchJobs({
-        q,
+        q: committedSearchQuery,
         platform,
         endClient,
         vaardigheid,
@@ -292,7 +288,7 @@ export function useSidebarFilters({
     initialData:
       pageParam === 1 &&
       limitParam === DEFAULT_OPDRACHTEN_LIMIT &&
-      !q &&
+      !committedSearchQuery &&
       !platform &&
       !endClient &&
       !vaardigheid &&

--- a/docs/brainstorms/2026-03-26-instant-vacatures-search-requirements.md
+++ b/docs/brainstorms/2026-03-26-instant-vacatures-search-requirements.md
@@ -1,0 +1,38 @@
+---
+date: 2026-03-26
+topic: instant-vacatures-search
+---
+
+# Instant Vacatures Search
+
+## Problem Frame
+Users searching vacatures should feel like the page is responding as they type, without waiting for a full submit or obvious page refresh. The goal is a search experience that feels snappy, stable, and progressive rather than blocking or jumpy.
+
+## Requirements
+- R1. The vacatures search should update automatically while the user types, without requiring an explicit submit action.
+- R2. Live search should begin once the query reaches 2 characters or more.
+- R3. While a new search is in flight, the current result list should remain visible until the updated results arrive.
+- R4. The search state should remain shareable and refresh-safe by updating the URL after a short pause rather than on every keystroke.
+- R5. If the query is shortened below the live-search threshold, the page should fall back to the default vacatures listing behavior.
+
+## Success Criteria
+- Typing into the vacatures search feels immediate and continuous.
+- Results visibly change while the user is typing, without a disruptive loading flash.
+- The current list never disappears just because a new search started.
+- A copied URL still reflects the active search state after typing settles.
+
+## Scope Boundaries
+- This work applies to vacatures only, not kandidaten.
+- This does not change the ranking model or the underlying search relevance logic.
+- This does not introduce new filter types or redesign the full vacatures page.
+
+## Key Decisions
+- Progressive updates: keep the previous results visible while the next query runs so the UI feels stable.
+- Live-search threshold: start live searching at 2 characters to balance responsiveness and noise.
+- URL sync timing: update the URL after a short pause so the page stays shareable without feeling noisy.
+
+## Dependencies / Assumptions
+- The current vacatures search stack can support incremental updates quickly enough for the UI to feel responsive.
+
+## Next Steps
+-> Run `/prompts:ce-plan` for structured implementation planning

--- a/docs/plans/2026-03-26-001-feat-instant-vacatures-search-plan.md
+++ b/docs/plans/2026-03-26-001-feat-instant-vacatures-search-plan.md
@@ -1,0 +1,54 @@
+---
+date: 2026-03-26
+topic: instant-vacatures-search
+---
+
+# Instant Vacatures Search Plan
+
+## Problem Frame
+The vacatures page already has debounced search and React Query-backed result loading, but the current interaction still leaves too much ambiguity around when a query becomes “active” and how short queries should behave. We want the search to feel responsive while typing, keep the current result list visible during refreshes, and avoid search noise for 0-1 character inputs. This plan keeps the UX change narrowly scoped to vacatures and preserves the current shared search architecture.
+
+## Requirements Traceability
+- R1. Search should update automatically while the user types.
+- R2. Live search should begin once the query reaches 2 characters or more.
+- R3. Existing results should remain visible while the next request loads.
+- R4. The URL should update after a short pause rather than on every keystroke.
+- R5. Shortened queries below the threshold should fall back to the default vacatures listing.
+
+These decisions come from the origin brief at [docs/brainstorms/2026-03-26-instant-vacatures-search-requirements.md](/Users/cortex-air/.codex/worktrees/116b/motian/docs/brainstorms/2026-03-26-instant-vacatures-search-requirements.md) and should stay aligned with the shared vacature search contract already used by the page and API routes.
+
+## Existing Patterns To Preserve
+- `components/sidebar/use-sidebar-filters.ts` already owns URL sync, debounced search input, and React Query state for the vacancies sidebar.
+- `components/sidebar/sidebar-utils.ts` already owns the browser-side fetch helper for `/api/vacatures/zoeken`.
+- `src/lib/vacatures-search.ts` and `src/lib/job-search-runner.ts` already funnel search requests through the shared search service.
+- `placeholderData: (prev) => prev` already keeps the previous page of results visible while React Query fetches the next result set.
+
+## High-Level Technical Design
+Normalize the search query in one shared place so UI and server agree on when a query counts as “live.” The sidebar should debounce the local input, commit the query to the URL only when it is at least 2 trimmed characters long, and clear the query back to the default listing when it drops below threshold. The search runners should apply the same normalization so direct route hits with short queries do not accidentally bypass the intended behavior.
+
+## Implementation Units
+- [ ] Add a shared vacatures search-query normalization helper in the central filter/search utilities and cover it with a focused unit test.
+- [ ] Update the vacatures sidebar hook so the debounced input commits only normalized search text to the URL, while preserving the current result list during fetches.
+- [ ] Update the shared vacatures search runners so short queries are treated as empty/default search state before they reach the search service.
+- [ ] Adjust the sidebar search-related tests to cover 0-1 character fallback, 2+ character activation, and backspacing back below threshold.
+
+## Test Coverage
+- Shared helper test: verify trimming, 0-1 character suppression, and 2+ character activation.
+- Sidebar behavior test: verify typing a short query does not trigger a committed search, typing a 2+ character query does, and reducing the query below threshold returns to the default listing state.
+- Route runner test: verify a direct `/api/vacatures/zoeken` request with a 1-character query is normalized to the default search path.
+
+## Risks & Dependencies
+- If the short-query rule is only applied in the sidebar and not the route runners, direct URL loads or manual API calls could still search on 1-character input.
+- If the query normalization is split across multiple files, the UI and API may drift again; the helper should stay shared.
+- The current React Query placeholder-data pattern should be preserved so the page does not flash empty between keystrokes.
+
+## Documentation / Operational Notes
+- No docs update is expected beyond this plan and the existing brainstorm note.
+- The change is intentionally limited to vacatures search behavior and should not alter kandidaten search.
+
+## Sources & References
+- **Origin document:** [docs/brainstorms/2026-03-26-instant-vacatures-search-requirements.md](/Users/cortex-air/.codex/worktrees/116b/motian/docs/brainstorms/2026-03-26-instant-vacatures-search-requirements.md)
+- Related code: [components/sidebar/use-sidebar-filters.ts](/Users/cortex-air/.codex/worktrees/116b/motian/components/sidebar/use-sidebar-filters.ts)
+- Related code: [components/sidebar/sidebar-utils.ts](/Users/cortex-air/.codex/worktrees/116b/motian/components/sidebar/sidebar-utils.ts)
+- Related code: [src/lib/vacatures-search.ts](/Users/cortex-air/.codex/worktrees/116b/motian/src/lib/vacatures-search.ts)
+- Related code: [src/lib/job-search-runner.ts](/Users/cortex-air/.codex/worktrees/116b/motian/src/lib/job-search-runner.ts)

--- a/src/lib/job-search-runner.ts
+++ b/src/lib/job-search-runner.ts
@@ -3,6 +3,7 @@ import {
   getOpdrachtenServiceSort,
   hasExplicitOpdrachtenSort,
   MAX_OPDRACHTEN_LIMIT,
+  normalizeOpdrachtenSearchQuery,
   parseOpdrachtenFilters,
   validateOpdrachtenQueryParams,
 } from "@/src/lib/opdrachten-filters";
@@ -48,18 +49,19 @@ export async function runJobSearch(
   }
 
   const filters = parseOpdrachtenFilters(params);
+  const q = normalizeOpdrachtenSearchQuery(filters.q);
   const { page, limit, offset } = parsePagination(params, {
     limit: DEFAULT_OPDRACHTEN_LIMIT,
     maxLimit: MAX_OPDRACHTEN_LIMIT,
   });
   const sortBy = getOpdrachtenServiceSort(
     filters.sort,
-    Boolean(filters.q?.trim()),
+    Boolean(q),
     hasExplicitOpdrachtenSort(params),
   );
 
   const result = await searchJobsUnified({
-    q: filters.q,
+    q: q || undefined,
     platform: filters.platform,
     endClient: filters.endClient,
     categories: filters.categories,
@@ -99,18 +101,19 @@ export async function runJobPageSearch(
   }
 
   const filters = parseOpdrachtenFilters(params);
+  const q = normalizeOpdrachtenSearchQuery(filters.q);
   const { page, limit, offset } = parsePagination(params, {
     limit: DEFAULT_OPDRACHTEN_LIMIT,
     maxLimit: MAX_OPDRACHTEN_LIMIT,
   });
   const sortBy = getOpdrachtenServiceSort(
     filters.sort,
-    Boolean(filters.q?.trim()),
+    Boolean(q),
     hasExplicitOpdrachtenSort(params),
   );
 
   const result = await searchJobsPageUnified({
-    q: filters.q,
+    q: q || undefined,
     platform: filters.platform,
     endClient: filters.endClient,
     categories: filters.categories,

--- a/src/lib/opdrachten-filters.ts
+++ b/src/lib/opdrachten-filters.ts
@@ -259,6 +259,13 @@ export function normalizeOpdrachtenStatus(value: string | null | undefined): Opd
   }
 }
 
+export function normalizeOpdrachtenSearchQuery(
+  value: string | null | undefined,
+): string | undefined {
+  const normalized = value?.trim() ?? "";
+  return normalized.length >= 2 ? normalized : undefined;
+}
+
 export function normalizeOpdrachtenProvince(
   value: string | null | undefined,
 ): OpdrachtenProvince | undefined {

--- a/src/lib/vacatures-search.ts
+++ b/src/lib/vacatures-search.ts
@@ -3,6 +3,7 @@ import {
   getOpdrachtenServiceSort,
   hasExplicitOpdrachtenSort,
   MAX_OPDRACHTEN_LIMIT,
+  normalizeOpdrachtenSearchQuery,
   parseOpdrachtenFilters,
   validateOpdrachtenQueryParams,
 } from "@/src/lib/opdrachten-filters";
@@ -41,18 +42,19 @@ export async function runVacaturesSearch(
   }
 
   const filters = parseOpdrachtenFilters(params);
+  const q = normalizeOpdrachtenSearchQuery(filters.q);
   const { page, limit, offset } = parsePagination(params, {
     limit: DEFAULT_OPDRACHTEN_LIMIT,
     maxLimit: MAX_OPDRACHTEN_LIMIT,
   });
   const sortBy = getOpdrachtenServiceSort(
     filters.sort,
-    Boolean(filters.q?.trim()),
+    Boolean(q),
     hasExplicitOpdrachtenSort(params),
   );
 
   const result = await searchJobsUnified({
-    q: filters.q,
+    q: q || undefined,
     platform: filters.platform,
     endClient: filters.endClient,
     categories: filters.categories,

--- a/tests/opdrachten-filters-pagination.test.ts
+++ b/tests/opdrachten-filters-pagination.test.ts
@@ -11,6 +11,7 @@ import {
   getOpdrachtenServiceSort,
   hasExplicitOpdrachtenSort,
   MAX_OPDRACHTEN_LIMIT,
+  normalizeOpdrachtenSearchQuery,
   normalizeOpdrachtenStatus,
   OPDRACHTEN_PAGE_SIZE_OPTIONS,
   OPDRACHTEN_SORT_OPTIONS,
@@ -75,6 +76,22 @@ describe("Opdrachten status normalization", () => {
     expect(normalizeOpdrachtenStatus("closed")).toBe("closed");
     expect(normalizeOpdrachtenStatus("archived")).toBe("archived");
     expect(normalizeOpdrachtenStatus("all")).toBe("all");
+  });
+});
+
+describe("Opdrachten search query normalization", () => {
+  it("treats 0-1 character queries as empty", () => {
+    expect(normalizeOpdrachtenSearchQuery(undefined)).toBeUndefined();
+    expect(normalizeOpdrachtenSearchQuery("")).toBeUndefined();
+    expect(normalizeOpdrachtenSearchQuery("  ")).toBeUndefined();
+    expect(normalizeOpdrachtenSearchQuery("a")).toBeUndefined();
+    expect(normalizeOpdrachtenSearchQuery(" a ")).toBeUndefined();
+  });
+
+  it("keeps queries with 2+ characters", () => {
+    expect(normalizeOpdrachtenSearchQuery("ab")).toBe("ab");
+    expect(normalizeOpdrachtenSearchQuery("  ab ")).toBe("ab");
+    expect(normalizeOpdrachtenSearchQuery("zoekterm")).toBe("zoekterm");
   });
 });
 
@@ -221,6 +238,8 @@ describe("Opdrachten UI/API contracts", () => {
 
     expect(source).toContain('placeholder="Platform"');
     expect(source).toContain("SearchableCombobox");
+    expect(source).toContain("normalizeOpdrachtenSearchQuery");
+    expect(source).toContain("placeholderData: (prev) => prev");
     expect(source).toContain('searchPlaceholder="Zoek eindopdrachtgever..."');
     expect(source).toContain('clearLabel="Alle eindopdrachtgevers"');
     expect(source).toContain('triggerId="opdrachten-eindopdrachtgever"');
@@ -245,6 +264,9 @@ describe("Opdrachten UI/API contracts", () => {
     expect(source).toContain('option.value !== "relevantie"');
     expect(normalizedSource).toContain(
       'const sort = !hasSearchQuery && parsedFilters.sort === "relevantie" ? "nieuwste" : parsedFilters.sort;',
+    );
+    expect(normalizedSource).toContain(
+      "if (!q && inputValue && !normalizeOpdrachtenSearchQuery(inputValue)) { return; }",
     );
     expect(filtersSource).toContain("Sluitingsdatum oplopend");
     expect(filtersSource).toContain("Sluitingsdatum aflopend");

--- a/tests/opdrachten-search-query.test.ts
+++ b/tests/opdrachten-search-query.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeOpdrachtenSearchQuery } from "../src/lib/opdrachten-filters";
+
+describe("normalizeOpdrachtenSearchQuery", () => {
+  it("suppresses empty and one-character queries", () => {
+    expect(normalizeOpdrachtenSearchQuery("")).toBeUndefined();
+    expect(normalizeOpdrachtenSearchQuery("a")).toBeUndefined();
+    expect(normalizeOpdrachtenSearchQuery(" a ")).toBeUndefined();
+  });
+
+  it("keeps trimmed queries with two or more characters", () => {
+    expect(normalizeOpdrachtenSearchQuery("ab")).toBe("ab");
+    expect(normalizeOpdrachtenSearchQuery(" manager ")).toBe("manager");
+  });
+});

--- a/tests/vacatures-search-threshold.test.ts
+++ b/tests/vacatures-search-threshold.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockSearchJobsPageUnified, mockSearchJobsUnified } = vi.hoisted(() => ({
+  mockSearchJobsPageUnified: vi.fn(),
+  mockSearchJobsUnified: vi.fn(),
+}));
+
+vi.mock("../src/services/jobs", () => ({
+  searchJobsPageUnified: mockSearchJobsPageUnified,
+  searchJobsUnified: mockSearchJobsUnified,
+}));
+
+import { runJobPageSearch } from "../src/lib/job-search-runner";
+import { runVacaturesSearch } from "../src/lib/vacatures-search";
+
+describe("vacatures search threshold", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchJobsUnified.mockResolvedValue({ data: [], total: 0 });
+    mockSearchJobsPageUnified.mockResolvedValue({ data: [], total: 0 });
+  });
+
+  it("treats a one-character query as the default vacatures listing in runVacaturesSearch", async () => {
+    await runVacaturesSearch(new URLSearchParams("q=a&platform=opdrachtoverheid"));
+
+    expect(mockSearchJobsUnified).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: undefined,
+        platform: "opdrachtoverheid",
+      }),
+    );
+  });
+
+  it("treats a one-character query as the default vacatures listing in runJobPageSearch", async () => {
+    await runJobPageSearch(new URLSearchParams("q=a&pagina=2&perPage=25"));
+
+    expect(mockSearchJobsPageUnified).toHaveBeenCalledWith(
+      expect.objectContaining({
+        q: undefined,
+        limit: 25,
+        offset: 25,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
This PR makes vacatures search feel responsive while typing.

What changed:
- Search now starts at 2 characters and falls back to the default listing below that threshold.
- The sidebar keeps the current results visible while new results load.
- The shared vacatures runners apply the same normalization so direct route hits behave like the UI.

Verification:
- 
> recruitment-platform@0.1.0 test /Users/cortex-air/.codex/worktrees/116b/motian
> vitest run "tests/opdrachten-search-query.test.ts" "tests/vacatures-search-threshold.test.ts" "tests/opdrachten-route.test.ts" "tests/opdrachten-zoeken-route.test.ts" "tests/vacatures-zoeken-route.test.ts" "tests/opdrachten-filters-pagination.test.ts"


 RUN  v3.2.4 /Users/cortex-air/.codex/worktrees/116b/motian

 ✓ tests/opdrachten-search-query.test.ts > normalizeOpdrachtenSearchQuery > suppresses empty and one-character queries 4ms
 ✓ tests/opdrachten-search-query.test.ts > normalizeOpdrachtenSearchQuery > keeps trimmed queries with two or more characters 1ms
 ✓ tests/vacatures-search-threshold.test.ts > vacatures search threshold > treats a one-character query as the default vacatures listing in runVacaturesSearch 32ms
 ✓ tests/vacatures-search-threshold.test.ts > vacatures search threshold > treats a one-character query as the default vacatures listing in runJobPageSearch 9ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten pagination aliases > supports Dutch and English page/limit aliases 3ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten pagination aliases > defaults opdrachten pagination to 50 and caps at 100 1ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten status normalization > defaults invalid or missing status values to open 0ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten status normalization > preserves closed, archived, and all status values 0ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten search query normalization > treats 0-1 character queries as empty 0ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten search query normalization > keeps queries with 2+ characters 0ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten shared filter parsing > normalizes multi-select recruiter filters and numeric hours ranges from URL params 2ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten shared filter parsing > accepts both recruiter and programmatic ESCO skill query aliases 13ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten shared filter parsing > falls back safely for invalid province, radius, and sort params 1ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten shared filter parsing > keeps the open-ended hours bucket valid for shared query building 0ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten shared filter parsing > supports descending deadline and search relevance sort values 0ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten shared filter parsing > keeps missing sort distinct from explicit nieuwste for API routing 0ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten shared filter parsing > validates malformed opdrachten query params with zod 2ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten filter URL helpers > preserves endClient params while clearing pagination aliases on detail routes 1ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten filter URL helpers > removes the endClient filter cleanly when all clients are selected 0ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten filter URL helpers > trims and deduplicates override values before building the next URL 3ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten UI/API contracts > sidebar exposes enhanced recruiter filters and URL-backed sorting 53ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten UI/API contracts > detail page wires a shared end-client combobox into the existing context-aware navigation 5ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten UI/API contracts > API routes consume the shared opdrachten parser and preserve pagination response shape 1ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten UI/API contracts > layout seed includes persisted end-client, deadline context, category metadata, and shared page-query wiring 3ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten UI/API contracts > detail routes preserve sidebar context and query-aware vacature links 7ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten UI/API contracts > overview results controls and cards reflow cleanly on narrow widths 9ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten UI/API contracts > uses the dark card-based filter panel as the primary sidebar UI 7ms
 ✓ tests/opdrachten-filters-pagination.test.ts > Opdrachten UI/API contracts > keeps mobile filters inside a bounded flex/min-h-0 scroll container 5ms
 ✓ tests/vacatures-zoeken-route.test.ts > GET /api/vacatures/zoeken > delegates filters to the shared page runner and returns compact vacatures rows 46ms
 ✓ tests/vacatures-zoeken-route.test.ts > GET /api/vacatures/zoeken > returns shared runner validation errors unchanged 2ms
 ✓ tests/opdrachten-zoeken-route.test.ts > GET /api/opdrachten/zoeken > delegates filters to the shared page runner and returns compact recruiter jobs 30ms
 ✓ tests/opdrachten-zoeken-route.test.ts > GET /api/opdrachten/zoeken > returns shared runner validation errors unchanged 2ms
 ✓ tests/opdrachten-zoeken-route.test.ts > GET /api/opdrachten/zoeken > returns empty page rows directly from the shared page runner 1ms
 ✓ tests/opdrachten-route.test.ts > GET /api/opdrachten > delegates the request query to the shared vacatures search runner 9ms
 ✓ tests/opdrachten-route.test.ts > GET /api/opdrachten > returns paginated canonicalized job data from the shared runner result 2ms
 ✓ tests/opdrachten-route.test.ts > GET /api/opdrachten > returns runner validation errors unchanged 1ms

 Test Files  6 passed (6)
      Tests  36 passed (36)
   Start at  12:40:21
   Duration  4.82s (transform 1.73s, setup 0ms, collect 5.04s, tests 280ms, environment 2ms, prepare 3.39s)
- Checked 7 files in 160ms. No fixes applied.

Notes:
- 
> recruitment-platform@0.1.0 lint /Users/cortex-air/.codex/worktrees/116b/motian
> biome check .

Checked 675 files in 22s. No fixes applied.
Found 3 errors.
Found 4 warnings.
 ELIFECYCLE  Command failed with exit code 1. still reports unrelated pre-existing issues elsewhere in the repo, outside the touched files.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search queries now require a minimum of 2 characters to trigger live results.
  * Search state is committed to the URL for sharing and persistence across page refreshes.
  * Current results remain visible while fetching updated search results in the background.

* **Documentation**
  * Added requirements and implementation plan for instant search functionality.

* **Tests**
  * Added comprehensive test coverage for search query normalization and threshold behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->