### PR TITLE
fix(scrapers): improve Striive and MiPublic count accuracy

### DIFF
--- a/app/vacatures/layout.tsx
+++ b/app/vacatures/layout.tsx
@@ -35,9 +35,7 @@ async function SidebarContent() {
   // The client fetches more on scroll/filter via the /api/vacatures/zoeken endpoint.
   const SIDEBAR_INITIAL_LIMIT = 20;
 
-  const metadata = await getSidebarMetadata().then(
-    (cached) => cached ?? refreshSidebarMetadata(),
-  );
+  const metadata = await getSidebarMetadata().then((cached) => cached ?? refreshSidebarMetadata());
   // Pass knownTotal from precomputed metadata to skip the COUNT(*) query
   const { data: sidebarJobs } = await listJobsPage({
     limit: SIDEBAR_INITIAL_LIMIT,

--- a/packages/scrapers/src/mipublic.ts
+++ b/packages/scrapers/src/mipublic.ts
@@ -63,12 +63,28 @@ function resolveMipublicOptions(config: PlatformRuntimeConfig): MipublicOptions 
   };
 }
 
+const SITEMAP_MAX_AGE_DAYS = 90;
+
 function extractSitemapUrls(xml: string): string[] {
   const urls = new Set<string>();
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - SITEMAP_MAX_AGE_DAYS);
 
-  for (const match of xml.matchAll(/<loc>([^<]+)<\/loc>/gi)) {
-    const value = match[1]?.trim();
+  // Parse <url> blocks to check <lastmod> dates when available
+  const urlBlocks = xml.match(/<url>[\s\S]*?<\/url>/gi) ?? [];
+  for (const block of urlBlocks) {
+    const locMatch = block.match(/<loc>([^<]+)<\/loc>/i);
+    if (!locMatch) continue;
+
+    const value = locMatch[1]?.trim();
     if (!value) continue;
+
+    // Skip stale entries based on <lastmod>
+    const lastmodMatch = block.match(/<lastmod>([^<]+)<\/lastmod>/i);
+    if (lastmodMatch) {
+      const lastmod = new Date(lastmodMatch[1].trim());
+      if (!Number.isNaN(lastmod.getTime()) && lastmod < cutoff) continue;
+    }
 
     try {
       const parsed = new URL(value);
@@ -77,6 +93,22 @@ function extractSitemapUrls(xml: string): string[] {
       }
     } catch {
       continue;
+    }
+  }
+
+  // Fallback: if no <url> blocks found, parse bare <loc> tags (simpler sitemaps)
+  if (urls.size === 0) {
+    for (const match of xml.matchAll(/<loc>([^<]+)<\/loc>/gi)) {
+      const value = match[1]?.trim();
+      if (!value) continue;
+      try {
+        const parsed = new URL(value);
+        if (parsed.hostname === "mipublic.nl" && /^\/vacature\/[^/]+\/?$/.test(parsed.pathname)) {
+          urls.add(parsed.toString());
+        }
+      } catch {
+        continue;
+      }
     }
   }
 
@@ -115,7 +147,27 @@ async function mapWithConcurrency<TInput, TOutput>(
  * Extracts a minimal listing from <title> or <h1> tags so the vacancy is not
  * silently dropped.
  */
+/** Signals in the HTML that indicate the vacancy page is expired/archived. */
+const EXPIRED_PAGE_SIGNALS = [
+  "niet meer beschikbaar",
+  "niet meer actief",
+  "vacature is verlopen",
+  "vacature is gesloten",
+  "pagina niet gevonden",
+  "page not found",
+  "deze vacature bestaat niet",
+  "404",
+];
+
+function isExpiredMipublicPage(html: string): boolean {
+  const lower = html.toLowerCase();
+  return EXPIRED_PAGE_SIGNALS.some((signal) => lower.includes(signal));
+}
+
 function parseMipublicHtmlFallback(html: string, canonicalUrl: string): RawScrapedListing | null {
+  // Don't create listings from expired/archived pages
+  if (isExpiredMipublicPage(html)) return null;
+
   const titleTagMatch = html.match(/<title[^>]*>([^<]+)<\/title>/i);
   const h1Match = html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/i);
 

--- a/packages/scrapers/src/striive.ts
+++ b/packages/scrapers/src/striive.ts
@@ -35,6 +35,24 @@ function mapWorkArrangement(remote) {
   }
 }
 
+function mapStriiveStatus(apiStatus) {
+  // Striive API statuses: OPEN, IN_PROGRESS, CLOSED, EXPIRED, DRAFT, etc.
+  // Map to Motian's open/closed model
+  switch (apiStatus) {
+    case "OPEN":
+    case "IN_PROGRESS":
+    case "PENDING":
+      return "open";
+    case "CLOSED":
+    case "EXPIRED":
+    case "CANCELLED":
+    case "FILLED":
+      return "closed";
+    default:
+      return "open"; // treat unknown statuses as open
+  }
+}
+
 function mapBasicListing(job) {
   const loc = job.locationName ?? "";
   const province = loc.includes(" - ") ? loc.split(" - ")[1]?.trim() : undefined;
@@ -47,6 +65,7 @@ function mapBasicListing(job) {
     description: job.description ?? job.shortDescription ?? "",
     externalId: job.referenceCode ?? String(job.id ?? ""),
     externalUrl: \`https://supplier.striive.com/jobrequests/\${job.id ?? ""}\`,
+    status: mapStriiveStatus(job.status),
     rateMax: undefined,
     startDate: job.startDate ?? undefined,
     endDate: job.endDate ?? undefined,
@@ -243,7 +262,9 @@ async function run() {
     const PAGE_SIZE = 50;
 
     while (true) {
-      const res = await fetch(API_LIST + "?page=" + pageNum + "&size=" + PAGE_SIZE + "&status=OPEN", {
+      // Fetch all statuses — the web UI shows OPEN, IN_PROGRESS, etc.
+      // Status mapping to Motian open/closed happens in mapBasicListing.
+      const res = await fetch(API_LIST + "?page=" + pageNum + "&size=" + PAGE_SIZE, {
         headers: { Cookie: cookie, Accept: "application/json" },
       });
 

--- a/tests/hybrid-search-short-query-policy.test.ts
+++ b/tests/hybrid-search-short-query-policy.test.ts
@@ -19,10 +19,7 @@ describe("hybrid search short-query policy", () => {
   });
 
   it("enables vector search for two-word queries (Dutch synonym matching)", () => {
-    const policy = getHybridSearchPolicy(
-      { query: "project manager", limit: 20, offset: 0 },
-      {},
-    );
+    const policy = getHybridSearchPolicy({ query: "project manager", limit: 20, offset: 0 }, {});
 
     expect(policy.shouldRunVectorSearch).toBe(true);
     expect(policy.vectorSearchSkippedReason).toBeNull();
@@ -49,25 +46,16 @@ describe("hybrid search short-query policy", () => {
   });
 
   it("normalizes multi-space and tab queries correctly", () => {
-    const policy = getHybridSearchPolicy(
-      { query: "  java  ", limit: 20, offset: 0 },
-      {},
-    );
+    const policy = getHybridSearchPolicy({ query: "  java  ", limit: 20, offset: 0 }, {});
     expect(policy.shouldRunVectorSearch).toBe(false);
 
-    const tabPolicy = getHybridSearchPolicy(
-      { query: "java\tdeveloper", limit: 20, offset: 0 },
-      {},
-    );
+    const tabPolicy = getHybridSearchPolicy({ query: "java\tdeveloper", limit: 20, offset: 0 }, {});
     expect(tabPolicy.shouldRunVectorSearch).toBe(true); // 2 words after normalization
   });
 
   it("handles hyphenated terms as single words", () => {
     // "ICT-beheerder" is 1 word → keyword only
-    const policy = getHybridSearchPolicy(
-      { query: "ICT-beheerder", limit: 20, offset: 0 },
-      {},
-    );
+    const policy = getHybridSearchPolicy({ query: "ICT-beheerder", limit: 20, offset: 0 }, {});
     expect(policy.shouldRunVectorSearch).toBe(false);
 
     // "full-stack developer" is 2 words → hybrid


### PR DESCRIPTION
## Summary

Fixes vacancy count discrepancies between Motian and source platforms.

### Striive: 65 shown vs 142 on portal

| Root Cause | Fix |
|-----------|-----|
| API filter `&status=OPEN` excluded IN_PROGRESS/PENDING jobs | Removed status filter, scrape all statuses |
| No status mapping for non-OPEN statuses | Added `mapStriiveStatus()` mapping OPEN/IN_PROGRESS→open, CLOSED/EXPIRED→closed |

**Expected result**: Striive count should increase from ~65 to ~100+ (after dedup).

### MiPublic: 978 shown vs 445 on site

| Root Cause | Fix |
|-----------|-----|
| WordPress sitemap contains 500+ expired URLs | Filter sitemap entries with `<lastmod>` older than 90 days |
| Fallback parser creates listings from expired pages | Added `isExpiredMipublicPage()` detection for "niet meer beschikbaar" etc. |

**Expected result**: MiPublic count should drop from ~978 to ~400-500 (matching actual site).

## Test plan

- [x] 1244 tests pass
- [x] TypeScript compiles cleanly
- [x] Biome lint clean
- [ ] Verify Striive count increases after next scrape
- [ ] Verify MiPublic count decreases to match site
- [ ] Monitor for any scraper errors in Trigger.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Eliminated display of expired or archived job listings, improving overall data quality
  - Implemented age-based filtering in sitemap processing to prioritize recent job postings

* **New Features**
  - Added comprehensive job status mapping for Striive listings, enabling accurate classification of all positions as open or closed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->