### PR TITLE
feat: migrate platform onboarding to background Trigger.dev task

### DIFF
--- a/components/chat/genui/genui-utils.ts
+++ b/components/chat/genui/genui-utils.ts
@@ -60,6 +60,7 @@ export const onboardingStepLabels: Record<string, string> = {
   verify_schedule: "Schema verifiëren",
   monitor_first_runs: "Monitoren",
   // Simplified aliases used by the trigger task
+  trigger: "Gestart",
   analyze: "Analyseren",
   configure: "Configureren",
   validate: "Valideren",

--- a/components/chat/genui/platform-card.tsx
+++ b/components/chat/genui/platform-card.tsx
@@ -43,6 +43,15 @@ type ExistsOutput = {
   message: string;
 };
 
+type OnboardingTriggeredOutput = {
+  status: "onboarding_triggered";
+  platform: string;
+  displayName: string;
+  runId: string;
+  adapterKind?: string;
+  message?: string;
+};
+
 type ErrorOutput = {
   success: false;
   step: string;
@@ -74,6 +83,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isCredentialsNeeded(o: unknown): o is CredentialsNeededOutput {
   return isRecord(o) && o.status === "credentials_needed";
+}
+
+function isOnboardingTriggered(o: unknown): o is OnboardingTriggeredOutput {
+  return isRecord(o) && o.status === "onboarding_triggered";
 }
 
 function isExists(o: unknown): o is ExistsOutput {
@@ -248,6 +261,26 @@ export function PlatformCard({ output }: { output: unknown }) {
         </CardHeader>
         <CardContent>
           <p className="text-xs text-muted-foreground">{output.message}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Onboarding triggered (running in background)
+  if (isOnboardingTriggered(output)) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-sm">{output.displayName}</CardTitle>
+            <Badge variant="secondary">Bezig met onboarding</Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <StepperBar currentStep="validate" />
+          <p className="text-xs text-muted-foreground">
+            {output.message ?? "Onboarding is gestart op de achtergrond."}
+          </p>
         </CardContent>
       </Card>
     );

--- a/src/ai/tools/platform-dynamic.ts
+++ b/src/ai/tools/platform-dynamic.ts
@@ -1,3 +1,4 @@
+import { tasks } from "@trigger.dev/sdk";
 import { tool } from "ai";
 import { revalidateTag } from "next/cache";
 import { z } from "zod";
@@ -8,9 +9,9 @@ import {
   createPlatformCatalogEntry,
   getPlatformByBaseUrl,
   getPlatformOnboardingStatus,
-  runPlatformOnboardingWorkflow,
   validateExternalUrl,
 } from "@/src/services/scrapers";
+import type { platformOnboardTask } from "@/trigger/platform-onboard";
 
 export const platformAnalyze = tool({
   description:
@@ -157,66 +158,45 @@ export const platformAutoSetup = tool({
       };
     }
 
-    // Step 3: Run the full onboarding workflow (config + validate + test + activate)
+    // Step 3: Create config and trigger background onboarding via Trigger.dev
     try {
-      const result = await runPlatformOnboardingWorkflow({
-        source: "agent",
-        config: {
-          platform: analysis.slug,
-          baseUrl: analysis.defaultBaseUrl,
-          parameters: {
-            scrapingStrategy: analysis.scrapingStrategy,
-            maxPages: analysis.scrapingStrategy.maxPages,
-          },
-          // Credentials are injected via /api/platforms/[slug]/credentials, not via tool params
-          source: "agent",
+      await createConfig({
+        platform: analysis.slug,
+        baseUrl: analysis.defaultBaseUrl,
+        parameters: {
+          scrapingStrategy: analysis.scrapingStrategy,
+          maxPages: analysis.scrapingStrategy.maxPages,
         },
-        activate,
+        source: "agent",
+      });
+    } catch {
+      // Config may already exist from a prior attempt — non-fatal
+    }
+
+    try {
+      const handle = await tasks.trigger<typeof platformOnboardTask>("platform-onboard", {
+        platform: analysis.slug,
+        source: "agent",
       });
 
       revalidateTag("scrapers", "default");
-      revalidateTag("jobs", "default");
 
       return {
-        success: true,
+        status: "onboarding_triggered" as const,
         platform: analysis.slug,
         displayName: analysis.displayName,
         adapterKind: analysis.adapterKind,
-        validation: {
-          ok: result.validation.ok,
-          message: result.validation.message,
-        },
-        testImport: {
-          status: result.testImport.status,
-          jobsFound: result.testImport.jobsFound,
-          sampleListings: result.testImport.listings.slice(0, 2).map((l) => ({
-            title: l.title,
-            company: l.company,
-            location: l.location,
-            externalUrl: l.externalUrl,
-          })),
-        },
-        activated: result.activated,
+        runId: handle.id,
         scrapingStrategy: analysis.scrapingStrategy,
-        nextSteps: result.activated
-          ? [
-              "Platform is actief en wordt automatisch gescrapet volgens het cron-schema.",
-              "Gebruik triggerScraper om direct een scrape te starten.",
-              "Monitor via platformOnboardingStatus of het scraper-dashboard.",
-            ]
-          : [
-              "Validatie of test-import is niet volledig geslaagd.",
-              "Controleer platformOnboardingStatus voor details.",
-              "Pas de configuratie aan met platformConfigUpdate indien nodig.",
-            ],
+        message: `Onboarding voor "${analysis.displayName}" is gestart op de achtergrond. Gebruik platformOnboardingStatus om de voortgang te volgen.`,
       };
     } catch (err) {
       revalidateTag("scrapers", "default");
 
       return {
         success: false,
-        step: "onboarding_workflow",
-        error: `Onboarding workflow mislukt: ${err instanceof Error ? err.message : String(err)}`,
+        step: "trigger",
+        error: `Onboarding task starten mislukt: ${err instanceof Error ? err.message : String(err)}`,
         platform: analysis.slug,
         analysis,
         suggestion:

--- a/src/mcp/tools/platforms.ts
+++ b/src/mcp/tools/platforms.ts
@@ -1,6 +1,8 @@
+import { tasks } from "@trigger.dev/sdk";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
+import type { platformOnboardTask } from "@/trigger/platform-onboard";
 import { publish } from "../../lib/event-bus";
 import { jsonObjectSchema } from "../../lib/json-value-schema";
 import {
@@ -8,9 +10,9 @@ import {
   completeOnboarding,
   createConfig,
   createPlatformCatalogEntry,
+  getPlatformByBaseUrl,
   getPlatformOnboardingStatus,
   listPlatformCatalog,
-  runPlatformOnboardingWorkflow,
   triggerTestRun,
   validateConfig,
 } from "../../services/scrapers";
@@ -171,7 +173,7 @@ export const handlers: Record<string, (args: unknown) => Promise<unknown>> = {
       .parse(raw);
 
     const { analyzePlatform } = await import("../../services/platform-analyzer");
-    const { validateExternalUrl, getPlatformByBaseUrl } = await import("../../services/scrapers");
+    const { validateExternalUrl } = await import("../../services/scrapers");
 
     // SSRF protection — validate URL before any external fetch
     try {
@@ -209,24 +211,32 @@ export const handlers: Record<string, (args: unknown) => Promise<unknown>> = {
     }
 
     await createPlatformCatalogEntry({ ...analysis, source: "mcp" });
-    const result = await runPlatformOnboardingWorkflow({
-      source: "mcp",
-      config: {
-        platform: analysis.slug,
-        baseUrl: analysis.defaultBaseUrl,
-        parameters: {
-          scrapingStrategy: analysis.scrapingStrategy,
-          maxPages: analysis.scrapingStrategy.maxPages,
-        },
-        ...(data.credentials ? { authConfig: data.credentials } : {}),
-        source: "mcp",
+
+    // Create config (with credentials if provided via MCP)
+    await createConfig({
+      platform: analysis.slug,
+      baseUrl: analysis.defaultBaseUrl,
+      parameters: {
+        scrapingStrategy: analysis.scrapingStrategy,
+        maxPages: analysis.scrapingStrategy.maxPages,
       },
-      activate: data.activate ?? true,
+      ...(data.credentials ? { authConfig: data.credentials } : {}),
+      source: "mcp",
     });
-    if (result.activated) {
-      publish("platform:activated", { platform: analysis.slug });
-    }
-    return { success: true, platform: analysis.slug, ...result };
+
+    const handle = await tasks.trigger<typeof platformOnboardTask>("platform-onboard", {
+      platform: analysis.slug,
+      source: "mcp",
+    });
+
+    publish("platform:configured", { platform: analysis.slug });
+
+    return {
+      status: "onboarding_triggered",
+      platform: analysis.slug,
+      displayName: analysis.displayName,
+      runId: handle.id,
+    };
   },
   platform_config_update: async (raw) => {
     const data = platformConfigSchema


### PR DESCRIPTION
## Summary
- Replace inline `runPlatformOnboardingWorkflow()` with `tasks.trigger()` in AI chat tool and MCP handler
- Tool returns immediately with run ID + "onboarding_triggered" status instead of blocking
- New `OnboardingTriggeredOutput` GenUI card shows "Bezig met onboarding" with stepper
- Users follow up with `platformOnboardingStatus` for live progress

## Why
The inline workflow blocks the HTTP request/chat response for 10-30s while it runs validate → test import → activate sequentially. Moving to Trigger.dev makes the response instant and the heavy work runs asynchronously with retries.

## Test plan
- [ ] `pnpm lint` passes
- [ ] `npx tsc --noEmit` passes  
- [ ] AI tool: calling platformAutoSetup returns immediately with `status: "onboarding_triggered"` and `runId`
- [ ] MCP tool: platform_auto_setup returns same async response
- [ ] PlatformCard: renders "Bezig met onboarding" badge for triggered status
- [ ] Credentials flow: POST credentials → Trigger.dev task starts (unchanged)
- [ ] `platformOnboardingStatus` shows live progress of background task

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
