### PR TITLE
docs: add Striive write API discovery research log (RJC-54)

### DIFF
--- a/docs/research/striive-write-api.md
+++ b/docs/research/striive-write-api.md
@@ -1,0 +1,96 @@
+# Striive write API discovery (POST/PUT) — research log
+
+**Date:** 2026-04-09 (UTC)  
+**Issue:** RJC-54  
+**Goal:** Reverse-engineer write endpoints used by the Striive supplier portal when creating/editing job listings.
+
+## Executive summary
+
+I was **not able to directly capture Striive POST/PUT write calls** in this environment on 2026-04-09, because the portal and login hosts returned `403 Forbidden` to non-interactive CLI requests and no authenticated browser session (with valid supplier credentials + UI access) is available in this runtime.
+
+What is confirmed from code and previous integration work:
+
+- Read-only supplier API is already used at `GET https://supplier.striive.com/api/v2/job-requests`.
+- Detail reads are used at `GET https://supplier.striive.com/api/job-requests/{id}`.
+- Authentication is cookie/session-based after login via `https://login.striive.com`.
+- The current Motian scraper has no discovered write endpoint yet.
+
+## Evidence collected
+
+### 1) Network reachability from this runtime
+
+- `curl -I https://supplier.striive.com` → `HTTP/1.1 403 Forbidden`
+- `curl -I https://login.striive.com` → `HTTP/1.1 403 Forbidden`
+
+Because both hosts reject basic CLI probing from this runtime, endpoint discovery requires an interactive browser session that can pass Striive’s anti-bot/access controls.
+
+### 2) Existing Motian Striive integration (read path only)
+
+From the current scraper implementation:
+
+- `STRIIVE_API_LIST = "https://supplier.striive.com/api/v2/job-requests"`
+- `STRIIVE_API_DETAIL = "https://supplier.striive.com/api/job-requests"`
+- Login flow uses Playwright against `https://login.striive.com`, then reuses cookies for API calls.
+
+No POST/PUT endpoint constants or write payload builders are present in the current code.
+
+## Discovery matrix requested in issue
+
+## 1) Endpoint URLs (POST/PUT)
+
+**Status:** Not yet discovered in this environment.  
+**Required next capture:** DevTools Network or Playwright `context.on("request")` while creating/editing a vacancy in supplier UI.
+
+## 2) Request payload schema
+
+**Status:** Not yet discovered in this environment.  
+**Required next capture:** Raw request JSON body from create/edit flow (including nullable fields and enum-like fields).
+
+## 3) Response format
+
+**Status:** Not yet discovered in this environment.  
+**Required next capture:** Raw JSON response and status codes for successful create, validation error, and unauthorized/forbidden flows.
+
+## 4) Required auth headers
+
+**Current inference (high confidence from read flow):**
+
+- Session cookie authentication is required.
+- `Accept: application/json` works for read endpoints.
+- Additional CSRF/auth headers for write requests are **unknown** until create/edit capture is performed.
+
+## 5) Verify write permissions for `STRIIVE_USERNAME` / `STRIIVE_PASSWORD`
+
+**Status:** Not verifiable in this runtime due to missing authenticated interactive session and host-level `403` from CLI probes.  
+**Required next check:** Attempt create/edit in supplier UI with the production/intended credentials and inspect whether request returns `2xx`, `403`, or role/permission errors.
+
+## Recommended next execution plan (to unblock RJC-54 quickly)
+
+1. Run an authenticated browser session (local desktop or remote browser) and open DevTools Network tab.
+2. Perform both flows:
+   - Create new job listing (minimal required fields)
+   - Edit existing job listing (single-field patch)
+3. Export HAR and redact secrets.
+4. Record in this doc:
+   - Exact method + URL
+   - Request headers (especially CSRF/session headers)
+   - Request body schema with required/optional fields
+   - Response schema and error cases
+5. Add a tiny adapter contract note in `src/services/channel-adapters/striive.ts` once schema is stable.
+
+## Suggested capture checklist template
+
+Use this when doing the live capture:
+
+- **Operation:** create or edit
+- **Method/URL:**
+- **Auth primitives:** cookie names, CSRF header names, origin/referer requirements
+- **Body shape:** top-level keys, nested objects, enum values
+- **Validation errors:** field-level error format
+- **Success response:** ID fields, status fields, timestamps
+- **Rate limits:** any 429 behavior
+
+## Notes
+
+- This document is intentionally explicit about what was and was not confirmed on **2026-04-09** to avoid false certainty.
+- Once a real browser capture is available, replace all “not yet discovered” sections with concrete artifacts.

