### PR TITLE
[codex] Optimize Salesforce XML feed revalidation

### DIFF
--- a/app/api/salesforce-feed/route.ts
+++ b/app/api/salesforce-feed/route.ts
@@ -1,5 +1,7 @@
+import { createHash } from "node:crypto";
 import { withApiHandler } from "@/src/lib/api-handler";
 import { parsePagination } from "@/src/lib/pagination";
+import type { SalesforceFeedRecord } from "@/src/services/salesforce-feed";
 import {
   buildSalesforceFeedXml,
   getSalesforceFeed,
@@ -8,6 +10,44 @@ import {
 } from "@/src/services/salesforce-feed";
 
 export const dynamic = "force-dynamic";
+
+function buildFeedEtag(xml: string): string {
+  return `"${createHash("sha1").update(xml).digest("base64url")}"`;
+}
+
+function matchesIfNoneMatch(headerValue: string | null, etag: string): boolean {
+  if (!headerValue) return false;
+
+  return headerValue.split(",").some((candidate) => {
+    const normalized = candidate.trim().replace(/^W\//, "");
+    return normalized === "*" || normalized === etag;
+  });
+}
+
+function getLastModifiedDate(records: SalesforceFeedRecord[]): Date | undefined {
+  const timestamps = records
+    .map((record) => record.fields.LastModifiedDate)
+    .filter((value): value is Date => value instanceof Date)
+    .map((value) => value.getTime())
+    .filter((value) => Number.isFinite(value));
+
+  if (timestamps.length === 0) return undefined;
+
+  return new Date(Math.max(...timestamps));
+}
+
+function toHttpTimestamp(value: Date): number {
+  return new Date(value.toUTCString()).getTime();
+}
+
+function matchesIfModifiedSince(headerValue: string | null, lastModifiedAt?: Date): boolean {
+  if (!headerValue || !lastModifiedAt) return false;
+
+  const parsed = new Date(headerValue);
+  if (Number.isNaN(parsed.getTime())) return false;
+
+  return toHttpTimestamp(lastModifiedAt) <= parsed.getTime();
+}
 
 export const GET = withApiHandler(
   async (request: Request) => {
@@ -44,11 +84,32 @@ export const GET = withApiHandler(
       limit,
       offset,
     });
+    const xml = buildSalesforceFeedXml(records);
+    const etag = buildFeedEtag(xml);
+    const lastModifiedAt = getLastModifiedDate(records);
+    const cacheHeaders = {
+      "Cache-Control": "private, no-cache",
+      ETag: etag,
+      ...(lastModifiedAt ? { "Last-Modified": lastModifiedAt.toUTCString() } : {}),
+      Vary: "Authorization",
+    };
 
-    return new Response(buildSalesforceFeedXml(records), {
+    const ifNoneMatch = request.headers.get("if-none-match");
+    const isNotModified = ifNoneMatch
+      ? matchesIfNoneMatch(ifNoneMatch, etag)
+      : matchesIfModifiedSince(request.headers.get("if-modified-since"), lastModifiedAt);
+
+    if (isNotModified) {
+      return new Response(null, {
+        status: 304,
+        headers: cacheHeaders,
+      });
+    }
+
+    return new Response(xml, {
       headers: {
-        "Cache-Control": "no-store",
         "Content-Type": "application/xml; charset=utf-8",
+        ...cacheHeaders,
       },
     });
   },

--- a/docs/plans/2026-03-30-fix-salesforce-feed-revalidation-plan.md
+++ b/docs/plans/2026-03-30-fix-salesforce-feed-revalidation-plan.md
@@ -1,0 +1,63 @@
+---
+date: 2026-03-30
+topic: salesforce-feed-revalidation
+---
+
+# Salesforce Feed Revalidation Plan
+
+## Problem Frame
+
+`/api/salesforce-feed` is a live pull-based XML export for Salesforce. Before this change, the route always returned the full XML payload with `Cache-Control: no-store`, even when the generated feed had not changed between polls. That makes repeat polling more expensive than necessary for both Motian and the consumer, especially because the same XML feed is likely to be fetched repeatedly on a schedule.
+
+This plan keeps the scope tight: optimize repeat fetch behavior without changing the feed schema, entity selection, filtering rules, or shared service contract used by the API, CLI, and MCP surfaces.
+
+## Requirements Traceability
+
+- R1. Keep the current XML schema and content unchanged for successful feed responses.
+- R2. Allow clients to revalidate unchanged feed responses instead of downloading the full XML every time.
+- R3. Support both entity-tag and timestamp-based HTTP validators so simpler polling clients can use `If-Modified-Since` as well as `If-None-Match`.
+- R4. Preserve the existing shared `getSalesforceFeed()` + `buildSalesforceFeedXml()` flow so CLI and MCP behavior stays stable.
+- R5. Add regression coverage for the route-level conditional request behavior.
+
+## Existing Patterns To Preserve
+
+- [app/api/salesforce-feed/route.ts](/Users/cortex-air/.codex/worktrees/4744/motian/app/api/salesforce-feed/route.ts) already owns request parsing, validation, and response headers for the feed.
+- [src/services/salesforce-feed.ts](/Users/cortex-air/.codex/worktrees/4744/motian/src/services/salesforce-feed.ts) already owns record selection and XML serialization.
+- [tests/salesforce-feed-route.test.ts](/Users/cortex-air/.codex/worktrees/4744/motian/tests/salesforce-feed-route.test.ts) already verifies route defaults, escaping, and invalid entity handling.
+
+## High-Level Technical Design
+
+Generate the XML exactly once per request, derive a deterministic `ETag` from that XML payload, and return it on successful responses. Also derive the latest record modification timestamp from the feed records and emit it as `Last-Modified`. If the caller sends either `If-None-Match` with the same validator or `If-Modified-Since` that is at or after the feed timestamp, short-circuit the route with a `304 Not Modified` response and no body. Keep the optimization at the route layer so the shared feed service remains unchanged and all non-HTTP consumers keep their current behavior.
+
+## Implementation Units
+
+- [ ] Add route-local feed validator helpers in [app/api/salesforce-feed/route.ts](/Users/cortex-air/.codex/worktrees/4744/motian/app/api/salesforce-feed/route.ts) to derive an `ETag` from the XML, derive `Last-Modified` from the feed records, and match incoming `If-None-Match` / `If-Modified-Since` values.
+- [ ] Update the Salesforce feed route to reuse the generated XML string, return validator/revalidation-friendly cache headers, and emit `304 Not Modified` when the incoming validator matches.
+- [ ] Extend [tests/salesforce-feed-route.test.ts](/Users/cortex-air/.codex/worktrees/4744/motian/tests/salesforce-feed-route.test.ts) with route-level regression coverage for both `ETag` and `Last-Modified` conditional requests.
+
+## Test Coverage
+
+- Route test verifies the initial response includes an `ETag` and `Last-Modified` when the feed exposes a modification timestamp.
+- Route test verifies the same request with matching `If-None-Match` returns `304` and an empty body.
+- Route test verifies the same request with matching `If-Modified-Since` returns `304` and an empty body.
+- Existing route tests continue to verify XML escaping, default entity behavior, and invalid entity rejection.
+- Shared CLI/MCP/auth tests should remain green because the service contract is intentionally unchanged.
+
+## Risks & Dependencies
+
+- The validator must be based on the final XML payload, not the raw records, so route behavior stays consistent with the actual response body.
+- `304` responses must continue returning the same `ETag` so clients can keep validating correctly.
+- This is a low-risk route-layer optimization and does not warrant broader feed schema or service refactors.
+
+## Verification
+
+- Targeted: Salesforce route test passes with the new `304` regression scenario.
+- Shared feed surfaces: Salesforce CLI, MCP, and auth-related tests still pass.
+- Quality gates: touched files pass Biome check, repository typecheck stays green, and repo lint still passes.
+
+## Sources & References
+
+- Route: [app/api/salesforce-feed/route.ts](/Users/cortex-air/.codex/worktrees/4744/motian/app/api/salesforce-feed/route.ts)
+- Feed service: [src/services/salesforce-feed.ts](/Users/cortex-air/.codex/worktrees/4744/motian/src/services/salesforce-feed.ts)
+- Route tests: [tests/salesforce-feed-route.test.ts](/Users/cortex-air/.codex/worktrees/4744/motian/tests/salesforce-feed-route.test.ts)
+- Architecture note: [docs/architecture.md](/Users/cortex-air/.codex/worktrees/4744/motian/docs/architecture.md)

--- a/tests/salesforce-feed-route.test.ts
+++ b/tests/salesforce-feed-route.test.ts
@@ -67,6 +67,125 @@ describe("GET /api/salesforce-feed", () => {
     expect(body).toContain("<LastModifiedDate>2026-03-01T00:00:00.000Z</LastModifiedDate>");
   });
 
+  it("returns 304 when the generated XML matches the If-None-Match header", async () => {
+    mockGetSalesforceFeed.mockResolvedValue([
+      {
+        objectType: "Candidate__c",
+        fields: {
+          Id: "candidate-1",
+          Name: "Ada Lovelace",
+          LastModifiedDate: new Date("2026-03-03T08:00:00.000Z"),
+        },
+      },
+    ]);
+
+    const firstResponse = await GET(
+      new Request("http://localhost/api/salesforce-feed?entity=candidates"),
+    );
+    const etag = firstResponse.headers.get("ETag");
+
+    expect(etag).toBeTruthy();
+
+    const cachedResponse = await GET(
+      new Request("http://localhost/api/salesforce-feed?entity=candidates", {
+        headers: { "If-None-Match": etag ?? "" },
+      }),
+    );
+
+    expect(cachedResponse.status).toBe(304);
+    expect(cachedResponse.headers.get("ETag")).toBe(etag);
+    await expect(cachedResponse.text()).resolves.toBe("");
+  });
+
+  it("returns Last-Modified and honors If-Modified-Since for unchanged feed content", async () => {
+    const lastModifiedAt = new Date("2026-03-04T09:30:00.000Z");
+
+    mockGetSalesforceFeed.mockResolvedValue([
+      {
+        objectType: "Application__c",
+        fields: {
+          Id: "app-1",
+          Name: "Ada Lovelace / Platform Engineer",
+          LastModifiedDate: lastModifiedAt,
+        },
+      },
+    ]);
+
+    const firstResponse = await GET(
+      new Request("http://localhost/api/salesforce-feed?entity=applications"),
+    );
+    const lastModified = firstResponse.headers.get("Last-Modified");
+
+    expect(lastModified).toBe(lastModifiedAt.toUTCString());
+
+    const cachedResponse = await GET(
+      new Request("http://localhost/api/salesforce-feed?entity=applications", {
+        headers: { "If-Modified-Since": lastModified ?? "" },
+      }),
+    );
+
+    expect(cachedResponse.status).toBe(304);
+    expect(cachedResponse.headers.get("Last-Modified")).toBe(lastModifiedAt.toUTCString());
+    await expect(cachedResponse.text()).resolves.toBe("");
+  });
+
+  it("ignores If-Modified-Since when If-None-Match is present but does not match", async () => {
+    const lastModifiedAt = new Date("2026-03-04T09:30:00.000Z");
+
+    mockGetSalesforceFeed.mockResolvedValue([
+      {
+        objectType: "Job__c",
+        fields: {
+          Id: "job-2",
+          Name: "Platform Engineer",
+          LastModifiedDate: lastModifiedAt,
+        },
+      },
+    ]);
+
+    const response = await GET(
+      new Request("http://localhost/api/salesforce-feed?entity=jobs", {
+        headers: {
+          "If-Modified-Since": lastModifiedAt.toUTCString(),
+          "If-None-Match": '"stale-etag"',
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toContain("<sObjects>");
+  });
+
+  it("treats a rounded Last-Modified header as unchanged for sub-second timestamps", async () => {
+    const lastModifiedAt = new Date("2026-03-04T09:30:00.987Z");
+
+    mockGetSalesforceFeed.mockResolvedValue([
+      {
+        objectType: "Candidate__c",
+        fields: {
+          Id: "candidate-2",
+          Name: "Grace Hopper",
+          LastModifiedDate: lastModifiedAt,
+        },
+      },
+    ]);
+
+    const firstResponse = await GET(
+      new Request("http://localhost/api/salesforce-feed?entity=candidates"),
+    );
+    const lastModified = firstResponse.headers.get("Last-Modified");
+
+    expect(lastModified).toBe(lastModifiedAt.toUTCString());
+
+    const cachedResponse = await GET(
+      new Request("http://localhost/api/salesforce-feed?entity=candidates", {
+        headers: { "If-Modified-Since": lastModified ?? "" },
+      }),
+    );
+
+    expect(cachedResponse.status).toBe(304);
+  });
+
   it("rejects unsupported entities", async () => {
     const response = await GET(new Request("http://localhost/api/salesforce-feed?entity=contacts"));
 


### PR DESCRIPTION
## Summary
- add HTTP revalidation support to the Salesforce XML feed route with `ETag` and `Last-Modified`
- return `304 Not Modified` for unchanged feed responses via both `If-None-Match` and `If-Modified-Since`
- cover validator precedence and HTTP-date rounding edge cases with route tests

## Why
Salesforce-style polling clients were always downloading the full XML payload because the route returned `Cache-Control: no-store` and no validators. This change keeps the XML contract untouched while making repeated polling cheaper and more compatible with standard HTTP cache validation.

## Impact
- no changes to the XML schema or feed entities
- CLI and MCP keep using the same shared feed service contract
- repeated HTTP feed requests can short-circuit when nothing changed

## Validation
- `pnpm test tests/salesforce-feed-route.test.ts tests/salesforce-feed-cli.test.ts tests/salesforce-feed-mcp.test.ts tests/salesforce-feed-auth.test.ts`
- `pnpm exec biome check app/api/salesforce-feed/route.ts tests/salesforce-feed-route.test.ts docs/plans/2026-03-30-fix-salesforce-feed-revalidation-plan.md`
- `pnpm exec tsc --noEmit`
- `pnpm lint`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/128" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
