### PR TITLE
Simplify sidebar navigation to five primary destinations

### DIFF
--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -1,29 +1,19 @@
 "use client";
 
-import {
-  Briefcase,
-  Calendar,
-  Code,
-  GalleryVerticalEnd,
-  Kanban,
-  LayoutDashboard,
-  MessageCircle,
-  MessageSquare,
-  Search,
-  Tags,
-  Users,
-  Wrench,
-} from "lucide-react";
+import { GalleryVerticalEnd, Search } from "lucide-react";
 import type * as React from "react";
 
 import { NavMain } from "@/components/nav-main";
+import { OverflowNavMenu } from "@/components/nav-overflow-menu";
 import { NavUser } from "@/components/nav-user";
+import { PRIMARY_NAV_ITEMS } from "@/components/navigation-config";
 import { SidebarCvDropZone } from "@/components/sidebar-cv-drop-zone";
 import { TeamSwitcher } from "@/components/team-switcher";
 import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
+  SidebarGroup,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
@@ -31,96 +21,35 @@ import {
   SidebarRail,
 } from "@/components/ui/sidebar";
 
-const data = {
-  teams: [
-    {
-      name: "Motian",
-      logo: GalleryVerticalEnd,
-    },
-  ],
-  // Legacy navigation contract (structural test expectations):
-  // url: "/opdrachten"
-  // url: "/kandidaten"
-  navGroups: [
-    {
-      label: "Werving",
-      items: [
-        {
-          title: "Overzicht",
-          url: "/overzicht",
-          icon: LayoutDashboard,
-        },
-        {
-          title: "Vacatures",
-          url: "/vacatures",
-          icon: Briefcase,
-        },
-        {
-          title: "Kandidaten",
-          url: "/kandidaten",
-          icon: Users,
-        },
-        {
-          title: "Pipeline",
-          url: "/pipeline",
-          icon: Kanban,
-          prefetch: false,
-        },
-        {
-          title: "Vaardigheden",
-          url: "/vaardigheden",
-          icon: Tags,
-        },
-        {
-          title: "Interviews",
-          url: "/interviews",
-          icon: Calendar,
-        },
-        {
-          title: "Chat",
-          url: "/chat",
-          icon: MessageCircle,
-        },
-        {
-          title: "Berichten",
-          url: "/messages",
-          icon: MessageSquare,
-        },
-      ],
-    },
-    {
-      label: "Platform",
-      items: [
-        {
-          title: "Automatisering",
-          url: "/automatisering",
-          icon: Wrench,
-          matchPaths: ["/agents", "/autopilot", "/scraper"],
-        },
-      ],
-    },
-    {
-      label: "Ontwikkelaar",
-      items: [
-        {
-          title: "Ontwikkelaar",
-          url: "/ontwikkelaar",
-          icon: Code,
-          matchPaths: ["/api-docs"],
-        },
-      ],
-    },
-  ],
-};
+const teams = [
+  {
+    name: "Motian",
+    logo: GalleryVerticalEnd,
+  },
+];
+
+const navGroups = [
+  {
+    label: "Werving",
+    items: PRIMARY_NAV_ITEMS,
+  },
+] as const;
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarHeader>
-        <TeamSwitcher teams={data.teams} />
+        <TeamSwitcher teams={teams} />
       </SidebarHeader>
       <SidebarContent>
-        <NavMain groups={data.navGroups} />
+        <NavMain groups={[...navGroups]} />
+        <SidebarGroup className="pt-0">
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <OverflowNavMenu variant="sidebar" />
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarGroup>
       </SidebarContent>
       <SidebarCvDropZone />
       <SidebarFooter>

--- a/components/command-palette.tsx
+++ b/components/command-palette.tsx
@@ -1,25 +1,9 @@
 "use client";
 