--- a/docs/research/striive-write-api.md
+++ b/docs/research/striive-write-api.md
@@ -1,96 +1,273 @@
 # Striive write API discovery (POST/PUT) — research log
 
-**Date:** 2026-04-09 (UTC)  
+**Date:** 2026-04-10 (UTC)
 **Issue:** RJC-54  
-**Goal:** Reverse-engineer write endpoints used by the Striive supplier portal when creating/editing job listings.
+**Goal:** Reverse-engineer write endpoints used by the Striive supplier portal when creating or editing job listings.
 
 ## Executive summary
 
-I was **not able to directly capture Striive POST/PUT write calls** in this environment on 2026-04-09, because the portal and login hosts returned `403 Forbidden` to non-interactive CLI requests and no authenticated browser session (with valid supplier credentials + UI access) is available in this runtime.
+I was able to run an authenticated browser session against Striive and capture the supplier portal traffic with the current Motian credentials.
 
-What is confirmed from code and previous integration work:
+Confirmed:
 
-- Read-only supplier API is already used at `GET https://supplier.striive.com/api/v2/job-requests`.
-- Detail reads are used at `GET https://supplier.striive.com/api/job-requests/{id}`.
-- Authentication is cookie/session-based after login via `https://login.striive.com`.
-- The current Motian scraper has no discovered write endpoint yet.
+- The current `STRIIVE_USERNAME` / `STRIIVE_PASSWORD` pair is valid for the Striive **supplier** portal.
+- The supplier SPA uses a same-origin API base of `/api` with cookie-backed auth and an `X-XSRF-TOKEN` header on observed `POST` requests.
+- The supplier role can access the dashboard, inbox (`Opdrachten`), individual job-request detail pages, employees, offers, and saved-search pages.
+- The supplier role reads opdrachten via:
+  - `GET https://supplier.striive.com/api/v2/job-requests`
+  - `GET https://supplier.striive.com/api/job-requests/{id}`
+  - `GET https://supplier.striive.com/api/job-requests?similar=true&jobRequestId={id}`
+- The only job-request `POST` observed in this role was view tracking:
+  - `POST https://supplier.striive.com/api/job-requests/log-view/{id}`
 
-## Evidence collected
+Not confirmed:
 
-### 1) Network reachability from this runtime
+- No `POST` / `PUT` / `PATCH` create-or-edit endpoint for job requests was exposed by the current supplier account.
+- Candidate create-style routes such as `/jobrequests/new`, `/jobrequests/create`, and `/dashboard/opdrachten/nieuw` all resolve back to the dashboard instead of opening an authoring screen.
+- No create/edit control is visible anywhere in the authenticated supplier UI.
 
-- `curl -I https://supplier.striive.com` → `HTTP/1.1 403 Forbidden`
-- `curl -I https://login.striive.com` → `HTTP/1.1 403 Forbidden`
+**Current conclusion:** the available credentials authenticate successfully, but they do **not** expose a job-listing authoring surface. For this account/role, Striive appears to be an inbox/bidding portal rather than a vacancy-posting portal.
 
-Because both hosts reject basic CLI probing from this runtime, endpoint discovery requires an interactive browser session that can pass Striive’s anti-bot/access controls.
+## Key runtime findings
 
