### PR TITLE
fix: diacritics off-by-one, GDPR grouping logic, cache headers

### DIFF
--- a/app/api/scrape-resultaten/route.ts
+++ b/app/api/scrape-resultaten/route.ts
@@ -14,7 +14,7 @@ export const GET = withApiHandler(
     return Response.json(
       { data: results, total: results.length },
       {
-        headers: { "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300" },
+        headers: { "Cache-Control": "private, max-age=60, stale-while-revalidate=300" },
       },
     );
   },

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -60,7 +60,7 @@ export function stripDiacritics(s: string): string {
 
 // Common Dutch diacritics mapping for SQL translate()
 const DIACRITICS_FROM = "àáâãäåæèéêëìíîïòóôõöùúûüýÿñçÀÁÂÃÄÅÆÈÉÊËÌÍÎÏÒÓÔÕÖÙÚÛÜÝÑÇ";
-const DIACRITICS_TO = "aaaaaaaeeeeiiiioooooouuuuyyncAAAAAAAEEEEIIIIOOOOOUUUUYNC";
+const DIACRITICS_TO = "aaaaaaaeeeeiiiiooooouuuuyyncAAAAAAAEEEEIIIIOOOOOUUUUYNC";
 
 /**
  * Cross-database case-insensitive + accent-insensitive "contains" filter.
@@ -82,7 +82,7 @@ export function toTsQueryInput(s: string): string {
   return stripDiacritics(s)
     .trim()
     .split(/\s+/)
-    .map((w) => w.replace(/[^a-zA-Z0-9]/g, ""))
+    .map((w) => w.replace(/[^\p{L}\p{N}]/gu, ""))
     .filter((w) => w.length > 0)
     .map((w) => `${w}:*`)
     .join(" & ");

--- a/src/services/gdpr.ts
+++ b/src/services/gdpr.ts
@@ -243,12 +243,13 @@ export async function scrubContactData(
     const agent = job.agentContact as { email?: string; name?: string } | null;
     const recruiter = job.recruiterContact as { email?: string; name?: string } | null;
 
+    const lowerIdentifier = identifier.toLowerCase();
     const matchAgent =
-      agent?.email?.toLowerCase() === identifier.toLowerCase() ||
-      agent?.name?.toLowerCase() === identifier.toLowerCase();
+      agent?.email?.toLowerCase().includes(lowerIdentifier) ||
+      agent?.name?.toLowerCase().includes(lowerIdentifier);
     const matchRecruiter =
-      recruiter?.email?.toLowerCase() === identifier.toLowerCase() ||
-      recruiter?.name?.toLowerCase() === identifier.toLowerCase();
+      recruiter?.email?.toLowerCase().includes(lowerIdentifier) ||
+      recruiter?.name?.toLowerCase().includes(lowerIdentifier);
 
     if (matchAgent && matchRecruiter) {
       nullBothIds.push(job.id);


### PR DESCRIPTION
## Summary
- **Fix critical diacritics off-by-one bug** in `DIACRITICS_TO` — extra `o` shifted all `translate()` mappings after position 19, breaking all accent-insensitive search (e.g. `ùtrecht` → `otrecht` instead of `utrecht`)
- **Fix Unicode-aware tsquery regex** — `[^a-zA-Z0-9]` → `[\p{L}\p{N}]` so characters like `ø`, `ß`, `ł` survive `stripDiacritics()` and don't break `to_tsquery`
- **Fix GDPR scrubContactData grouping** — ILIKE query uses fuzzy matching but grouping used strict `===` equality, causing matched jobs to fall through all groups
- **Fix scrape-resultaten cache** — `public, s-maxage` → `private, max-age` for user-scoped data

Resolves remaining unaddressed comments from PR #116 review (Devin + CodeRabbit).

## Test plan
- [ ] Search for candidates with accented names (ù, ñ, ç) — should match correctly
- [ ] Verify `toTsQueryInput("coördinator")` produces valid tsquery
- [ ] Test GDPR contact scrub with partial name match
- [ ] Verify scrape-resultaten response headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/118" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
