### PR TITLE
Add clarify-first interview prep to recruiter chat

### DIFF
--- a/components/chat/genui/interview-prep-card.tsx
+++ b/components/chat/genui/interview-prep-card.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { ClipboardList, ShieldCheck, Sparkles } from "lucide-react";
+import { memo } from "react";
+import { getToolErrorMessage, isToolError } from "./genui-utils";
+import { ToolErrorBlock } from "./tool-error-block";
+
+type ClarificationOutput = {
+  status: "needs_clarification";
+  missingInformation: string[];
+  recommendedQuestions: string[];
+  nextStep: string;
+};
+
+type ScorecardCriterion = {
+  criterion: string;
+  whatGoodLooksLike: string;
+  redFlag: string;
+};
+
+type ReadyOutput = {
+  status: "ready";
+  artifact: {
+    prepSummary: {
+      interviewType: string;
+      interviewGoal: string;
+      recommendedDuration: string;
+      contextSummary: string;
+    };
+    openingPrompt: string;
+    mustAskQuestions: string[];
+    scorecardCriteria: ScorecardCriterion[];
+    evidenceToCapture: string[];
+    recruiterNotes: string[];
+    humanGuardrails: string[];
+    writebackPayload: {
+      type: "interview_prep_template";
+      interviewType: string;
+      linkedJobId: string | null;
+      linkedCandidateId: string | null;
+      linkedMatchId: string | null;
+      mustAskQuestions: string[];
+      evidenceToCapture: string[];
+    };
+  };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isClarificationOutput(value: unknown): value is ClarificationOutput {
+  return (
+    isRecord(value) &&
+    value.status === "needs_clarification" &&
+    Array.isArray(value.recommendedQuestions)
+  );
+}
+
+function isReadyOutput(value: unknown): value is ReadyOutput {
+  return (
+    isRecord(value) &&
+    value.status === "ready" &&
+    isRecord(value.artifact) &&
+    isRecord(value.artifact.prepSummary)
+  );
+}
+
+function BulletList({ items }: { items: string[] }) {
+  return (
+    <ul className="space-y-1 text-sm text-foreground">
+      {items.map((item) => (
+        <li key={item}>• {item}</li>
+      ))}
+    </ul>
+  );
+}
+
+export const InterviewPrepCard = memo(function InterviewPrepCard({ output }: { output: unknown }) {
+  if (isToolError(output)) {
+    return (
+      <ToolErrorBlock
+        message={getToolErrorMessage(output, "Interviewvoorbereiding niet beschikbaar")}
+      />
+    );
+  }
+
+  if (isClarificationOutput(output)) {
+    return (
+      <div className="my-1.5 rounded-lg border border-amber-500/30 bg-amber-500/5 p-4">
+        <div className="flex items-center gap-2">
+          <ClipboardList className="h-4 w-4 text-amber-600" />
+          <p className="text-sm font-semibold text-foreground">Eerst verduidelijken</p>
+        </div>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+          Er ontbreekt nog context voordat Motian een bruikbare interviewvoorbereiding kan maken.
+        </p>
+        <div className="mt-4 rounded-md border border-border/70 bg-background/70 p-3">
+          <p className="text-sm font-semibold text-foreground">Nog nodig</p>
+          <BulletList items={output.missingInformation} />
+        </div>
+        <div className="mt-4 rounded-md border border-border/70 bg-background/70 p-3">
+          <p className="text-sm font-semibold text-foreground">Aanbevolen vragen</p>
+          <ol className="mt-2 space-y-2 text-sm text-foreground">
+            {output.recommendedQuestions.map((question, index) => (
+              <li key={question}>
+                <span className="mr-2 text-muted-foreground">{index + 1}.</span>
+                {question}
+              </li>
+            ))}
+          </ol>
+        </div>
+        <p className="mt-3 text-xs text-muted-foreground">{output.nextStep}</p>
+      </div>
+    );
+  }
+
+  if (!isReadyOutput(output)) return null;
+
+  const { artifact } = output;
+
+  return (
+    <div className="my-1.5 rounded-lg border border-border bg-card p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <Sparkles className="h-4 w-4 text-primary" />
+            <p className="text-sm font-semibold text-foreground">
+              Interviewprep: {artifact.prepSummary.interviewType}
+            </p>
+          </div>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            {artifact.prepSummary.contextSummary}
+          </p>
+        </div>
+        <span className="inline-flex items-center rounded-full bg-emerald-500/10 px-2.5 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-400">
+          Recruiter-ready
+        </span>
+      </div>
+
+      <div className="mt-4 grid gap-2 sm:grid-cols-2">
+        <div className="rounded-md border border-border/70 bg-background/70 p-3">
+          <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Doel</p>
+          <p className="mt-1 text-sm text-foreground">{artifact.prepSummary.interviewGoal}</p>
+        </div>
+        <div className="rounded-md border border-border/70 bg-background/70 p-3">
+          <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Duur</p>
+          <p className="mt-1 text-sm text-foreground">{artifact.prepSummary.recommendedDuration}</p>
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-md border border-border/70 bg-background/70 p-3">
+        <p className="text-sm font-semibold text-foreground">Opening voor de recruiter</p>
+        <p className="mt-2 text-sm leading-6 text-foreground">{artifact.openingPrompt}</p>
+      </div>
+
+      <div className="mt-4 grid gap-4 lg:grid-cols-2">
+        <div className="rounded-md border border-border/70 bg-background/70 p-3">
+          <p className="text-sm font-semibold text-foreground">Must-ask vragen</p>
+          <div className="mt-2">
+            <BulletList items={artifact.mustAskQuestions} />
+          </div>
+        </div>
+        <div className="rounded-md border border-border/70 bg-background/70 p-3">
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="h-4 w-4 text-blue-600" />
+            <p className="text-sm font-semibold text-foreground">Human guardrails</p>
+          </div>
+          <div className="mt-2">
+            <BulletList items={artifact.humanGuardrails} />
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-md border border-border/70 bg-background/70 p-3">
+        <p className="text-sm font-semibold text-foreground">Scorecardcriteria</p>
+        <div className="mt-2 space-y-2">
+          {artifact.scorecardCriteria.map((criterion) => (
+            <div
+              key={criterion.criterion}
+              className="rounded-md border border-border/70 bg-muted/30 p-3"
+            >
+              <p className="text-sm font-medium text-foreground">{criterion.criterion}</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Goed signaal: {criterion.whatGoodLooksLike}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">Red flag: {criterion.redFlag}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-4 lg:grid-cols-2">
+        <div className="rounded-md border border-border/70 bg-background/70 p-3">
+          <p className="text-sm font-semibold text-foreground">Evidence vastleggen</p>
+          <div className="mt-2">
+            <BulletList items={artifact.evidenceToCapture} />
+          </div>
+        </div>
+        <div className="rounded-md border border-border/70 bg-background/70 p-3">
+          <p className="text-sm font-semibold text-foreground">Recruiter notes</p>
+          <div className="mt-2">
+            <BulletList items={artifact.recruiterNotes} />
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 rounded-md border border-border/70 bg-background/70 p-3">
+        <p className="text-sm font-semibold text-foreground">Writeback payload</p>
+        <p className="mt-1 text-xs text-muted-foreground">Type: {artifact.writebackPayload.type}</p>
+        <p className="text-xs text-muted-foreground">
+          Job: {artifact.writebackPayload.linkedJobId ?? "geen"} · Kandidaat:{" "}
+          {artifact.writebackPayload.linkedCandidateId ?? "geen"} · Match:{" "}
+          {artifact.writebackPayload.linkedMatchId ?? "geen"}
+        </p>
+      </div>
+    </div>
+  );
+});

--- a/components/chat/genui/registry.ts
+++ b/components/chat/genui/registry.ts
@@ -52,6 +52,12 @@ export const GENUI_REGISTRY: Record<string, GenUIEntry> = {
     ),
     label: "Interviews",
   },
+  genereerInterviewPrep: {
+    component: lazy(() =>
+      import("./interview-prep-card").then((m) => ({ default: m.InterviewPrepCard })),
+    ),
+    label: "Interviewprep",
+  },
   // Analytics
   analyseData: {
     component: lazy(() => import("./insight-chart").then((m) => ({ default: m.InsightChart }))),

--- a/src/ai/agent.ts
+++ b/src/ai/agent.ts
@@ -1,5 +1,5 @@
-import { applications, db, isNull, sql } from "@/src/db";
 import type { ToolResultCache } from "@/src/lib/tool-result-cache";
+import { getApplicationStats } from "@/src/services/applications";
 import { HYBRID_BLEND, SCORING_WEIGHTS } from "@/src/services/scoring";
 import { getAllSettings } from "@/src/services/settings";
 import { getWorkspaceSummary } from "@/src/services/workspace";
@@ -95,6 +95,10 @@ const canvasTools = {
   readCanvasState: tools.readCanvasState,
 };
 
+const interviewPrepTools = {
+  genereerInterviewPrep: tools.genereerInterviewPrep,
+};
+
 const gdprTools = {
   exporteerKandidaatData: tools.exporteerKandidaatData,
   wisKandidaatData: tools.wisKandidaatData,
@@ -112,6 +116,7 @@ export const recruitmentTools = {
   ...berichtTools,
   ...gdprTools,
   ...canvasTools,
+  ...interviewPrepTools,
 };
 
 function isOpdrachtContext(context?: AgentContext) {
@@ -138,6 +143,7 @@ function getCapabilityLines(context?: AgentContext): string[] {
       "Sollicitaties bekijken en pipeline-fases bijwerken",
       "Data analyseren (tarieven, platforms, deadlines)",
       "Semantisch zoeken naar vacatures op basis van beschrijving of profiel (vector embeddings)",
+      "Interviewvoorbereiding opstellen met screeningvragen, scorecriteria en recruiter-notes (genereerInterviewPrep)",
       "Scrapers en scoring-batches starten voor opdrachten",
       "Platform onboarding beheren: catalogus, credentials, config, validatie, implementatie, monitoring en smoke imports",
       "Nieuwe platformen automatisch toevoegen: URL analyseren → scraping strategie bepalen → volledig inrichten (platformAutoSetup)",
@@ -151,6 +157,7 @@ function getCapabilityLines(context?: AgentContext): string[] {
       "Notities toevoegen aan kandidaatprofielen",
       "Kandidaten zoeken op vaardigheden, rol, naam of locatie",
       "Kandidaten en opdrachten matchen, inclusief structured matching",
+      "Interviewvoorbereiding opstellen met screeningvragen, scorecriteria en recruiter-notes (genereerInterviewPrep)",
       "Sollicitaties, interviews en berichten rondom kandidaten beheren",
       "GDPR-acties uitvoeren voor kandidaten en contactgegevens",
     ];
@@ -168,6 +175,7 @@ function getCapabilityLines(context?: AgentContext): string[] {
     "Sollicitaties aanmaken en door de pipeline verplaatsen",
     "Interviews plannen en bijwerken",
     "Berichten versturen en bekijken",
+    "Interviewvoorbereiding opstellen met screeningvragen, scorecriteria en recruiter-notes (genereerInterviewPrep)",
     "Data analyseren (tarieven, platforms, deadlines)",
     "Scrapers starten voor nieuwe opdrachten",
     "Batch import draaien over actieve scrapers (importeerOpdrachtenBatch)",
@@ -275,6 +283,7 @@ export function getRecruitmentTools(context?: AgentContext, cache?: ToolResultCa
       ...platformTools,
       ...matchTools,
       ...sollicitatieTools,
+      ...interviewPrepTools,
     } as typeof recruitmentTools;
   } else if (isKandidaatContext(context)) {
     selected = {
@@ -284,6 +293,7 @@ export function getRecruitmentTools(context?: AgentContext, cache?: ToolResultCa
       ...interviewTools,
       ...berichtTools,
       ...gdprTools,
+      ...interviewPrepTools,
     } as typeof recruitmentTools;
   } else {
     selected = recruitmentTools;
@@ -349,14 +359,7 @@ async function getWorkspaceContext(): Promise<{
   // Fetch settings and pipeline state in parallel, independent of the main summary
   const [settingsResult, pipelineResult] = await Promise.allSettled([
     getAllSettings(),
-    db
-      .select({
-        stage: applications.stage,
-        count: sql<number>`count(*)::int`,
-      })
-      .from(applications)
-      .where(isNull(applications.deletedAt))
-      .groupBy(applications.stage),
+    getApplicationStats(),
   ]);
 
   let settingsText = "";
@@ -367,10 +370,7 @@ async function getWorkspaceContext(): Promise<{
 
   let pipelineText = "";
   if (pipelineResult.status === "fulfilled") {
-    const byStage: Record<string, number> = {};
-    for (const row of pipelineResult.value) {
-      byStage[row.stage] = row.count;
-    }
+    const byStage = pipelineResult.value.byStage;
     const stageLabels: [string, string][] = [
       ["new", "nieuw"],
       ["screening", "screening"],
@@ -467,6 +467,13 @@ Matching configuratie: top ${workspace.settings?.autoMatchTopN ?? process.env.AU
 Zoektips: queryOpdrachten zoekt op losse woorden in de titel. Gebruik korte termen (bijv. "jurist" i.p.v. "juridische functies"). Voor semantisch zoeken gebruik semantischZoeken met een beschrijving of profiel, of matchKandidaten voor kandidaat-vacature matching.
 
 Tarief-vragen: Voor "hoogste tarief" of "duurste vacature" gebruik queryOpdrachten met sortBy="tarief_hoog" en limit=5 (ZONDER q). Voor tarief-statistieken gebruik analyseData met analysis="top_tarieven" of "avg_rates". Gebruik NOOIT rateMin/rateMax filters als de gebruiker alleen wil weten wat het hoogste/laagste tarief is.
+
+Voor requests om screeningvragen, interviewscorecards, intakebriefings of interviewvoorbereiding te maken:
+- stel eerst 3-5 verduidelijkende vragen voordat je een prep pakket genereert
+- gebruik pas daarna genereerInterviewPrep
+- als de tool status "needs_clarification" teruggeeft, stel precies die open punten eerst aan de gebruiker
+- gebruik AI alleen voor voorbereiding, vraagontwerp, samenvatting en aanbevelingen
+- laat AI nooit de definitieve hiring-beslissing of eindbeoordeling nemen
 ${workspace.text}`;
 
   // User context (entity references extracted from recent messages)

--- a/src/ai/tools/index.ts
+++ b/src/ai/tools/index.ts
@@ -12,6 +12,7 @@ export {
   wisKandidaatData,
 } from "./gdpr";
 export { getOpdrachtDetail } from "./get-opdracht-detail";
+export { genereerInterviewPrep } from "./interview-prep";
 // Interview tools
 export {
   getInterviewDetail,

--- a/src/ai/tools/interview-prep.ts
+++ b/src/ai/tools/interview-prep.ts
@@ -1,0 +1,14 @@
+import { tool } from "ai";
+import {
+  generateInterviewPrep,
+  interviewPrepGeneratorInputSchema,
+} from "@/src/services/interview-prep-generator";
+
+export const genereerInterviewPrep = tool({
+  description:
+    "Genereer interviewvoorbereiding voor recruiters, zoals screeningvragen, scorecriteria en recruiter-notes. Gebruik deze tool pas nadat je eerst 3-5 verduidelijkende vragen hebt gesteld. Als cruciale context ontbreekt, retourneert de tool verduidelijkingsvragen in plaats van direct een prep pakket.",
+  inputSchema: interviewPrepGeneratorInputSchema,
+  execute: async (input) => {
+    return generateInterviewPrep(input);
+  },
+});

--- a/src/services/interview-prep-generator.ts
+++ b/src/services/interview-prep-generator.ts
@@ -1,0 +1,261 @@
+import { z } from "zod";
+import { gemini31FlashLite, tracedGenerateObject as generateObject } from "../lib/ai-models";
+import { getCandidateById } from "./candidates";
+import { getJobById } from "./jobs";
+import { getMatchById } from "./matches";
+import { generateScreeningQuestions } from "./screening-calls";
+
+const SYSTEM_PROMPT = `Je bent een recruiter-copilot voor Motian en maakt interviewvoorbereiding voor vacatures, kandidaten en matches.
+
+Regels:
+- Schrijf alles in helder Nederlands.
+- Gebruik AI alleen voor interviewvoorbereiding, samenvatting en aanbevelingen.
+- Laat AI nooit de definitieve hiring-beslissing nemen.
+- Maak scorecriteria concreet en observeerbaar.
+- Zorg dat de output bruikbaar is voor recruiter-notes of latere writeback in Motian.`;
+
+export const interviewPrepGeneratorInputSchema = z.object({
+  request: z.string().min(1).describe("Korte omschrijving van het gewenste interviewprep pakket"),
+  jobId: z.string().uuid().optional(),
+  candidateId: z.string().uuid().optional(),
+  matchId: z.string().uuid().optional(),
+  jobSummary: z.string().optional(),
+  candidateSummary: z.string().optional(),
+  interviewType: z
+    .string()
+    .optional()
+    .describe("Bijv. screening, intake, klantinterview, technical"),
+  interviewGoal: z
+    .string()
+    .optional()
+    .describe("Wat moet het gesprek vooral uitwijzen of opleveren"),
+  focusAreas: z.array(z.string()).optional().describe("Belangrijkste thema's of risico's"),
+  answersSummary: z
+    .string()
+    .optional()
+    .describe("Samenvatting van verduidelijkende antwoorden uit het gesprek"),
+  constraints: z.string().optional(),
+});
+
+const scorecardCriterionSchema = z.object({
+  criterion: z.string(),
+  whatGoodLooksLike: z.string(),
+  redFlag: z.string(),
+});
+
+const readyArtifactSchema = z.object({
+  prepSummary: z.object({
+    interviewType: z.string(),
+    interviewGoal: z.string(),
+    recommendedDuration: z.string(),
+    contextSummary: z.string(),
+  }),
+  openingPrompt: z.string(),
+  mustAskQuestions: z.array(z.string()).min(4).max(8),
+  scorecardCriteria: z.array(scorecardCriterionSchema).min(3).max(6),
+  evidenceToCapture: z.array(z.string()).min(3).max(6),
+  recruiterNotes: z.array(z.string()).min(3).max(6),
+  humanGuardrails: z.array(z.string()).min(3).max(6),
+  writebackPayload: z.object({
+    type: z.literal("interview_prep_template"),
+    interviewType: z.string(),
+    linkedJobId: z.string().nullable(),
+    linkedCandidateId: z.string().nullable(),
+    linkedMatchId: z.string().nullable(),
+    mustAskQuestions: z.array(z.string()),
+    evidenceToCapture: z.array(z.string()),
+  }),
+});
+
+export const interviewPrepGeneratorOutputSchema = z.discriminatedUnion("status", [
+  z.object({
+    status: z.literal("needs_clarification"),
+    missingInformation: z.array(z.string()).min(1),
+    recommendedQuestions: z.array(z.string()).min(3).max(5),
+    nextStep: z.string(),
+  }),
+  z.object({
+    status: z.literal("ready"),
+    artifact: readyArtifactSchema,
+  }),
+]);
+
+export type InterviewPrepGeneratorInput = z.infer<typeof interviewPrepGeneratorInputSchema>;
+export type InterviewPrepGeneratorOutput = z.infer<typeof interviewPrepGeneratorOutputSchema>;
+
+const DETAIL_LABELS: Record<string, string> = {
+  context: "vacature-, kandidaat- of matchcontext",
+  interviewType: "interviewtype",
+  interviewGoal: "gespreksdoel",
+  focusAreas: "belangrijkste focusgebieden of risico's",
+};
+
+const DETAIL_QUESTIONS: Record<string, string> = {
+  context:
+    "Gaat dit interview over een specifieke vacature, kandidaat of match, en welke context moet ik meenemen?",
+  interviewType:
+    "Welk type gesprek is dit precies: screening, intake, klantinterview of technisch interview?",
+  interviewGoal:
+    "Wat moet dit gesprek vooral uitwijzen: motivatie, ervaring, skill-fit, tarief, beschikbaarheid of iets anders?",
+  focusAreas: "Welke risico's, competenties of thema's wil je expliciet toetsen in dit gesprek?",
+};
+
+function compactText(value?: string | null) {
+  return value?.trim() ?? "";
+}
+
+function cleanList(values?: string[]) {
+  return (values ?? []).map((value) => value.trim()).filter(Boolean);
+}
+
+function collectMissingDetails(input: InterviewPrepGeneratorInput) {
+  const missing: string[] = [];
+  const hasStructuredContext =
+    Boolean(input.jobId) ||
+    Boolean(input.candidateId) ||
+    Boolean(input.matchId) ||
+    Boolean(compactText(input.jobSummary)) ||
+    Boolean(compactText(input.candidateSummary));
+
+  if (!hasStructuredContext) missing.push("context");
+  if (!compactText(input.interviewType)) missing.push("interviewType");
+  if (!compactText(input.interviewGoal)) missing.push("interviewGoal");
+  if (cleanList(input.focusAreas).length === 0 && !compactText(input.answersSummary)) {
+    missing.push("focusAreas");
+  }
+
+  return missing;
+}
+
+function buildClarificationResponse(
+  missing: string[],
+): Extract<InterviewPrepGeneratorOutput, { status: "needs_clarification" }> {
+  const recommendedQuestions = missing
+    .slice(0, 5)
+    .map((key) => DETAIL_QUESTIONS[key] ?? key)
+    .filter(Boolean);
+
+  return {
+    status: "needs_clarification",
+    missingInformation: missing.map((key) => DETAIL_LABELS[key] ?? key),
+    recommendedQuestions:
+      recommendedQuestions.length >= 3
+        ? recommendedQuestions
+        : [
+            DETAIL_QUESTIONS.context,
+            DETAIL_QUESTIONS.interviewType,
+            DETAIL_QUESTIONS.interviewGoal,
+          ],
+    nextStep:
+      "Vraag eerst 3-5 verduidelijkende vragen, vat de antwoorden kort samen en genereer daarna pas de interviewvoorbereiding.",
+  };
+}
+
+function summarizeContext(params: {
+  jobSummary?: string;
+  candidateSummary?: string;
+  answersSummary?: string;
+  focusAreas: string[];
+}) {
+  return [
+    params.jobSummary ? `Vacaturecontext: ${params.jobSummary}` : null,
+    params.candidateSummary ? `Kandidaatcontext: ${params.candidateSummary}` : null,
+    params.answersSummary ? `Samenvatting: ${params.answersSummary}` : null,
+    params.focusAreas.length > 0 ? `Focusgebieden: ${params.focusAreas.join(", ")}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export async function generateInterviewPrep(
+  input: InterviewPrepGeneratorInput,
+): Promise<InterviewPrepGeneratorOutput> {
+  const parsed = interviewPrepGeneratorInputSchema.parse(input);
+  const missing = collectMissingDetails(parsed);
+
+  if (missing.length > 0) {
+    return buildClarificationResponse(missing);
+  }
+
+  const [job, candidate, match] = await Promise.all([
+    parsed.jobId ? getJobById(parsed.jobId) : Promise.resolve(null),
+    parsed.candidateId ? getCandidateById(parsed.candidateId) : Promise.resolve(null),
+    parsed.matchId ? getMatchById(parsed.matchId) : Promise.resolve(null),
+  ]);
+
+  const derivedJob = job ?? (match?.jobId ? await getJobById(match.jobId) : null);
+  const derivedCandidate =
+    candidate ?? (match?.candidateId ? await getCandidateById(match.candidateId) : null);
+
+  const screeningQuestions =
+    derivedCandidate || derivedJob || match
+      ? await generateScreeningQuestions(
+          (derivedCandidate ?? {}) as Record<string, unknown>,
+          (derivedJob ?? {}) as Record<string, unknown>,
+          (match ?? {}) as Record<string, unknown>,
+        )
+      : [];
+
+  const focusAreas = cleanList(parsed.focusAreas);
+  const contextSummary = summarizeContext({
+    jobSummary:
+      compactText(parsed.jobSummary) ||
+      (derivedJob
+        ? `${derivedJob.title}${derivedJob.company ? ` bij ${derivedJob.company}` : ""}${derivedJob.location ? ` in ${derivedJob.location}` : ""}`
+        : ""),
+    candidateSummary:
+      compactText(parsed.candidateSummary) ||
+      (derivedCandidate
+        ? `${derivedCandidate.name}${derivedCandidate.role ? `, ${derivedCandidate.role}` : ""}${derivedCandidate.location ? ` uit ${derivedCandidate.location}` : ""}`
+        : ""),
+    answersSummary: compactText(parsed.answersSummary),
+    focusAreas,
+  });
+
+  const seedQuestions = screeningQuestions.map((question) => question.question).slice(0, 5);
+
+  const result = await generateObject({
+    model: gemini31FlashLite,
+    schema: readyArtifactSchema,
+    system: SYSTEM_PROMPT,
+    prompt: `Maak een recruiter-ready interviewvoorbereiding voor Motian.
+
+Verzoek:
+${parsed.request}
+
+Interviewtype: ${compactText(parsed.interviewType)}
+Gespreksdoel: ${compactText(parsed.interviewGoal)}
+Constraints: ${compactText(parsed.constraints) || "geen extra constraints"}
+
+Context:
+${contextSummary || "Geen extra context"}
+
+Bestaande screeningvragen uit Motian:
+${seedQuestions.length > 0 ? seedQuestions.map((question) => `- ${question}`).join("\n") : "- geen"}
+
+Vereisten:
+1. Gebruik de context om het gesprek concreet te maken.
+2. Neem bestaande screeningvragen mee waar relevant, maar maak er een sterker interviewprep pakket van.
+3. Maak scorecriteria observeerbaar en praktisch voor recruiters.
+4. Neem expliciete human guardrails op: AI beslist nooit over hiring of eindbeoordeling.
+5. Maak een writebackPayload dat later in Motian-notes of interviewlogging gebruikt kan worden.`,
+    providerOptions: {
+      google: {
+        structuredOutputs: true,
+      },
+    },
+  });
+
+  return {
+    status: "ready",
+    artifact: {
+      ...result.object,
+      writebackPayload: {
+        ...result.object.writebackPayload,
+        linkedJobId: derivedJob?.id ?? parsed.jobId ?? null,
+        linkedCandidateId: derivedCandidate?.id ?? parsed.candidateId ?? null,
+        linkedMatchId: match?.id ?? parsed.matchId ?? null,
+      },
+    },
+  };
+}

--- a/tests/chat-interview-prep-surface.test.ts
+++ b/tests/chat-interview-prep-surface.test.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { InterviewPrepCard } from "@/components/chat/genui/interview-prep-card";
+
+const ROOT = path.resolve(__dirname, "..");
+
+function readFile(...segments: string[]) {
+  return fs.readFileSync(path.join(ROOT, ...segments), "utf8");
+}
+
+describe("interview prep chat surface", () => {
+  it("renders the clarification state in Dutch", () => {
+    const html = renderToStaticMarkup(
+      createElement(InterviewPrepCard, {
+        output: {
+          status: "needs_clarification",
+          missingInformation: ["interviewtype", "gespreksdoel"],
+          recommendedQuestions: [
+            "Welk type gesprek is dit precies?",
+            "Wat moet dit gesprek vooral uitwijzen?",
+            "Welke risico's wil je expliciet toetsen?",
+          ],
+          nextStep:
+            "Vraag eerst 3-5 verduidelijkende vragen, vat de antwoorden kort samen en genereer daarna pas de interviewvoorbereiding.",
+        },
+      }),
+    );
+
+    expect(html).toContain("Eerst verduidelijken");
+    expect(html).toContain("interviewtype");
+    expect(html).toContain("Welk type gesprek is dit precies?");
+  });
+
+  it("renders the ready state with scorecard and writeback payload", () => {
+    const html = renderToStaticMarkup(
+      createElement(InterviewPrepCard, {
+        output: {
+          status: "ready",
+          artifact: {
+            prepSummary: {
+              interviewType: "screening",
+              interviewGoal: "Toets sourcingdiepgang en stakeholderfit",
+              recommendedDuration: "30 minuten",
+              contextSummary: "Senior Recruiter bij Motian met matchscore 72%.",
+            },
+            openingPrompt: "Bedank de kandidaat en schets kort de focus van het gesprek.",
+            mustAskQuestions: [
+              "Kunt u uw sourcing-aanpak toelichten?",
+              "Hoe stemt u met hiring managers af?",
+              "Hoe prioriteert u vacatures?",
+              "Welke signalen gebruikt u om risico te zien?",
+            ],
+            scorecardCriteria: [
+              {
+                criterion: "Sourcingdiepgang",
+                whatGoodLooksLike: "Concreet proces met metrics",
+                redFlag: "Geen eigen aanpak",
+              },
+              {
+                criterion: "Stakeholdermanagement",
+                whatGoodLooksLike: "Beschrijft alignment en escalatie",
+                redFlag: "Geen voorbeelden van samenwerking",
+              },
+              {
+                criterion: "Tempo en prioritering",
+                whatGoodLooksLike: "Kan trade-offs helder uitleggen",
+                redFlag: "Onhelder over keuzes",
+              },
+            ],
+            evidenceToCapture: ["Concrete sourcingmetrics", "Beschikbaarheid", "Tariefverwachting"],
+            recruiterNotes: [
+              "Check of sourcingvoorbeelden echt eigen werk zijn.",
+              "Let op stakeholderconflicten.",
+              "Valideer beschikbaarheid tegen vacaturedruk.",
+            ],
+            humanGuardrails: [
+              "AI vat alleen samen en adviseert.",
+              "Hiring-beslissingen blijven menselijk.",
+              "Eindbeoordeling wordt niet door AI vastgesteld.",
+            ],
+            writebackPayload: {
+              type: "interview_prep_template",
+              interviewType: "screening",
+              linkedJobId: "job-1",
+              linkedCandidateId: "cand-1",
+              linkedMatchId: "match-1",
+              mustAskQuestions: ["Kunt u uw sourcing-aanpak toelichten?"],
+              evidenceToCapture: ["Concrete sourcingmetrics"],
+            },
+          },
+        },
+      }),
+    );
+
+    expect(html).toContain("Interviewprep: screening");
+    expect(html).toContain("Scorecardcriteria");
+    expect(html).toContain("Writeback payload");
+    expect(html).toContain("Recruiter-ready");
+  });
+
+  it("registers the GenUI card and keeps screening question discoverability in chat", () => {
+    const registrySource = readFile("components", "chat", "genui", "registry.ts");
+    const chatPageSource = readFile("components", "chat", "chat-page-content.tsx");
+
+    expect(registrySource).toContain("genereerInterviewPrep");
+    expect(registrySource).toContain('import("./interview-prep-card")');
+
+    expect(chatPageSource).toContain("Maak screeningvragen");
+    expect(chatPageSource).toContain("Schrijf 5 screeningvragen voor kandidaten op deze opdracht.");
+  });
+});

--- a/tests/interview-prep-generator.test.ts
+++ b/tests/interview-prep-generator.test.ts
@@ -1,0 +1,238 @@
+import { readFileSync } from "node:fs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  tracedGenerateObject,
+  getJobById,
+  getCandidateById,
+  getMatchById,
+  generateScreeningQuestions,
+} = vi.hoisted(() => ({
+  tracedGenerateObject: vi.fn(),
+  getJobById: vi.fn(),
+  getCandidateById: vi.fn(),
+  getMatchById: vi.fn(),
+  generateScreeningQuestions: vi.fn(),
+}));
+
+vi.mock("../src/lib/ai-models", () => ({
+  gemini31FlashLite: "gemini-3.1-flash-lite",
+  tracedGenerateObject,
+  embeddingModel: "openai-embedding-model",
+}));
+
+vi.mock("../src/services/jobs", () => ({
+  getJobById,
+}));
+
+vi.mock("../src/services/candidates", () => ({
+  getCandidateById,
+}));
+
+vi.mock("../src/services/matches", () => ({
+  getMatchById,
+}));
+
+vi.mock("../src/services/screening-calls", () => ({
+  generateScreeningQuestions,
+}));
+
+vi.mock("../src/services/applications", () => ({
+  getApplicationStats: vi.fn().mockResolvedValue({
+    byStage: { new: 0, screening: 0, interview: 0, offer: 0, hired: 0 },
+  }),
+}));
+
+vi.mock("../src/services/settings", () => ({
+  getAllSettings: vi.fn().mockResolvedValue({
+    minimumScoreThreshold: 60,
+    autoEnrichmentEnabled: true,
+    gdprRetentionDays: 365,
+    scoringSkillWeight: 40,
+    scoringLocationWeight: 20,
+    scoringRateWeight: 20,
+    scoringRoleWeight: 20,
+    autoMatchTopN: 3,
+    autoMatchMinScore: 25,
+  }),
+}));
+
+vi.mock("../src/services/workspace", () => ({
+  getWorkspaceSummary: vi.fn().mockResolvedValue({
+    jobs: { total: 10, withEmbedding: 5 },
+    candidates: { total: 4 },
+    matches: { total: 3, pending: 1 },
+    scraperHealth: {
+      overall: "gezond",
+      configuredPlatforms: 1,
+      supportedPlatforms: 1,
+      pendingOnboarding: 0,
+      platforms: [],
+      catalog: [],
+    },
+  }),
+}));
+
+vi.mock("../src/ai/user-context", () => ({
+  getUserContext: vi.fn().mockResolvedValue(null),
+}));
+
+import { buildSystemPrompt, getRecruitmentTools } from "../src/ai/agent";
+import { generateInterviewPrep } from "../src/services/interview-prep-generator";
+
+describe("generateInterviewPrep", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns clarification output when core interview context is missing", async () => {
+    const result = await generateInterviewPrep({
+      request: "Maak interviewvoorbereiding voor een recruiter",
+      interviewGoal: "Toets motivatie en beschikbaarheid",
+    });
+
+    expect(result.status).toBe("needs_clarification");
+    if (result.status === "needs_clarification") {
+      expect(result.missingInformation).toContain("vacature-, kandidaat- of matchcontext");
+      expect(result.recommendedQuestions.length).toBeGreaterThanOrEqual(3);
+      expect(result.nextStep).toContain("3-5 verduidelijkende vragen");
+    }
+    expect(tracedGenerateObject).not.toHaveBeenCalled();
+  });
+
+  it("uses live recruitment context and screening questions when enough detail is available", async () => {
+    getJobById.mockResolvedValue({
+      id: "11111111-1111-4111-8111-111111111111",
+      title: "Senior Recruiter",
+      company: "Motian",
+      location: "Amsterdam",
+      requirements: ["Stakeholdermanagement", "Sourcing"],
+    });
+    getCandidateById.mockResolvedValue({
+      id: "22222222-2222-4222-8222-222222222222",
+      name: "Jane Doe",
+      role: "Recruiter",
+      location: "Utrecht",
+      skills: ["Stakeholdermanagement", "ATS"],
+    });
+    getMatchById.mockResolvedValue({
+      id: "33333333-3333-4333-8333-333333333333",
+      jobId: "11111111-1111-4111-8111-111111111111",
+      candidateId: "22222222-2222-4222-8222-222222222222",
+      matchScore: 72,
+      riskProfile: { risks: [{ label: "Sourcing diepgang nog onduidelijk" }] },
+    });
+    generateScreeningQuestions.mockResolvedValue([
+      {
+        id: "q-1",
+        question: "Kunt u uw sourcing-aanpak toelichten?",
+        category: "ai_generated",
+        priority: 0,
+      },
+    ]);
+    tracedGenerateObject.mockResolvedValue({
+      object: {
+        prepSummary: {
+          interviewType: "screening",
+          interviewGoal: "Toets sourcingdiepgang en stakeholderfit",
+          recommendedDuration: "30 minuten",
+          contextSummary: "Senior Recruiter bij Motian met matchscore 72%.",
+        },
+        openingPrompt: "Bedank de kandidaat en schets kort de rol en de focus van het gesprek.",
+        mustAskQuestions: [
+          "Kunt u uw sourcing-aanpak toelichten?",
+          "Hoe stemt u met hiring managers af?",
+          "Hoe prioriteert u vacatures met meerdere stakeholders?",
+          "Welke signalen gebruikt u om pipeline-risico vroeg te zien?",
+        ],
+        scorecardCriteria: [
+          {
+            criterion: "Sourcingdiepgang",
+            whatGoodLooksLike: "Concreet proces met voorbeelden en metrics",
+            redFlag: "Blijft te algemeen of noemt geen eigen aanpak",
+          },
+          {
+            criterion: "Stakeholdermanagement",
+            whatGoodLooksLike: "Beschrijft verwachtingsmanagement en escalatie",
+            redFlag: "Geen voorbeelden van alignment met hiring managers",
+          },
+          {
+            criterion: "Tempo en prioritering",
+            whatGoodLooksLike: "Kan afwegingen onder druk helder uitleggen",
+            redFlag: "Onhelder over keuzes en trade-offs",
+          },
+        ],
+        evidenceToCapture: [
+          "Voorbeeld van een lastige vacature",
+          "Concrete sourcingmetrics",
+          "Beschikbaarheid en tariefverwachting",
+        ],
+        recruiterNotes: [
+          "Check of sourcingvoorbeelden echt eigen werk zijn.",
+          "Let op hoe de kandidaat stakeholderconflicten beschrijft.",
+          "Valideer of beschikbaarheid aansluit bij de vacature.",
+        ],
+        humanGuardrails: [
+          "AI vat alleen samen en adviseert.",
+          "Hiring-beslissingen blijven menselijk.",
+          "Eindbeoordeling wordt niet door AI vastgesteld.",
+        ],
+        writebackPayload: {
+          type: "interview_prep_template",
+          interviewType: "screening",
+          linkedJobId: null,
+          linkedCandidateId: null,
+          linkedMatchId: null,
+          mustAskQuestions: [
+            "Kunt u uw sourcing-aanpak toelichten?",
+            "Hoe stemt u met hiring managers af?",
+          ],
+          evidenceToCapture: ["Concrete sourcingmetrics", "Beschikbaarheid en tariefverwachting"],
+        },
+      },
+    });
+
+    const result = await generateInterviewPrep({
+      request: "Maak screeningvoorbereiding voor deze match",
+      jobId: "11111111-1111-4111-8111-111111111111",
+      candidateId: "22222222-2222-4222-8222-222222222222",
+      matchId: "33333333-3333-4333-8333-333333333333",
+      interviewType: "screening",
+      interviewGoal: "Toets sourcingdiepgang en stakeholderfit",
+      focusAreas: ["Sourcing", "Stakeholdermanagement"],
+      answersSummary: "Recruiter wil een compacte prep voor een eerste screening.",
+    });
+
+    expect(result.status).toBe("ready");
+    if (result.status !== "ready") throw new Error("Expected ready status");
+    expect(generateScreeningQuestions).toHaveBeenCalledTimes(1);
+    expect(tracedGenerateObject).toHaveBeenCalledTimes(1);
+    expect(result.artifact.writebackPayload.linkedJobId).toBe(
+      "11111111-1111-4111-8111-111111111111",
+    );
+    expect(result.artifact.writebackPayload.linkedCandidateId).toBe(
+      "22222222-2222-4222-8222-222222222222",
+    );
+    expect(result.artifact.mustAskQuestions[0]).toContain("sourcing");
+  });
+});
+
+describe("interview prep tool wiring", () => {
+  it("registers the interview prep tool in the recruitment tool map", () => {
+    const tools = getRecruitmentTools();
+    expect(tools).toHaveProperty("genereerInterviewPrep");
+  });
+
+  it("includes clarify-first recruiter interview guidance in the system prompt", async () => {
+    const prompt = await buildSystemPrompt({ sessionId: "sessie-1", turnCount: 1 });
+
+    expect(prompt).toContain("screeningvragen");
+    expect(prompt).toContain("genereerInterviewPrep");
+    expect(prompt).toContain("definitieve hiring-beslissing");
+  });
+
+  it("exports the interview prep tool from the AI tool index", () => {
+    const source = readFileSync(new URL("../src/ai/tools/index.ts", import.meta.url), "utf8");
+    expect(source).toContain('export { genereerInterviewPrep } from "./interview-prep";');
+  });
+});


### PR DESCRIPTION
## Summary
- add a Motian-native interview prep generator for recruiter chat workflows
- generate clarify-first screening questions, scorecard criteria, evidence capture, and recruiter notes from vacancy/candidate/match context
- render the output as a GenUI interview prep card and cover it with focused tests

## Verification
- pnpm lint
- pnpm vitest run tests/interview-prep-generator.test.ts tests/chat-interview-prep-surface.test.ts
- pnpm exec tsc --noEmit

## Notes
- kept the scope inside Motian recruiting workflows and reused existing screening-call question generation
- clean-worktree typecheck still surfaced pre-existing packages/db `pg` resolution issues, so the authoritative full verification was run in the main workspace before cherry-picking into this clean branch

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