-### 2) Existing Motian Striive integration (read path only)
+### 1) CLI probes were misleading; real browser access works
 
-From the current scraper implementation:
+Unauthenticated `curl -I` requests to `login.striive.com` and `supplier.striive.com` still return `403 Forbidden`, but a real Chromium session loads both portals successfully.
 
-- `STRIIVE_API_LIST = "https://supplier.striive.com/api/v2/job-requests"`
-- `STRIIVE_API_DETAIL = "https://supplier.striive.com/api/job-requests"`
-- Login flow uses Playwright against `https://login.striive.com`, then reuses cookies for API calls.
+That means endpoint discovery must be performed with a browser context, not bare HTTP probes.
 
-No POST/PUT endpoint constants or write payload builders are present in the current code.
+### 2) Supplier SPA configuration
 
-## Discovery matrix requested in issue
+The supplier frontend bundle exposes these relevant runtime settings:
 
-## 1) Endpoint URLs (POST/PUT)
+- `apiUrl: "/api"`
+- `withCredentialsInclusions: ["/api"]`
+- `websocketUrl: "wss://supplier.striive.com/api/ws/agreement"`
 
-**Status:** Not yet discovered in this environment.  
-**Required next capture:** DevTools Network or Playwright `context.on("request")` while creating/editing a vacancy in supplier UI.
+This confirms that authenticated supplier traffic is same-origin and cookie-backed rather than using the older read-only public path directly.
 
-## 2) Request payload schema
+## Authentication flow
 
-**Status:** Not yet discovered in this environment.  
-**Required next capture:** Raw request JSON body from create/edit flow (including nullable fields and enum-like fields).
+### Login portal bootstrap
 
-## 3) Response format
+When loading `https://login.striive.com/`, the browser performs:
 
-**Status:** Not yet discovered in this environment.  
-**Required next capture:** Raw JSON response and status codes for successful create, validation error, and unauthorized/forbidden flows.
+- `GET https://login.striive.com/api/auth/check-session`
 
-## 4) Required auth headers
+Observed unauthenticated response:
 
-**Current inference (high confidence from read flow):**
+- HTTP `401`
+- Empty body
 
-- Session cookie authentication is required.
-- `Accept: application/json` works for read endpoints.
-- Additional CSRF/auth headers for write requests are **unknown** until create/edit capture is performed.
+### Login request
 
-## 5) Verify write permissions for `STRIIVE_USERNAME` / `STRIIVE_PASSWORD`
+Observed login mutation:
 
-**Status:** Not verifiable in this runtime due to missing authenticated interactive session and host-level `403` from CLI probes.  
-**Required next check:** Attempt create/edit in supplier UI with the production/intended credentials and inspect whether request returns `2xx`, `403`, or role/permission errors.
+- `POST https://login.striive.com/api/auth/login`
 
-## Recommended next execution plan (to unblock RJC-54 quickly)
+Observed request headers:
 
-1. Run an authenticated browser session (local desktop or remote browser) and open DevTools Network tab.
-2. Perform both flows:
-   - Create new job listing (minimal required fields)
-   - Edit existing job listing (single-field patch)
-3. Export HAR and redact secrets.
-4. Record in this doc:
-   - Exact method + URL
-   - Request headers (especially CSRF/session headers)
-   - Request body schema with required/optional fields
-   - Response schema and error cases
-5. Add a tiny adapter contract note in `src/services/channel-adapters/striive.ts` once schema is stable.
+- `Accept: application/json, text/plain, */*`
+- `Content-Type: application/json`
+- `Referer: https://login.striive.com/`
+- `X-XSRF-TOKEN: <value from login.striive.com XSRF-TOKEN cookie>`
 
-## Suggested capture checklist template
+Observed request body schema:
 
-Use this when doing the live capture:
+```json
+{
+  "username": "<string>",
+  "password": "<string>"
+}
+```
 
