### PR TITLE
Hide internal ops pages from recruiter UI

### DIFF
--- a/app/automatisering/page.tsx
+++ b/app/automatisering/page.tsx
@@ -1,4 +1,4 @@
-import { Activity, Bot, ChevronRight, Database, Sparkles } from "lucide-react";
+import { ChevronRight, Database, Sparkles } from "lucide-react";
 import Link from "next/link";
 import { PageHeader } from "@/components/page-header";
 import { Badge } from "@/components/ui/badge";
@@ -6,20 +6,6 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 const SURFACES = [
-  {
-    title: "Agents",
-    href: "/agents",
-    icon: Bot,
-    description: "Bekijk autonome runs, activiteit en operationele gezondheid.",
-    tone: "text-blue-600 dark:text-blue-400",
-  },
-  {
-    title: "Autopilot",
-    href: "/autopilot",
-    icon: Activity,
-    description: "Volg nachtelijke checks en zie welke journeys aandacht vragen.",
-    tone: "text-amber-600 dark:text-amber-400",
-  },
   {
     title: "Databronnen",
     href: "/scraper",
@@ -113,7 +99,7 @@ export default function AutomatiseringPage() {
             </CardHeader>
             <CardContent className="space-y-3 text-sm text-muted-foreground">
               <div className="rounded-lg border border-border/70 bg-muted/20 p-3">
-                Agents, Autopilot en Databronnen zijn bewust samengebracht in één zone.
+                Databronnen en AI Assistent blijven hier zichtbaar als ondersteunende tooling.
               </div>
               <div className="rounded-lg border border-border/70 bg-muted/20 p-3">
                 Instellingen blijft een utility-pagina en hoort niet in deze hub.
@@ -121,6 +107,10 @@ export default function AutomatiseringPage() {
               <div className="rounded-lg border border-border/70 bg-muted/20 p-3">
                 Matching blijft als compatibiliteitsroute bestaan, maar wordt niet meer
                 gepresenteerd als primaire bestemming.
+              </div>
+              <div className="rounded-lg border border-border/70 bg-muted/20 p-3">
+                Operationele admin-pagina&apos;s blijven bereikbaar via directe route, maar worden
+                niet actief gepromoot in de recruiter-UI.
               </div>
             </CardContent>
           </Card>

--- a/components/command-palette.tsx
+++ b/components/command-palette.tsx
@@ -2,7 +2,6 @@
 
 import {
   Activity,
-  Bot,
   Briefcase,
   Calendar,
   Code,
@@ -15,7 +14,6 @@ import {
   Plug,
   Rss,
   Settings,
-  Sparkles,
   Users,
   Wrench,
   Zap,
@@ -89,20 +87,6 @@ const PAGES: PageEntry[] = [
     icon: Wrench,
     group: "Platform",
     keywords: ["operaties", "tools", "automatisch"],
-  },
-  {
-    label: "Agents",
-    href: "/agents",
-    icon: Bot,
-    group: "Operaties",
-    keywords: ["bot", "automatisch", "ai"],
-  },
-  {
-    label: "Autopilot",
-    href: "/autopilot",
-    icon: Sparkles,
-    group: "Operaties",
-    keywords: ["auto", "zelfstandig"],
   },
   {
     label: "Databronnen",

--- a/tests/recruiter-dashboard-navigation.test.ts
+++ b/tests/recruiter-dashboard-navigation.test.ts
@@ -47,6 +47,7 @@ describe("Recruiter-first navigation", () => {
   it("keeps recruiter workflow routes prominent in the sidebar", () => {
     const source = readFile("components", "app-sidebar.tsx");
     const commandPaletteSource = readFile("components", "command-palette.tsx");
+    const automationHubSource = readFile("app", "automatisering", "page.tsx");
 
     expect(source).toContain('title: "Overzicht"');
     expect(source).toContain('title: "Vacatures"');
@@ -74,8 +75,6 @@ describe("Recruiter-first navigation", () => {
     expect(source).not.toContain('title: "Databronnen"');
 
     expect(commandPaletteSource).toContain('label: "Automatisering"');
-    expect(commandPaletteSource).toContain('label: "Agents"');
-    expect(commandPaletteSource).toContain('label: "Autopilot"');
     expect(commandPaletteSource).toContain('label: "Databronnen"');
     expect(commandPaletteSource).toContain('label: "Matching"');
     expect(commandPaletteSource).toContain('label: "AI Assistent"');
@@ -83,6 +82,14 @@ describe("Recruiter-first navigation", () => {
     expect(commandPaletteSource).toContain('label: "XML Feed"');
     expect(commandPaletteSource).toContain('label: "MCP Server"');
     expect(commandPaletteSource).toContain('label: "OpenAPI Spec"');
+
+    expect(commandPaletteSource).not.toContain('label: "Agents"');
+    expect(commandPaletteSource).not.toContain('label: "Autopilot"');
+
+    expect(automationHubSource).not.toContain('title: "Agents"');
+    expect(automationHubSource).not.toContain('title: "Autopilot"');
+    expect(automationHubSource).not.toContain('href: "/agents"');
+    expect(automationHubSource).not.toContain('href: "/autopilot"');
   });
 
   it("keeps heavy pipeline visuals out of eager sidebar prefetches", () => {


### PR DESCRIPTION
## Summary
- remove `Agents` and `Autopilot` from the promoted Automatisering hub cards
- remove `Agents` and `Autopilot` from the command palette while keeping their routes alive
- update recruiter navigation coverage to assert those internal pages are no longer promoted

## Test Plan
- [x] `pnpm test tests/recruiter-dashboard-navigation.test.ts`
- [x] `pnpm exec biome check app/automatisering/page.tsx components/command-palette.tsx tests/recruiter-dashboard-navigation.test.ts`
- [ ] Full repo test suite not run in this pass

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed Agents and Autopilot from recruiter interface navigation and visibility
  * Updated messaging to clarify that Databronnen and AI Assistent remain available as supporting tools
  * Added clarification that operational admin pages are accessible via direct routes but not actively promoted in the recruiter UI

<!-- end of auto-generated comment: release notes by coderabbit.ai -->