-import {
-  Activity,
-  Briefcase,
-  Calendar,
-  Code,
-  FileJson,
-  GitCompareArrows,
-  Kanban,
-  LayoutDashboard,
-  type LucideIcon,
-  MessageSquare,
-  Plug,
-  Rss,
-  Settings,
-  Users,
-  Wrench,
-  Zap,
-} from "lucide-react";
+import { Zap } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
+import { COMMAND_PALETTE_PAGES } from "@/components/navigation-config";
 import {
   CommandDialog,
   CommandEmpty,
@@ -29,122 +13,6 @@ import {
   CommandList,
   CommandSeparator,
 } from "@/components/ui/command";
-
-interface PageEntry {
-  label: string;
-  href: string;
-  icon: LucideIcon;
-  group: string;
-  keywords?: string[];
-}
-
-const PAGES: PageEntry[] = [
-  {
-    label: "Overzicht",
-    href: "/overzicht",
-    icon: LayoutDashboard,
-    group: "Werving",
-    keywords: ["dashboard", "home", "start"],
-  },
-  {
-    label: "Vacatures",
-    href: "/vacatures",
-    icon: Briefcase,
-    group: "Werving",
-    keywords: ["jobs", "opdrachten", "werk"],
-  },
-  {
-    label: "Kandidaten",
-    href: "/kandidaten",
-    icon: Users,
-    group: "Werving",
-    keywords: ["talent", "cv", "sollicitant"],
-  },
-  {
-    label: "Pipeline",
-    href: "/pipeline",
-    icon: Kanban,
-    group: "Werving",
-    keywords: ["kanban", "status", "fase"],
-  },
-  {
-    label: "Interviews",
-    href: "/interviews",
-    icon: Calendar,
-    group: "Werving",
-    keywords: ["gesprekken", "agenda", "planning"],
-  },
-  {
-    label: "Berichten",
-    href: "/messages",
-    icon: MessageSquare,
-    group: "Werving",
-    keywords: ["communicatie", "email", "sms"],
-  },
-  {
-    label: "Automatisering",
-    href: "/automatisering",
-    icon: Wrench,
-    group: "Platform",
-    keywords: ["operaties", "tools", "automatisch"],
-  },
-  {
-    label: "Databronnen",
-    href: "/scraper",
-    icon: Activity,
-    group: "Operaties",
-    keywords: ["scraper", "bron", "import"],
-  },
-  {
-    label: "Matching",
-    href: "/matching",
-    icon: GitCompareArrows,
-    group: "Hulpmiddelen",
-    keywords: ["koppelen", "score"],
-  },
-  {
-    label: "AI Assistent",
-    href: "/chat",
-    icon: Zap,
-    group: "Hulpmiddelen",
-    keywords: ["chat", "ai", "vraag", "hulp"],
-  },
-  {
-    label: "Instellingen",
-    href: "/settings",
-    icon: Settings,
-    group: "Hulpmiddelen",
-    keywords: ["config", "profiel"],
-  },
-  {
-    label: "API Documentatie",
-    href: "/api-docs",
-    icon: FileJson,
-    group: "Ontwikkelaar",
-    keywords: ["api", "docs", "openapi", "swagger", "endpoints"],
-  },
-  {
-    label: "XML Feed",
-    href: "/api/salesforce-feed",
-    icon: Rss,
-    group: "Ontwikkelaar",
-    keywords: ["xml", "feed", "salesforce", "export"],
-  },
-  {
-    label: "MCP Server",
-    href: "/ontwikkelaar",
-    icon: Plug,
-    group: "Ontwikkelaar",
-    keywords: ["mcp", "protocol", "tools", "integratie", "ide"],
-  },
-  {
-    label: "OpenAPI Spec",
-    href: "/api/openapi",
-    icon: Code,
-    group: "Ontwikkelaar",
-    keywords: ["openapi", "json", "spec", "schema"],
-  },
-];
 
 export function CommandPalette() {
   const [open, setOpen] = useState(false);
@@ -175,7 +43,7 @@ export function CommandPalette() {
     router.push(href);
   }
 
-  const grouped = PAGES.reduce(
+  const grouped = COMMAND_PALETTE_PAGES.reduce(
     (acc, page) => {
       if (!acc[page.group]) {
         acc[page.group] = [];
@@ -183,7 +51,7 @@ export function CommandPalette() {
       acc[page.group].push(page);
       return acc;
     },
-    {} as Record<string, PageEntry[]>,
+    {} as Record<string, (typeof COMMAND_PALETTE_PAGES)[number][]>,
   );
 
   return (

--- a/components/mobile-bottom-nav.tsx
+++ b/components/mobile-bottom-nav.tsx
@@ -1,28 +1,12 @@
 "use client";
 
-import { Briefcase, Kanban, LayoutDashboard, MessageCircle, Users } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { isNavItemActive, PRIMARY_NAV_ITEMS } from "@/components/navigation-config";
 import { cn } from "@/lib/utils";
-
-const MOBILE_NAV_ITEMS = [
-  { href: "/overzicht", label: "Overzicht", icon: LayoutDashboard },
-  { href: "/vacatures", label: "Vacatures", icon: Briefcase },
-  { href: "/kandidaten", label: "Kandidaten", icon: Users },
-  { href: "/pipeline", label: "Pipeline", icon: Kanban },
-  { href: "/chat", label: "Chat", icon: MessageCircle },
-] as const;
-
-function isItemActive(pathname: string, href: string) {
-  return pathname === href || pathname.startsWith(`${href}/`);
-}
 
 export function MobileBottomNav() {
   const pathname = usePathname();
-
-  if (pathname.startsWith("/chat")) {
-    return null;
-  }
 
   return (
     <nav
@@ -30,14 +14,14 @@ export function MobileBottomNav() {
       className="fixed inset-x-0 bottom-0 z-40 border-t border-border/80 bg-background/95 pb-[max(0.25rem,env(safe-area-inset-bottom))] backdrop-blur supports-backdrop-filter:bg-background/80 md:hidden"
     >
       <ul className="grid grid-cols-5 gap-1 px-2 pt-1">
-        {MOBILE_NAV_ITEMS.map((item) => {
-          const active = isItemActive(pathname, item.href);
+        {PRIMARY_NAV_ITEMS.map((item) => {
+          const active = isNavItemActive(pathname, item);
           const Icon = item.icon;
 
           return (
-            <li key={item.href}>
+            <li key={item.url}>
               <Link
-                href={item.href}
+                href={item.url}
                 className={cn(
                   "flex min-h-14 flex-col items-center justify-center rounded-xl px-1 text-[11px] font-medium transition-colors",
                   active
@@ -47,7 +31,7 @@ export function MobileBottomNav() {
                 aria-current={active ? "page" : undefined}
               >
                 <Icon className="mb-0.5 h-4 w-4" />
-                <span className="truncate">{item.label}</span>
+                <span className="truncate">{item.title}</span>
               </Link>
             </li>
           );

--- a/components/nav-main.tsx
+++ b/components/nav-main.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import type { LucideIcon } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import type { NavigationItem } from "@/components/navigation-config";
+import { isNavItemActive } from "@/components/navigation-config";
 import { Badge } from "@/components/ui/badge";
 import {
   SidebarGroup,
@@ -12,19 +13,9 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 
-interface NavItem {
-  title: string;
-  url: string;
-  icon?: LucideIcon;
-  badge?: { text: string; variant: string };
-  prefetch?: boolean;
-  tooltip?: string;
-  matchPaths?: string[];
-}
-
 interface NavGroup {
   label: string;
-  items: NavItem[];
+  items: readonly NavigationItem[];
 }
 
 export function NavMain({ groups }: { groups: NavGroup[] }) {
@@ -37,13 +28,7 @@ export function NavMain({ groups }: { groups: NavGroup[] }) {
           <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
           <SidebarMenu>
             {group.items.map((item) => {
-              const isActive =
-                pathname === item.url ||
-                pathname.startsWith(`${item.url}/`) ||
-                item.matchPaths?.some(
-                  (matchPath) => pathname === matchPath || pathname.startsWith(`${matchPath}/`),
-                ) ||
-                false;
+              const isActive = isNavItemActive(pathname, item);
 
               return (
                 <SidebarMenuItem key={item.title}>
@@ -71,4 +56,3 @@ export function NavMain({ groups }: { groups: NavGroup[] }) {
     </>
   );
 }
-// trigger CI

--- a/components/nav-overflow-menu.tsx
+++ b/components/nav-overflow-menu.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { ChevronDown, MoreHorizontal } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  isAnyNavItemActive,
+  isNavItemActive,
+  MEER_NAV_ITEMS,
+} from "@/components/navigation-config";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { SidebarMenuButton, useSidebar } from "@/components/ui/sidebar";
+import { cn } from "@/lib/utils";
+
+interface OverflowNavMenuProps {
+  variant?: "sidebar" | "mobile";
+  className?: string;
+}
+
+export function OverflowNavMenu({ variant = "sidebar", className }: OverflowNavMenuProps) {
+  const pathname = usePathname();
+  const { isMobile } = useSidebar();
+  const isActive = isAnyNavItemActive(pathname, MEER_NAV_ITEMS);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        {variant === "sidebar" ? (
+          <SidebarMenuButton isActive={isActive} tooltip="Meer" className={className}>
+            <MoreHorizontal className="h-4 w-4" />
+            <span>Meer</span>
+            <ChevronDown className="ml-auto size-4 opacity-60 group-data-[collapsible=icon]:hidden" />
+          </SidebarMenuButton>
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className={cn(
+              "h-10 rounded-xl border border-border bg-background/95 px-3 shadow-sm",
+              isActive && "border-primary/40 bg-primary/10 text-primary",
+              className,
+            )}
+          >
+            <MoreHorizontal className="h-4 w-4" />
+            <span>Meer</span>
+          </Button>
+        )}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align={variant === "sidebar" && !isMobile ? "start" : "end"}
+        side={variant === "sidebar" && !isMobile ? "right" : "bottom"}
+        sideOffset={8}
+        className="w-56 rounded-xl"
+      >
+        <DropdownMenuLabel>Meer</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {MEER_NAV_ITEMS.map((item) => {
+          const itemActive = isNavItemActive(pathname, item);
+          const Icon = item.icon;
+
+          return (
+            <DropdownMenuItem
+              key={item.title}
+              asChild
+              className={itemActive ? "bg-accent text-accent-foreground font-medium" : undefined}
+            >
+              <Link href={item.url} aria-current={itemActive ? "page" : undefined}>
+                <Icon className="h-4 w-4" />
+                {item.title}
+              </Link>
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/components/navigation-config.ts
+++ b/components/navigation-config.ts
@@ -1,0 +1,202 @@
+import {
+  Bot,
+  Briefcase,
+  Calendar,
+  Database,
+  FileJson,
+  GitCompareArrows,
+  Kanban,
+  LayoutDashboard,
+  type LucideIcon,
+  MessageCircle,
+  MessageSquare,
+  Plug,
+  Rocket,
+  Rss,
+  Settings,
+  Tags,
+  Users,
+  Wrench,
+} from "lucide-react";
+
+export interface NavigationItem {
+  title: string;
+  url: string;
+  icon: LucideIcon;
+  badge?: { text: string; variant: string };
+  keywords?: string[];
+  matchPaths?: string[];
+  prefetch?: boolean;
+  tooltip?: string;
+}
+
+export interface CommandPalettePage {
+  label: string;
+  href: string;
+  icon: LucideIcon;
+  group: string;
+  keywords?: string[];
+}
+
+export const PRIMARY_NAV_ITEMS = [
+  {
+    title: "Overzicht",
+    url: "/overzicht",
+    icon: LayoutDashboard,
+    keywords: ["dashboard", "home", "start"],
+  },
+  {
+    title: "Vacatures",
+    url: "/vacatures",
+    icon: Briefcase,
+    keywords: ["jobs", "opdrachten", "werk"],
+    matchPaths: ["/opdrachten"],
+  },
+  {
+    title: "Kandidaten",
+    url: "/kandidaten",
+    icon: Users,
+    keywords: ["talent", "cv", "sollicitant"],
+  },
+  {
+    title: "Pipeline",
+    url: "/pipeline",
+    icon: Kanban,
+    keywords: ["kanban", "status", "fase"],
+    prefetch: false,
+  },
+  {
+    title: "Chat",
+    url: "/chat",
+    icon: MessageCircle,
+    keywords: ["chat", "ai", "assistent", "vraag", "hulp"],
+  },
+] as const satisfies readonly NavigationItem[];
+
+export const MEER_NAV_ITEMS = [
+  {
+    title: "Interviews",
+    url: "/interviews",
+    icon: Calendar,
+    keywords: ["gesprekken", "agenda", "planning"],
+  },
+  {
+    title: "Berichten",
+    url: "/messages",
+    icon: MessageSquare,
+    keywords: ["communicatie", "email", "sms"],
+  },
+  {
+    title: "Matching",
+    url: "/matching",
+    icon: GitCompareArrows,
+    keywords: ["koppelen", "score"],
+  },
+  {
+    title: "Agents",
+    url: "/agents",
+    icon: Bot,
+    keywords: ["agent", "workflow", "automatisering"],
+  },
+  {
+    title: "Autopilot",
+    url: "/autopilot",
+    icon: Rocket,
+    keywords: ["autopilot", "runs", "bewaking"],
+  },
+  {
+    title: "Databronnen",
+    url: "/scraper",
+    icon: Database,
+    keywords: ["scraper", "bron", "import"],
+  },
+] as const satisfies readonly NavigationItem[];
+
+function toCommandPalettePage(group: string, item: NavigationItem): CommandPalettePage {
+  return {
+    label: item.title,
+    href: item.url,
+    icon: item.icon,
+    group,
+    keywords: item.keywords,
+  };
+}
+
+const COMMAND_PALETTE_UTILITY_PAGES = [
+  {
+    label: "Automatisering",
+    href: "/automatisering",
+    icon: Wrench,
+    group: "Hulpmiddelen",
+    keywords: ["operaties", "tools", "automatisch"],
+  },
+  {
+    label: "Vaardigheden",
+    href: "/vaardigheden",
+    icon: Tags,
+    group: "Hulpmiddelen",
+    keywords: ["skills", "esco", "taxonomie"],
+  },
+  {
+    label: "Instellingen",
+    href: "/settings",
+    icon: Settings,
+    group: "Hulpmiddelen",
+    keywords: ["config", "profiel"],
+  },
+  {
+    label: "API Documentatie",
+    href: "/api-docs",
+    icon: FileJson,
+    group: "Ontwikkelaar",
+    keywords: ["api", "docs", "openapi", "swagger", "endpoints"],
+  },
+  {
+    label: "XML Feed",
+    href: "/api/salesforce-feed",
+    icon: Rss,
+    group: "Ontwikkelaar",
+    keywords: ["xml", "feed", "salesforce", "export"],
+  },
+  {
+    label: "MCP Server",
+    href: "/ontwikkelaar",
+    icon: Plug,
+    group: "Ontwikkelaar",
+    keywords: ["mcp", "protocol", "tools", "integratie", "ide"],
+  },
+  {
+    label: "OpenAPI Spec",
+    href: "/api/openapi",
+    icon: FileJson,
+    group: "Ontwikkelaar",
+    keywords: ["openapi", "json", "spec", "schema"],
+  },
+] as const satisfies readonly CommandPalettePage[];
+
+export const COMMAND_PALETTE_PAGES = [
+  ...PRIMARY_NAV_ITEMS.map((item) => toCommandPalettePage("Werving", item)),
+  ...MEER_NAV_ITEMS.map((item) => toCommandPalettePage("Meer", item)),
+  ...COMMAND_PALETTE_UTILITY_PAGES,
+] as const satisfies readonly CommandPalettePage[];
+
+export function isNavItemActive(
+  pathname: string,
+  item: Pick<NavigationItem, "url" | "matchPaths">,
+) {
+  return (
+    pathname === item.url ||
+    pathname.startsWith(`${item.url}/`) ||
+    item.matchPaths?.some(
+      (matchPath) => pathname === matchPath || pathname.startsWith(`${matchPath}/`),
+    ) ||
+    false
+  );
+}
+
+export function isAnyNavItemActive(
+  pathname: string,
+  items: readonly Pick<NavigationItem, "url" | "matchPaths">[],
+) {
+  return items.some((item) => isNavItemActive(pathname, item));
+}

--- a/components/sidebar-layout.tsx
+++ b/components/sidebar-layout.tsx
@@ -3,6 +3,7 @@
 import { Search } from "lucide-react";
 import { AppSidebar } from "@/components/app-sidebar";
 import { MobileBottomNav } from "@/components/mobile-bottom-nav";
+import { OverflowNavMenu } from "@/components/nav-overflow-menu";
 import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
@@ -18,6 +19,7 @@ export function SidebarLayout({ children }: { children: React.ReactNode }) {
               title="Navigatie openen of sluiten (⌘/Ctrl+B)"
             />
             <div className="flex-1" />
+            <OverflowNavMenu variant="mobile" />
             <button
               type="button"
               onClick={() => document.dispatchEvent(new CustomEvent("motian-command-palette-open"))}

--- a/scripts/harness/auto-resolve-threads.ts
+++ b/scripts/harness/auto-resolve-threads.ts
@@ -166,7 +166,9 @@ async function main(): Promise<void> {
 }
 
 // Only run when executed directly (not when imported in tests)
-const isDirectRun = process.argv[1]?.endsWith("auto-resolve-threads.ts") || process.argv[1]?.includes("auto-resolve-threads");
+const isDirectRun =
+  process.argv[1]?.endsWith("auto-resolve-threads.ts") ||
+  process.argv[1]?.includes("auto-resolve-threads");
 if (isDirectRun) {
   main().catch((err) => {
     console.error(`[auto-resolve-threads] Onverwerkte fout: ${err}`);

--- a/scripts/harness/pr-comment-writer.ts
+++ b/scripts/harness/pr-comment-writer.ts
@@ -43,12 +43,7 @@ function findMarkedComment(comments: GitHubComment[], marker: string): GitHubCom
   return comments.find((c) => c.body.includes(marker));
 }
 
-function createComment(
-  owner: string,
-  repo: string,
-  prNumber: number,
-  body: string,
-): GitHubComment {
+function createComment(owner: string, repo: string, prNumber: number, body: string): GitHubComment {
   const raw = execSync(
     `gh api -X POST repos/${owner}/${repo}/issues/${prNumber}/comments --field body='${escapeShellArg(body)}' --jq '{id: .id, body: .body}'`,
     { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },

--- a/scripts/harness/sha-discipline.ts
+++ b/scripts/harness/sha-discipline.ts
@@ -94,7 +94,12 @@ export function markStaleComments(
 // Main
 // ---------------------------------------------------------------------------
 
-export async function run(prNumber: number, newHeadSha: string, owner: string, repo: string): Promise<ShaDisciplineResult> {
+export async function run(
+  prNumber: number,
+  newHeadSha: string,
+  owner: string,
+  repo: string,
+): Promise<ShaDisciplineResult> {
   const comments = fetchComments(owner, repo, prNumber);
   const { toUpdate, skipped } = markStaleComments(comments, newHeadSha);
 
@@ -136,7 +141,8 @@ async function main(): Promise<void> {
 }
 
 // Only run when executed directly (not when imported in tests)
-const isDirectRun = process.argv[1]?.endsWith("sha-discipline.ts") || process.argv[1]?.includes("sha-discipline");
+const isDirectRun =
+  process.argv[1]?.endsWith("sha-discipline.ts") || process.argv[1]?.includes("sha-discipline");
 if (isDirectRun) {
   main().catch((err) => {
     console.error(`[sha-discipline] Onverwerkte fout: ${err}`);

--- a/tests/harness/auto-resolve-threads.test.ts
+++ b/tests/harness/auto-resolve-threads.test.ts
@@ -9,11 +9,7 @@ import { classifyThreads, run } from "@/scripts/harness/auto-resolve-threads";
 // Fixtures
 // ---------------------------------------------------------------------------
 
-function makeThread(
-  id: string,
-  isResolved: boolean,
-  logins: string[],
-) {
+function makeThread(id: string, isResolved: boolean, logins: string[]) {
   return {
     id,
     isResolved,
@@ -29,9 +25,7 @@ function makeThread(
 
 describe("classifyThreads", () => {
   it("classifies bot-only unresolved threads as botOnly", () => {
-    const threads = [
-      makeThread("T1", false, ["review-bot[bot]", "github-actions"]),
-    ];
+    const threads = [makeThread("T1", false, ["review-bot[bot]", "github-actions"])];
 
     const { botOnly, withHumans, alreadyResolved } = classifyThreads(threads);
 
@@ -42,9 +36,7 @@ describe("classifyThreads", () => {
   });
 
   it("classifies threads with human comments as withHumans", () => {
-    const threads = [
-      makeThread("T2", false, ["review-bot[bot]", "human-dev"]),
-    ];
+    const threads = [makeThread("T2", false, ["review-bot[bot]", "human-dev"])];
 
     const { botOnly, withHumans } = classifyThreads(threads);
 
@@ -54,9 +46,7 @@ describe("classifyThreads", () => {
   });
 
   it("classifies already-resolved threads separately", () => {
-    const threads = [
-      makeThread("T3", true, ["review-bot[bot]"]),
-    ];
+    const threads = [makeThread("T3", true, ["review-bot[bot]"])];
 
     const { botOnly, withHumans, alreadyResolved } = classifyThreads(threads);
 
@@ -76,10 +66,10 @@ describe("classifyThreads", () => {
 
   it("correctly handles mixed thread types", () => {
     const threads = [
-      makeThread("T4", false, ["ci-bot[bot]"]),                  // bot-only
-      makeThread("T5", false, ["ci-bot[bot]", "developer"]),     // has human
-      makeThread("T6", true, ["ci-bot[bot]"]),                   // already resolved
-      makeThread("T7", false, ["github-actions"]),               // bot-only (known bot)
+      makeThread("T4", false, ["ci-bot[bot]"]), // bot-only
+      makeThread("T5", false, ["ci-bot[bot]", "developer"]), // has human
+      makeThread("T6", true, ["ci-bot[bot]"]), // already resolved
+      makeThread("T7", false, ["github-actions"]), // bot-only (known bot)
     ];
 
     const { botOnly, withHumans, alreadyResolved } = classifyThreads(threads);
@@ -114,8 +104,8 @@ describe("run", () => {
     });
 
     mockExecSync
-      .mockReturnValueOnce(graphqlResponse)  // fetch threads
-      .mockReturnValueOnce("{}");            // resolve T10
+      .mockReturnValueOnce(graphqlResponse) // fetch threads
+      .mockReturnValueOnce("{}"); // resolve T10
 
     const result = await run(42, "TestOwner", "test-repo");
 
@@ -137,9 +127,7 @@ describe("run", () => {
   });
 
   it("does nothing when all threads are already resolved", async () => {
-    const threads = [
-      makeThread("T20", true, ["lint-bot[bot]"]),
-    ];
+    const threads = [makeThread("T20", true, ["lint-bot[bot]"])];
 
     const graphqlResponse = JSON.stringify({
       data: {

--- a/tests/harness/pr-comment-writer.test.ts
+++ b/tests/harness/pr-comment-writer.test.ts
@@ -96,7 +96,9 @@ describe("upsertPrComment", () => {
     // Verify the PATCH call references the correct comment ID
     expect(mockExecSync).toHaveBeenNthCalledWith(
       2,
-      expect.stringContaining(`-X PATCH repos/${BASE_OPTIONS.owner}/${BASE_OPTIONS.repo}/issues/comments/77`),
+      expect.stringContaining(
+        `-X PATCH repos/${BASE_OPTIONS.owner}/${BASE_OPTIONS.repo}/issues/comments/77`,
+      ),
       expect.any(Object),
     );
   });

--- a/tests/harness/sha-discipline.test.ts
+++ b/tests/harness/sha-discipline.test.ts
@@ -25,9 +25,7 @@ describe("markStaleComments", () => {
   const NEW_SHA = "abc1234";
 
   it("marks stale bot comments when SHA changes", () => {
-    const comments = [
-      makeComment(1, "Review feedback\n<!-- sha:oldsha999 -->", "some-app[bot]"),
-    ];
+    const comments = [makeComment(1, "Review feedback\n<!-- sha:oldsha999 -->", "some-app[bot]")];
 
     const { toUpdate, skipped } = markStaleComments(comments, NEW_SHA);
 
@@ -40,9 +38,7 @@ describe("markStaleComments", () => {
   });
 
   it("skips non-bot comments", () => {
-    const comments = [
-      makeComment(2, "Human review\n<!-- sha:oldsha999 -->", "human-reviewer"),
-    ];
+    const comments = [makeComment(2, "Human review\n<!-- sha:oldsha999 -->", "human-reviewer")];
 
     const { toUpdate, skipped } = markStaleComments(comments, NEW_SHA);
 
@@ -51,9 +47,7 @@ describe("markStaleComments", () => {
   });
 
   it("skips comments without SHA tags", () => {
-    const comments = [
-      makeComment(3, "Just a regular comment with no SHA tag", "some-app[bot]"),
-    ];
+    const comments = [makeComment(3, "Just a regular comment with no SHA tag", "some-app[bot]")];
 
     const { toUpdate, skipped } = markStaleComments(comments, NEW_SHA);
 
@@ -69,9 +63,7 @@ describe("markStaleComments", () => {
   });
 
   it("skips bot comments whose SHA already matches the new HEAD", () => {
-    const comments = [
-      makeComment(4, `Up-to-date\n<!-- sha:${NEW_SHA} -->`, "github-actions"),
-    ];
+    const comments = [makeComment(4, `Up-to-date\n<!-- sha:${NEW_SHA} -->`, "github-actions")];
 
     const { toUpdate, skipped } = markStaleComments(comments, NEW_SHA);
 
@@ -91,9 +83,7 @@ describe("markStaleComments", () => {
   });
 
   it("recognizes github-actions as a known bot", () => {
-    const comments = [
-      makeComment(6, "CI feedback\n<!-- sha:oldsha999 -->", "github-actions"),
-    ];
+    const comments = [makeComment(6, "CI feedback\n<!-- sha:oldsha999 -->", "github-actions")];
 
     const { toUpdate } = markStaleComments(comments, NEW_SHA);
 
@@ -139,9 +129,7 @@ describe("run", () => {
   });
 
   it("does nothing when all comments are up-to-date", async () => {
-    const comments = [
-      makeComment(20, "Current review\n<!-- sha:currentsha -->", "ci-bot[bot]"),
-    ];
+    const comments = [makeComment(20, "Current review\n<!-- sha:currentsha -->", "ci-bot[bot]")];
 
     mockExecSync.mockReturnValueOnce(JSON.stringify(comments));
 

--- a/tests/recruiter-dashboard-navigation.test.ts
+++ b/tests/recruiter-dashboard-navigation.test.ts
@@ -5,6 +5,8 @@ import {
   COMMAND_PALETTE_PAGES,
   MEER_NAV_ITEMS,
   PRIMARY_NAV_ITEMS,
+  isAnyNavItemActive,
+  isNavItemActive,
 } from "../components/navigation-config";
 
 const ROOT = path.resolve(__dirname, "..");
@@ -49,6 +51,24 @@ function collectRepositoryFiles(directory: string, files: string[] = []) {
 }
 
 describe("Recruiter-first navigation", () => {
+  it("covers direct helper matching for exact, nested, and alias paths", () => {
+    const vacaturesItem = PRIMARY_NAV_ITEMS.find((item) => item.title === "Vacatures");
+    const kandidatenItem = PRIMARY_NAV_ITEMS.find((item) => item.title === "Kandidaten");
+
+    expect(vacaturesItem).toBeDefined();
+    expect(kandidatenItem).toBeDefined();
+    expect(isNavItemActive("/vacatures", vacaturesItem!)).toBe(true);
+    expect(isNavItemActive("/vacatures/123", vacaturesItem!)).toBe(true);
+    expect(isNavItemActive("/opdrachten/123", vacaturesItem!)).toBe(true);
+    expect(isNavItemActive("/agents", kandidatenItem!)).toBe(false);
+  });
+
+  it("marks overflow routes active through the shared helper", () => {
+    expect(isAnyNavItemActive("/messages", MEER_NAV_ITEMS)).toBe(true);
+    expect(isAnyNavItemActive("/messages/thread-1", MEER_NAV_ITEMS)).toBe(true);
+    expect(isAnyNavItemActive("/settings", MEER_NAV_ITEMS)).toBe(false);
+  });
+
   it("defines a 5-item primary nav plus a 6-item Meer overflow", () => {
     expect(PRIMARY_NAV_ITEMS.map((item) => item.title)).toEqual([
       "Overzicht",

--- a/tests/recruiter-dashboard-navigation.test.ts
+++ b/tests/recruiter-dashboard-navigation.test.ts
@@ -1,6 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import {
+  COMMAND_PALETTE_PAGES,
+  MEER_NAV_ITEMS,
+  PRIMARY_NAV_ITEMS,
+} from "../components/navigation-config";
 
 const ROOT = path.resolve(__dirname, "..");
 const EXCLUDED_DIRECTORIES = new Set([".git", ".next", "coverage", "dist", "node_modules"]);
@@ -44,70 +49,70 @@ function collectRepositoryFiles(directory: string, files: string[] = []) {
 }
 
 describe("Recruiter-first navigation", () => {
-  it("keeps recruiter workflow routes prominent in the sidebar", () => {
-    const source = readFile("components", "app-sidebar.tsx");
+  it("defines a 5-item primary nav plus a 6-item Meer overflow", () => {
+    expect(PRIMARY_NAV_ITEMS.map((item) => item.title)).toEqual([
+      "Overzicht",
+      "Vacatures",
+      "Kandidaten",
+      "Pipeline",
+      "Chat",
+    ]);
+    expect(MEER_NAV_ITEMS.map((item) => item.title)).toEqual([
+      "Interviews",
+      "Berichten",
+      "Matching",
+      "Agents",
+      "Autopilot",
+      "Databronnen",
+    ]);
+    expect(PRIMARY_NAV_ITEMS.find((item) => item.title === "Pipeline")?.prefetch).toBe(false);
+    expect(PRIMARY_NAV_ITEMS.find((item) => item.title === "Vacatures")?.matchPaths).toContain(
+      "/opdrachten",
+    );
+  });
+
+  it("keeps the shell focused on primary nav plus an explicit overflow entry", () => {
+    const sidebarSource = readFile("components", "app-sidebar.tsx");
+    const overflowSource = readFile("components", "nav-overflow-menu.tsx");
+    const mobileNavSource = readFile("components", "mobile-bottom-nav.tsx");
+    const shellSource = readFile("components", "sidebar-layout.tsx");
+
+    expect(sidebarSource).toContain("PRIMARY_NAV_ITEMS");
+    expect(sidebarSource).toContain("OverflowNavMenu");
+    expect(overflowSource).toContain("MEER_NAV_ITEMS");
+    expect(overflowSource).toContain("isAnyNavItemActive(pathname, MEER_NAV_ITEMS)");
+    expect(mobileNavSource).toContain("PRIMARY_NAV_ITEMS");
+    expect(mobileNavSource).not.toContain('pathname.startsWith("/chat")');
+    expect(shellSource).toContain('<OverflowNavMenu variant="mobile"');
+  });
+
+  it("keeps command palette coverage for moved and utility destinations", () => {
     const commandPaletteSource = readFile("components", "command-palette.tsx");
-    const automationHubSource = readFile("app", "automatisering", "page.tsx");
+    const labels = COMMAND_PALETTE_PAGES.map((page) => page.label);
 
-    expect(source).toContain('title: "Overzicht"');
-    expect(source).toContain('title: "Vacatures"');
-    expect(source).toContain('title: "Kandidaten"');
-    expect(source).toContain('title: "Pipeline"');
-    expect(source).toContain('title: "Interviews"');
-    expect(source).toContain('title: "Berichten"');
-    expect(source).toContain('title: "Automatisering"');
-    expect(source).toContain('title: "Ontwikkelaar"');
-
-    expect(source).toContain('url: "/overzicht"');
-    expect(source).toContain('url: "/vacatures"');
-    expect(source).toContain('url: "/kandidaten"');
-    expect(source).toContain('url: "/pipeline"');
-    expect(source).toContain('url: "/interviews"');
-    expect(source).toContain('url: "/messages"');
-    expect(source).toContain('url: "/automatisering"');
-    expect(source).toContain('url: "/ontwikkelaar"');
-
-    expect(source).not.toContain('title: "Aanbevelingen"');
-    expect(source).not.toContain('title: "Matching"');
-    expect(source).not.toContain('title: "AI Assistent"');
-    expect(source).not.toContain('title: "Agents"');
-    expect(source).not.toContain('title: "Autopilot"');
-    expect(source).not.toContain('title: "Databronnen"');
-
-    expect(commandPaletteSource).toContain('label: "Automatisering"');
-    expect(commandPaletteSource).toContain('label: "Databronnen"');
-    expect(commandPaletteSource).toContain('label: "Matching"');
-    expect(commandPaletteSource).toContain('label: "AI Assistent"');
-    expect(commandPaletteSource).toContain('label: "API Documentatie"');
-    expect(commandPaletteSource).toContain('label: "XML Feed"');
-    expect(commandPaletteSource).toContain('label: "MCP Server"');
-    expect(commandPaletteSource).toContain('label: "OpenAPI Spec"');
-
-    expect(commandPaletteSource).not.toContain('label: "Agents"');
-    expect(commandPaletteSource).not.toContain('label: "Autopilot"');
-
-    expect(automationHubSource).not.toContain('title: "Agents"');
-    expect(automationHubSource).not.toContain('title: "Autopilot"');
-    expect(automationHubSource).not.toContain('href: "/agents"');
-    expect(automationHubSource).not.toContain('href: "/autopilot"');
-  });
-
-  it("keeps heavy pipeline visuals out of eager sidebar prefetches", () => {
-    const sidebarSource = readFile("components", "app-sidebar.tsx");
-    const navSource = readFile("components", "nav-main.tsx");
-
-    expect(sidebarSource).toContain('title: "Pipeline"');
-    expect(sidebarSource).toContain("prefetch: false");
-    expect(navSource).toContain("prefetch={item.prefetch}");
-  });
-
-  it("keeps Automatisering active for demoted operational pages", () => {
-    const sidebarSource = readFile("components", "app-sidebar.tsx");
-    const navSource = readFile("components", "nav-main.tsx");
-
-    expect(sidebarSource).toContain('matchPaths: ["/agents", "/autopilot", "/scraper"]');
-    expect(navSource).toContain("item.matchPaths?.some");
-    expect(navSource).toContain("pathname === matchPath");
+    expect(labels).toEqual(
+      expect.arrayContaining([
+        "Overzicht",
+        "Vacatures",
+        "Kandidaten",
+        "Pipeline",
+        "Chat",
+        "Interviews",
+        "Berichten",
+        "Matching",
+        "Agents",
+        "Autopilot",
+        "Databronnen",
+        "Automatisering",
+        "Vaardigheden",
+        "Instellingen",
+        "API Documentatie",
+        "XML Feed",
+        "MCP Server",
+        "OpenAPI Spec",
+      ]),
+    );
+    expect(commandPaletteSource).toContain("COMMAND_PALETTE_PAGES");
   });
 });
 

--- a/tests/recruiter-dashboard-navigation.test.ts
+++ b/tests/recruiter-dashboard-navigation.test.ts
@@ -3,10 +3,10 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   COMMAND_PALETTE_PAGES,
-  MEER_NAV_ITEMS,
-  PRIMARY_NAV_ITEMS,
   isAnyNavItemActive,
   isNavItemActive,
+  MEER_NAV_ITEMS,
+  PRIMARY_NAV_ITEMS,
 } from "../components/navigation-config";
 
 const ROOT = path.resolve(__dirname, "..");
@@ -55,12 +55,14 @@ describe("Recruiter-first navigation", () => {
     const vacaturesItem = PRIMARY_NAV_ITEMS.find((item) => item.title === "Vacatures");
     const kandidatenItem = PRIMARY_NAV_ITEMS.find((item) => item.title === "Kandidaten");
 
-    expect(vacaturesItem).toBeDefined();
-    expect(kandidatenItem).toBeDefined();
-    expect(isNavItemActive("/vacatures", vacaturesItem!)).toBe(true);
-    expect(isNavItemActive("/vacatures/123", vacaturesItem!)).toBe(true);
-    expect(isNavItemActive("/opdrachten/123", vacaturesItem!)).toBe(true);
-    expect(isNavItemActive("/agents", kandidatenItem!)).toBe(false);
+    if (!vacaturesItem || !kandidatenItem) {
+      throw new Error("Expected primary navigation items to include Vacatures and Kandidaten");
+    }
+
+    expect(isNavItemActive("/vacatures", vacaturesItem)).toBe(true);
+    expect(isNavItemActive("/vacatures/123", vacaturesItem)).toBe(true);
+    expect(isNavItemActive("/opdrachten/123", vacaturesItem)).toBe(true);
+    expect(isNavItemActive("/agents", kandidatenItem)).toBe(false);
   });
 
   it("marks overflow routes active through the shared helper", () => {

--- a/tests/sidebar-shell-top-bar.test.ts
+++ b/tests/sidebar-shell-top-bar.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { MEER_NAV_ITEMS, PRIMARY_NAV_ITEMS } from "../components/navigation-config";
 
 const ROOT = path.resolve(__dirname, "..");
 
@@ -32,7 +33,10 @@ describe("sidebar shell top-bar refactor", () => {
     const widgetSource = readFile("components", "chat", "chat-widget.tsx");
     const candidateDetailSource = readFile("app", "kandidaten", "[id]", "page.tsx");
 
-    expect(sidebarSource).toContain('title: "Interviews"');
+    expect(sidebarSource).toContain("PRIMARY_NAV_ITEMS");
+    expect(sidebarSource).toContain("OverflowNavMenu");
+    expect(PRIMARY_NAV_ITEMS.map((item) => item.title)).toContain("Chat");
+    expect(MEER_NAV_ITEMS.map((item) => item.title)).toContain("Interviews");
     expect(userSource).toContain("motian-chat-open");
     expect(userSource).toContain("⌘J");
     expect(candidateDetailSource).toContain("CandidateRecommendationPanel");


### PR DESCRIPTION
## Summary
- centralize recruiter navigation in one shared config for sidebar, mobile nav, and command palette
- collapse the desktop shell to five primary destinations plus a Meer overflow for secondary routes
- keep the mobile bottom nav aligned with the primary tabs, including an active Chat tab on `/chat`

## Validation
- `pnpm exec vitest run tests/recruiter-dashboard-navigation.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- Playwright screenshots on `/automatisering` and `/chat` with a temporary `DATABASE_URL` placeholder

## Notes
- Runtime browser evidence is embedded in the Linear workpad comment.
- Data-backed primary routes were not validated against a live Neon database in this workspace.

## Linear
- RJC-68

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added overflow navigation menu ("Meer") to access additional navigation items in sidebar and mobile layouts
  * Improved navigation consistency across desktop and mobile interfaces through centralized navigation configuration

* **Refactor**
  * Consolidated navigation definitions for improved maintainability and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->