### PR TITLE
fix(scrapers): Striive race condition, Flextender validation, MiPublic noise

### DIFF
--- a/packages/scrapers/src/flextender.ts
+++ b/packages/scrapers/src/flextender.ts
@@ -192,6 +192,10 @@ async function enrichListings(
               `Uren per week: ${listing._rawHours}`,
             ];
           }
+          // Don't let a short detail description override a valid listing description
+          if (detail.description && detail.description.length < 10 && listing.description.length >= 10) {
+            delete detail.description;
+          }
           const { _rawHours, ...listingClean } = listing;
           const merged = { ...listingClean, ...detail };
           return merged;

--- a/packages/scrapers/src/mipublic.ts
+++ b/packages/scrapers/src/mipublic.ts
@@ -167,6 +167,7 @@ async function scrapeMipublicListings(
         return {
           error: `MiPublic detailpagina bevat geen JobPosting-data: ${detailUrl}`,
           listings: [] as RawScrapedListing[],
+          isNoData: true,
         };
       }
 
@@ -180,11 +181,18 @@ async function scrapeMipublicListings(
   });
 
   const listings = results.flatMap((entry) => entry.listings);
-  const errors = results.flatMap((entry) => (entry.error ? [entry.error] : []));
+  const noDataCount = results.filter((entry) => "isNoData" in entry && entry.isNoData).length;
+  const realErrors = results.flatMap((entry) =>
+    entry.error && !("isNoData" in entry && entry.isNoData) ? [entry.error] : [],
+  );
+  // Summarise missing-data pages into a single line instead of one per URL
+  if (noDataCount > 0) {
+    realErrors.push(`${noDataCount} MiPublic detailpagina's bevatten geen JobPosting-data`);
+  }
 
   return {
     listings,
-    errors: errors.length > 0 ? errors : undefined,
+    errors: realErrors.length > 0 ? realErrors : undefined,
   };
 }
 

--- a/packages/scrapers/src/striive.ts
+++ b/packages/scrapers/src/striive.ts
@@ -362,11 +362,12 @@ async function scrapeViaModal(username: string, password: string): Promise<RawSc
 
     console.log("[striive] Modal sandbox created, executing scrape script...");
 
-    // Write the scraping script into the sandbox
-    await sandbox.exec(
+    // Write the scraping script into the sandbox and wait for the write to complete
+    const writeProc = await sandbox.exec(
       ["bash", "-c", `cat > /root/scrape.js << 'SCRIPT_EOF'\n${MODAL_SCRAPE_SCRIPT}\nSCRIPT_EOF`],
       { timeoutMs: 10_000 },
     );
+    await writeProc.wait();
 
     // Execute the script
     const proc = await sandbox.exec(["node", "/root/scrape.js"], {


### PR DESCRIPTION
## Summary

- **Striive** — fix `Cannot find module '/root/scrape.js'` by awaiting the file-write process before executing the scrape script in the Modal sandbox
- **Flextender** — prevent short detail-page descriptions (<10 chars) from overriding valid listing descriptions, fixing Zod validation rejection ("Beschrijving moet minimaal 10 tekens bevatten")
- **MiPublic** — collapse 320+ per-URL "no JobPosting data" warnings into a single summary line

## Root Causes

| Scraper | Error | Root Cause |
|---------|-------|------------|
| Striive | `Cannot find module '/root/scrape.js'` | `sandbox.exec()` for file write was not awaited — race condition |
| Flextender | Zod validation: description < 10 chars | Detail enrichment overwrote valid listing description with a short one |
| MiPublic | 320+ log warnings per run | Each page without JobPosting data logged individually |

## Test plan

- [x] All 1234 tests pass (`pnpm test`)
- [x] Biome lint clean (`pnpm lint`)
- [ ] Verify Striive scrape succeeds on next scheduled run
- [ ] Verify Flextender produces 0 validation skips
- [ ] Verify MiPublic logs show 1 summary warning instead of 320+

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