-- **Operation:** create or edit
-- **Method/URL:**
-- **Auth primitives:** cookie names, CSRF header names, origin/referer requirements
-- **Body shape:** top-level keys, nested objects, enum values
-- **Validation errors:** field-level error format
-- **Success response:** ID fields, status fields, timestamps
-- **Rate limits:** any 429 behavior
+Observed response:
+
+- HTTP `200`
+- `Content-Type: application/json`
+- Browser redirects into `https://supplier.striive.com/dashboard`
+
+### Post-login cookies
+
+After successful login, the browser holds these auth-relevant cookies:
+
+- `SESSION` on `.striive.com` (`HttpOnly`, `Secure`, `SameSite=Lax`)
+- `XSRF-TOKEN` on `supplier.striive.com`
+- `XSRF-TOKEN` on `login.striive.com`
+
+### Authenticated user bootstrap
+
+The supplier app validates the session with:
+
+- `GET https://supplier.striive.com/api/auth/user`
+
+Observed response format:
+
+```json
+{
+  "id": 208802,
+  "userNames": {
+    "firstName": "<string>",
+    "fullName": "<string>",
+    "lastName": "<string>"
+  },
+  "emailAddress": "<string>",
+  "workPhoneNumber": "<string>",
+  "accountCreatedDate": "<string>",
+  "language": "NL",
+  "avatar": {
+    "full": "<string>"
+  }
+}
+```
+
+The app also loads:
+
+- `GET https://supplier.striive.com/api/company`
+
+Observed response characteristics:
+
+- HTTP `200`
+- JSON body
+- Includes `accountType`, address, `authorizedPersons`, and avatar metadata
+
+## Authenticated supplier pages and permissions
+
+Confirmed reachable pages with the current credentials:
+
+- `https://supplier.striive.com/dashboard`
+- `https://supplier.striive.com/inbox`
+- `https://supplier.striive.com/inbox/all/{jobRequestId}`
+- `https://supplier.striive.com/employees`
+- `https://supplier.striive.com/offers`
+- `https://supplier.striive.com/profile/search-commands`
+
+Visible top-level navigation in the supplier portal:
+
+- `Overzicht`
+- `Opdrachten`
+- `Professionals`
+- `Biedingen`
+- `Solutions`
+
+### Create/edit route probing
+
+I explicitly tested likely authoring routes after successful login:
+
+- `/jobrequests/new`
+- `/jobrequests/create`
+- `/dashboard/opdrachten/nieuw`
+
+Observed behavior for all of them:
+
+- Initial HTTP `200`
+- Final URL becomes `https://supplier.striive.com/dashboard`
+- Dashboard UI is shown instead of any create/edit form
+
+This is strong evidence that the current supplier role does **not** have a job-request authoring route.
+
+## Job-request API traffic observed
+
+### Inbox list
+
+The `Opdrachten` inbox uses:
+
+- `GET https://supplier.striive.com/api/v2/job-requests?page=0&size=1000&maxRadius=50&sortBy=&sortOrder=ASCENDING&clientNames=&professionalTypes=&remoteAllowed=&locations=&skills=`
+
+Related support calls on the page:
+
+- `GET https://supplier.striive.com/api/clients?withOpenJobRequests=true`
+- `GET https://supplier.striive.com/api/reference/regions?countryCode=NL&search=`
+- `GET https://supplier.striive.com/api/search-command`
+
+### Job-request detail
+
+Opening an opdracht detail page triggers:
+
+- `GET https://supplier.striive.com/api/job-requests/{id}`
+- `GET https://supplier.striive.com/api/job-requests?similar=true&jobRequestId={id}`
+- `POST https://supplier.striive.com/api/job-requests/log-view/{id}`
+
+Observed `POST /api/job-requests/log-view/{id}` request headers:
+
+- `Accept: application/json, text/plain, */*`
+- `Content-Type: application/json`
+- `Referer: https://supplier.striive.com/inbox/all/{id}`
+- `X-XSRF-TOKEN: <value from supplier.striive.com XSRF-TOKEN cookie>`
+
+Observed request body:
+
+```json
+293108
+```
+
+Observed response:
+
+- HTTP `200`
+- `Content-Type: application/json`
+- Response body is a full job-request JSON document (same shape as detail read response)
+
+This endpoint is a tracking/logging write, not a create/update mutation.
+
+## Discovery matrix requested in RJC-54
+
+### 1) Create/edit endpoint URLs
+
+**Status:** Not discovered.
+**Observed result:** No `POST` / `PUT` / `PATCH` create-or-edit job-request endpoint surfaced in the current supplier UI or route probing.
+
+### 2) Request payload schema
+
+**Status:** Not discovered for create/edit job requests.
+**Observed result:** No authoring request was triggered because no authoring UI is available to the current supplier account.
+
+### 3) Response format
+
+**Status:** Not discovered for create/edit job requests.
+**Observed result:** No create/edit response exists to capture in this role.
+
+### 4) Required auth headers
+
+**Confirmed for observed writes (`login`, `logout`, `log-view`):**
+
+- Session cookies are required.
+- `X-XSRF-TOKEN` is required on observed `POST` requests.
+- `Content-Type: application/json`
+- `Accept: application/json, text/plain, */*`
+- A same-origin `Referer` is present and likely expected.
+
+### 5) Do the current credentials have write permissions?
+
+**Answer:** Partially, but not for vacancy authoring.
+
+What the current credentials can do:
+
+- Successfully authenticate to the supplier portal
+- Read inbox job requests and detail payloads
+- Perform at least one same-origin POST (`/api/job-requests/log-view/{id}`), which confirms the session is valid for authenticated writes in principle
+
+What the current credentials do **not** expose:
+
+- Any visible UI to create or edit job requests
+- Any accessible create-style route for a new job request
+- Any observed `POST` / `PUT` / `PATCH` mutation endpoint that creates or edits a job request
+
+## Practical implication for Motian
+
+Motian's current Striive integration is aligned with the supplier role:
+
+- read opdrachten,
+- inspect details,
+- potentially respond/bid later through a different flow,
+- but **not** publish new vacancies into Striive.
+
+If auto-posting vacancies remains a product requirement, the missing piece is not browser automation quality anymore; it is **account role / portal type**. We likely need:
+
+1. employer-side Striive credentials (or a different Striive portal),
+2. or documentation that supplier accounts are intentionally read/inbox-only for job requests.
 
 ## Notes
 
-- This document is intentionally explicit about what was and was not confirmed on **2026-04-09** to avoid false certainty.
-- Once a real browser capture is available, replace all “not yet discovered” sections with concrete artifacts.
+- This document now reflects authenticated runtime evidence from 2026-04-10.
+- The earlier assumption that credentials were unavailable in-session was wrong; Vercel project linking and `vercel env pull .env.local` provided the required secrets.
+- No secret values are recorded here; only endpoint structure, header requirements, cookie names, and observed behavior are documented.


### PR DESCRIPTION
### Motivation
- Record the reverse-engineering status for the Striive supplier write API (POST/PUT) for issue `RJC-54`, capture current blockers (host-level `403` from this runtime) and provide a concrete checklist to unblock live capture.

### Description
- Add `docs/research/striive-write-api.md` containing the executive summary, evidence (read endpoints and cookie-based auth), network probing results, a discovery matrix for POST/PUT endpoints/payloads/response/auth, and a step-by-step DevTools/Playwright capture checklist and next steps.

### Testing
- Verified network probes with `curl -I https://supplier.striive.com` and `curl -I https://login.striive.com` (both returned `403 Forbidden`), and attempted `pnpm lint` which failed in this environment because the `biome` binary is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8070106848330bfedd9fca10e94c7)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a research log summarizing an authenticated browser-based investigation of the supplier portal API.
  * Documents that current credentials permit authenticated reads and a view-tracking POST action, but no job-request create/edit surfaces were discovered for this account/role.
  * Identifies gaps and next steps for further discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->