### PR TITLE
RJC-61: decouple write latency from deferred embedding sync

### DIFF
--- a/app/api/feed/vacatures/route.ts
+++ b/app/api/feed/vacatures/route.ts
@@ -56,7 +56,6 @@ export async function GET(request: Request) {
       headers.set("Content-Type", "application/rss+xml; charset=utf-8");
       return new Response(toJobRss(feedJobs), { headers });
 
-    case "xml":
     default:
       headers.set("Content-Type", "application/xml; charset=utf-8");
       return new Response(toJobXml(feedJobs), { headers });

--- a/app/kandidaten/page.tsx
+++ b/app/kandidaten/page.tsx
@@ -1,4 +1,4 @@
-import { Euro, MapPin, Search, UserPlus, Users, Zap } from "lucide-react";
+import { Euro, LoaderCircle, MapPin, Search, UserPlus, Users, Zap } from "lucide-react";
 import Link from "next/link";
 import { Suspense } from "react";
 import { AddCandidateWizard } from "@/components/add-candidate-wizard";
@@ -210,6 +210,7 @@ async function KandidatenContent({ searchParams }: Props) {
           <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
             {candidateRows.map((candidate) => {
               const skills = Array.isArray(candidate.skills) ? (candidate.skills as string[]) : [];
+              const isIndexing = candidate.embedding == null;
 
               return (
                 <DraggableCandidate
@@ -235,6 +236,15 @@ async function KandidatenContent({ searchParams }: Props) {
                             className="shrink-0 text-[10px] capitalize border-border text-muted-foreground bg-transparent"
                           >
                             {candidate.source}
+                          </Badge>
+                        )}
+                        {isIndexing && (
+                          <Badge
+                            variant="outline"
+                            className="shrink-0 flex items-center gap-1 text-[10px] border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+                          >
+                            <LoaderCircle className="h-3 w-3 animate-spin" />
+                            Indexeren…
                           </Badge>
                         )}
                       </div>

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/components/job-list-item.tsx
+++ b/components/job-list-item.tsx
@@ -1,4 +1,12 @@
-import { ArrowRight, BriefcaseBusiness, Building2, Clock, MapPin, Users } from "lucide-react";
+import {
+  ArrowRight,
+  BriefcaseBusiness,
+  Building2,
+  Clock,
+  LoaderCircle,
+  MapPin,
+  Users,
+} from "lucide-react";
 import Link from "next/link";
 import { DroppableVacancy } from "@/components/droppable-vacancy";
 import { Badge } from "@/components/ui/badge";
@@ -16,6 +24,7 @@ interface JobListItemProps {
     workArrangement: string | null;
     contractType: string | null;
     applicationDeadline?: Date | string | null;
+    isIndexing?: boolean;
   };
   isActive: boolean;
   variant?: "compact" | "card";
@@ -172,6 +181,15 @@ export function JobListItem({
 
             <div className="mt-3 flex flex-col items-start gap-2.5 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
               <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+                {job.isIndexing ? (
+                  <Badge
+                    variant="outline"
+                    className="flex min-h-5 h-auto max-w-full items-center gap-1 whitespace-normal wrap-break-word rounded-md border-amber-500/20 bg-amber-500/10 px-2 py-1 text-[10px] font-medium text-amber-700 dark:text-amber-300"
+                  >
+                    <LoaderCircle className="h-2.5 w-2.5 animate-spin" />
+                    Indexeren…
+                  </Badge>
+                ) : null}
                 {job.contractType && (
                   <Badge
                     variant="outline"
@@ -236,6 +254,15 @@ export function JobListItem({
             >
               {job.platform}
             </Badge>
+            {job.isIndexing ? (
+              <Badge
+                variant="outline"
+                className="flex items-center gap-0.5 border-amber-500/20 bg-amber-500/10 px-1.5 py-0 text-[9px] text-amber-700 dark:text-amber-300"
+              >
+                <LoaderCircle className="h-2.5 w-2.5 animate-spin" />
+                Indexeren
+              </Badge>
+            ) : null}
             {deadlineMeta && (
               <Badge
                 variant="outline"

--- a/components/sidebar/sidebar-types.ts
+++ b/components/sidebar/sidebar-types.ts
@@ -15,6 +15,7 @@ export interface SidebarJob {
   applicationDeadline?: Date | string | null;
   pipelineCount?: number;
   hasPipeline?: boolean;
+  isIndexing?: boolean;
 }
 
 export interface SearchResponse {

--- a/scripts/harness/auto-resolve-threads.ts
+++ b/scripts/harness/auto-resolve-threads.ts
@@ -166,7 +166,9 @@ async function main(): Promise<void> {
 }
 
 // Only run when executed directly (not when imported in tests)
-const isDirectRun = process.argv[1]?.endsWith("auto-resolve-threads.ts") || process.argv[1]?.includes("auto-resolve-threads");
+const isDirectRun =
+  process.argv[1]?.endsWith("auto-resolve-threads.ts") ||
+  process.argv[1]?.includes("auto-resolve-threads");
 if (isDirectRun) {
   main().catch((err) => {
     console.error(`[auto-resolve-threads] Onverwerkte fout: ${err}`);

--- a/scripts/harness/pr-comment-writer.ts
+++ b/scripts/harness/pr-comment-writer.ts
@@ -43,12 +43,7 @@ function findMarkedComment(comments: GitHubComment[], marker: string): GitHubCom
   return comments.find((c) => c.body.includes(marker));
 }
 
-function createComment(
-  owner: string,
-  repo: string,
-  prNumber: number,
-  body: string,
-): GitHubComment {
+function createComment(owner: string, repo: string, prNumber: number, body: string): GitHubComment {
   const raw = execSync(
     `gh api -X POST repos/${owner}/${repo}/issues/${prNumber}/comments --field body='${escapeShellArg(body)}' --jq '{id: .id, body: .body}'`,
     { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },

--- a/scripts/harness/sha-discipline.ts
+++ b/scripts/harness/sha-discipline.ts
@@ -94,7 +94,12 @@ export function markStaleComments(
 // Main
 // ---------------------------------------------------------------------------
 
-export async function run(prNumber: number, newHeadSha: string, owner: string, repo: string): Promise<ShaDisciplineResult> {
+export async function run(
+  prNumber: number,
+  newHeadSha: string,
+  owner: string,
+  repo: string,
+): Promise<ShaDisciplineResult> {
   const comments = fetchComments(owner, repo, prNumber);
   const { toUpdate, skipped } = markStaleComments(comments, newHeadSha);
 
@@ -136,7 +141,8 @@ async function main(): Promise<void> {
 }
 
 // Only run when executed directly (not when imported in tests)
-const isDirectRun = process.argv[1]?.endsWith("sha-discipline.ts") || process.argv[1]?.includes("sha-discipline");
+const isDirectRun =
+  process.argv[1]?.endsWith("sha-discipline.ts") || process.argv[1]?.includes("sha-discipline");
 if (isDirectRun) {
   main().catch((err) => {
     console.error(`[sha-discipline] Onverwerkte fout: ${err}`);

--- a/src/lib/event-bus.ts
+++ b/src/lib/event-bus.ts
@@ -1,6 +1,8 @@
 // In-memory pub/sub event bus for SSE (Server-Sent Events).
 // Single-instance only — suitable for Vercel serverless with limited concurrency.
 
+import type { DeferredEmbeddingSyncPayload } from "../services/embedding";
+
 export type SSEEvent = {
   type: string;
   data: Record<string, unknown>;
@@ -30,5 +32,36 @@ export function publish(type: string, data: Record<string, unknown> = {}): void 
     } catch {
       listeners.delete(listener);
     }
+  }
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+export async function queueDeferredEmbeddingSync(
+  payload: DeferredEmbeddingSyncPayload,
+): Promise<void> {
+  publish("embedding:needed", payload);
+
+  let triggerTasks: typeof import("@trigger.dev/sdk").tasks;
+  try {
+    const sdk = await import("@trigger.dev/sdk");
+    triggerTasks = sdk.tasks;
+  } catch (error) {
+    const message = getErrorMessage(error);
+    console.error("[embedding] Trigger.dev SDK unavailable for deferred sync:", message);
+    publish("embedding:queue_failed", { ...payload, error: message });
+    return;
+  }
+
+  try {
+    const handle = await triggerTasks.trigger("defer-embedding-sync", payload);
+    publish("embedding:queued", { ...payload, runId: handle.id });
+  } catch (error) {
+    const message = getErrorMessage(error);
+    console.error("[embedding] Failed to queue deferred sync:", message);
+    publish("embedding:queue_failed", { ...payload, error: message });
   }
 }

--- a/src/services/candidates.ts
+++ b/src/services/candidates.ts
@@ -1,10 +1,12 @@
 import { createHash } from "node:crypto";
 import { and, db, desc, eq, inArray, isNull, sql } from "../db";
 import { candidateSkills, candidates } from "../db/schema";
+import { queueDeferredEmbeddingSync } from "../lib/event-bus";
 import { caseInsensitiveContains, escapeLike, toTsQueryInput } from "../lib/helpers";
 import { LIST_SLO_MS, logSlowQuery, SEARCH_SLO_MS } from "../lib/query-observability";
 import type { ParsedCV } from "../schemas/candidate-intelligence";
 import { emitAgentEvent } from "./agent-events";
+import { type EmbeddingStatus, withPendingEmbeddingStatus } from "./embedding";
 import { syncCandidateEscoSkills } from "./esco";
 import { searchCandidateIdsByTypesense } from "./search-index/typesense-search";
 import { deleteCandidatesByIds, upsertCandidatesByIds } from "./search-index/typesense-sync";
@@ -12,6 +14,7 @@ import { deleteCandidatesByIds, upsertCandidatesByIds } from "./search-index/typ
 // ========== Types ==========
 
 export type Candidate = typeof candidates.$inferSelect;
+export type CandidateMutationResult = Candidate & { embeddingStatus: EmbeddingStatus };
 
 export const CANDIDATE_MATCHING_STATUSES = ["open", "in_review", "linked", "no_match"] as const;
 
@@ -194,10 +197,7 @@ async function emitAutoMatchEventIfReady(candidate: Candidate): Promise<void> {
   }
 }
 
-async function runCandidateDerivedSync(candidateId: string): Promise<void> {
-  const candidate = await getCandidateById(candidateId);
-  if (!candidate) return;
-
+async function runCandidateEscoSync(candidate: Candidate): Promise<void> {
   try {
     await syncCandidateEscoSkills({
       candidateId: candidate.id,
@@ -206,19 +206,6 @@ async function runCandidateDerivedSync(candidateId: string): Promise<void> {
     });
   } catch (err) {
     console.error(`[Candidates] ESCO sync error for ${candidate.id}:`, err);
-  }
-
-  try {
-    const { embedCandidate } = await import("./embedding");
-    await embedCandidate(candidate.id);
-  } catch (err) {
-    console.error(`[Candidates] Embedding error for ${candidate.id}:`, err);
-  }
-
-  try {
-    await upsertCandidatesByIds([candidate.id]);
-  } catch (err) {
-    console.error(`[Candidates] Typesense sync error for ${candidate.id}:`, err);
   }
 }
 
@@ -350,7 +337,7 @@ export async function countCandidates(
 }
 
 /** Nieuwe kandidaat aanmaken en teruggeven. Genereert embedding op de achtergrond. */
-export async function createCandidate(data: CreateCandidateData): Promise<Candidate> {
+export async function createCandidate(data: CreateCandidateData): Promise<CandidateMutationResult> {
   const rows = await db
     .insert(candidates)
     .values({
@@ -373,17 +360,22 @@ export async function createCandidate(data: CreateCandidateData): Promise<Candid
     .returning();
 
   const candidate = rows[0];
-  await runCandidateDerivedSync(candidate.id);
+  await runCandidateEscoSync(candidate);
+  void queueDeferredEmbeddingSync({
+    entityType: "candidate",
+    entityId: candidate.id,
+    source: "candidate:create",
+  });
   await emitAutoMatchEventIfReady(candidate);
 
-  return candidate;
+  return withPendingEmbeddingStatus(candidate);
 }
 
 /** Kandidaat bijwerken en teruggeven, of null als niet gevonden. */
 export async function updateCandidate(
   id: string,
   data: Partial<CreateCandidateData>,
-): Promise<Candidate | null> {
+): Promise<CandidateMutationResult | null> {
   const rows = await db
     .update(candidates)
     .set({
@@ -395,10 +387,15 @@ export async function updateCandidate(
 
   const candidate = rows[0] ?? null;
   if (!candidate) return null;
-  await runCandidateDerivedSync(candidate.id);
+  await runCandidateEscoSync(candidate);
+  void queueDeferredEmbeddingSync({
+    entityType: "candidate",
+    entityId: candidate.id,
+    source: "candidate:update",
+  });
   await emitAutoMatchEventIfReady(candidate);
 
-  return candidate;
+  return withPendingEmbeddingStatus(candidate);
 }
 
 export async function updateCandidateMatchingStatus(
@@ -552,7 +549,7 @@ export async function enrichCandidateFromCV(
   parsed: ParsedCV,
   resumeRaw: string,
   resumeUrl?: string,
-): Promise<Candidate | null> {
+): Promise<CandidateMutationResult | null> {
   const existing = await getCandidateById(candidateId);
   if (!existing) return null;
 
@@ -599,8 +596,12 @@ export async function enrichCandidateFromCV(
   const candidate = rows[0] ?? null;
   if (!candidate) return null;
 
-  // Reuse full derived sync (ESCO + embedding + Typesense) for consistency
-  await runCandidateDerivedSync(candidate.id);
+  await runCandidateEscoSync(candidate);
+  void queueDeferredEmbeddingSync({
+    entityType: "candidate",
+    entityId: candidate.id,
+    source: "candidate:cv-enrichment",
+  });
 
-  return candidate;
+  return withPendingEmbeddingStatus(candidate);
 }

--- a/src/services/embedding.ts
+++ b/src/services/embedding.ts
@@ -6,6 +6,7 @@ import {
   tracedEmbedMany as embedMany,
 } from "../lib/ai-models";
 import { withRetry } from "../lib/retry";
+import { upsertCandidatesByIds, upsertJobsByIds } from "./search-index/typesense-sync";
 
 // ========== Config ==========
 
@@ -23,6 +24,22 @@ const QUERY_EMBEDDING_CACHE_MAX_ENTRIES = 256;
 type CachedQueryEmbedding = {
   embedding: number[];
   expiresAt: number;
+};
+
+export type EmbeddingStatus = "pending" | "ready";
+
+export type DeferredEmbeddingEntityType = "candidate" | "job";
+
+export type DeferredEmbeddingSyncPayload = {
+  entityType: DeferredEmbeddingEntityType;
+  entityId: string;
+  source?: string;
+};
+
+export type DeferredEmbeddingSyncResult = DeferredEmbeddingSyncPayload & {
+  embedded: boolean;
+  indexed: boolean;
+  embeddingStatus: EmbeddingStatus;
 };
 
 const queryEmbeddingCache = new Map<string, CachedQueryEmbedding>();
@@ -95,6 +112,39 @@ function setCachedQueryEmbedding(key: string, embedding: number[]) {
     if (!oldestKey) break;
     queryEmbeddingCache.delete(oldestKey);
   }
+}
+
+export function getEmbeddingStatusFromValue(embedding: unknown): EmbeddingStatus {
+  return embedding == null ? "pending" : "ready";
+}
+
+export function withPendingEmbeddingStatus<T extends Record<string, unknown>>(
+  record: T,
+): T & { embeddingStatus: "pending" } {
+  return {
+    ...record,
+    embeddingStatus: "pending",
+  };
+}
+
+async function getCandidateEmbeddingStatus(candidateId: string): Promise<EmbeddingStatus> {
+  const [row] = await db
+    .select({ embedding: candidates.embedding })
+    .from(candidates)
+    .where(and(eq(candidates.id, candidateId), isNull(candidates.deletedAt)))
+    .limit(1);
+
+  return getEmbeddingStatusFromValue(row?.embedding ?? null);
+}
+
+async function getJobEmbeddingStatus(jobId: string): Promise<EmbeddingStatus> {
+  const [row] = await db
+    .select({ embedding: jobs.embedding })
+    .from(jobs)
+    .where(eq(jobs.id, jobId))
+    .limit(1);
+
+  return getEmbeddingStatusFromValue(row?.embedding ?? null);
 }
 
 // ========== Text Preparation ==========
@@ -328,6 +378,35 @@ export async function embedCandidate(candidateId: string): Promise<boolean> {
     .where(eq(candidates.id, candidateId));
 
   return true;
+}
+
+export async function runDeferredEmbeddingSync(
+  payload: DeferredEmbeddingSyncPayload,
+): Promise<DeferredEmbeddingSyncResult> {
+  switch (payload.entityType) {
+    case "candidate": {
+      const embedded = await embedCandidate(payload.entityId);
+      await upsertCandidatesByIds([payload.entityId]);
+
+      return {
+        ...payload,
+        embedded,
+        indexed: true,
+        embeddingStatus: await getCandidateEmbeddingStatus(payload.entityId),
+      };
+    }
+    case "job": {
+      const embedded = await embedJob(payload.entityId);
+      await upsertJobsByIds([payload.entityId]);
+
+      return {
+        ...payload,
+        embedded,
+        indexed: true,
+        embeddingStatus: await getJobEmbeddingStatus(payload.entityId),
+      };
+    }
+  }
 }
 
 // ========== Backfill Candidate Embeddings ==========

--- a/src/services/jobs/deduplication.ts
+++ b/src/services/jobs/deduplication.ts
@@ -303,6 +303,7 @@ export async function loadJobPageRowsByIds(ids: string[]) {
       contractType: jobs.contractType,
       applicationDeadline: jobs.applicationDeadline,
       pipelineCount: sql<number>`coalesce(${pipelineCounts.pipelineCount}, 0)::int`,
+      isIndexing: sql<boolean>`${jobs.embedding} is null`,
     })
     .from(jobs)
     .leftJoin(pipelineCounts, sql`${pipelineCounts.jobId} = ${jobs.id}`)

--- a/src/services/jobs/page-query.ts
+++ b/src/services/jobs/page-query.ts
@@ -29,6 +29,7 @@ export type JobPageRow = {
   applicationDeadline: Date | null;
   hasPipeline: boolean;
   pipelineCount: number;
+  isIndexing: boolean;
 };
 
 export type ListJobsPageOptions = SearchJobsOptions &

--- a/src/services/jobs/repository.ts
+++ b/src/services/jobs/repository.ts
@@ -1,9 +1,12 @@
 import { and, db, eq, getTableColumns, isNotNull, ne, or, type SQL, sql } from "../../db";
 import { jobs } from "../../db/schema";
-import { deleteJobsByIds, upsertJobsByIds } from "../search-index/typesense-sync";
+import { queueDeferredEmbeddingSync } from "../../lib/event-bus";
+import { type EmbeddingStatus, withPendingEmbeddingStatus } from "../embedding";
+import { deleteJobsByIds } from "../search-index/typesense-sync";
 import { scheduleDedupeRanksRefresh } from "./dedupe-ranks";
 
 export type Job = typeof jobs.$inferSelect;
+export type JobMutationResult = Job & { embeddingStatus: EmbeddingStatus };
 
 function getNormalizedCompatibilityExpression(value: SQL) {
   return sql<string>`trim(regexp_replace(lower(coalesce(${value}, '')), '[^[:alnum:]]+', ' ', 'g'))`;
@@ -40,16 +43,6 @@ export function getJobReadSelection() {
 
 export const jobReadSelection = getJobReadSelection();
 
-async function runJobDerivedSync(jobId: string): Promise<void> {
-  try {
-    await upsertJobsByIds([jobId]);
-  } catch (err) {
-    console.error(`[Jobs] Typesense sync error for ${jobId}:`, err);
-  }
-
-  scheduleDedupeRanksRefresh();
-}
-
 async function runJobDeleteSync(jobIds: string[]): Promise<void> {
   if (jobIds.length === 0) return;
 
@@ -83,7 +76,7 @@ export async function updateJob(
       | "workArrangement"
     >
   >,
-): Promise<Job | null> {
+): Promise<JobMutationResult | null> {
   type JobSearchHelperUpdate = {
     dedupeLocationNormalized?: SQL<string>;
     dedupeTitleNormalized?: SQL<string>;
@@ -128,10 +121,15 @@ export async function updateJob(
     .returning(getJobReadSelection());
 
   if (rows[0]?.id) {
-    await runJobDerivedSync(rows[0].id);
+    scheduleDedupeRanksRefresh();
+    void queueDeferredEmbeddingSync({
+      entityType: "job",
+      entityId: rows[0].id,
+      source: "job:update",
+    });
   }
 
-  return rows[0] ?? null;
+  return rows[0] ? withPendingEmbeddingStatus(rows[0]) : null;
 }
 
 /** Opdracht verrijken met AI-geëxtraheerde data. Retourneert bijgewerkte job of null. */
@@ -150,7 +148,7 @@ export async function updateJobEnrichment(
       | "categories"
     >
   >,
-): Promise<Job | null> {
+): Promise<JobMutationResult | null> {
   const rows = await db
     .update(jobs)
     .set(data)
@@ -158,10 +156,15 @@ export async function updateJobEnrichment(
     .returning(getJobReadSelection());
 
   if (rows[0]?.id) {
-    await runJobDerivedSync(rows[0].id);
+    scheduleDedupeRanksRefresh();
+    void queueDeferredEmbeddingSync({
+      entityType: "job",
+      entityId: rows[0].id,
+      source: "job:enrichment",
+    });
   }
 
-  return rows[0] ?? null;
+  return rows[0] ? withPendingEmbeddingStatus(rows[0]) : null;
 }
 
 /** Handmatig een vacature aanmaken. Retourneert de nieuwe job. */
@@ -183,14 +186,19 @@ export async function createJob(
         | "hoursPerWeek"
       >
     >,
-): Promise<Job> {
+): Promise<JobMutationResult> {
   const rows = await db.insert(jobs).values(data).returning(getJobReadSelection());
 
   if (rows[0]?.id) {
-    await runJobDerivedSync(rows[0].id);
+    scheduleDedupeRanksRefresh();
+    void queueDeferredEmbeddingSync({
+      entityType: "job",
+      entityId: rows[0].id,
+      source: "job:create",
+    });
   }
 
-  return rows[0];
+  return withPendingEmbeddingStatus(rows[0]);
 }
 
 /** Opdracht archiveren. Retourneert true als de status is bijgewerkt. */

--- a/tests/candidate-auto-match-event.test.ts
+++ b/tests/candidate-auto-match-event.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------- Mocks (hoisted) ----------
 
-const { mockDb, mockEmitAgentEvent } = vi.hoisted(() => {
+const { mockDb, mockEmitAgentEvent, mockQueueDeferredEmbeddingSync } = vi.hoisted(() => {
   const mockInsert = vi.fn();
   const mockUpdate = vi.fn();
   const mockSelect = vi.fn();
@@ -26,6 +26,7 @@ const { mockDb, mockEmitAgentEvent } = vi.hoisted(() => {
       returning: returningFn,
     },
     mockEmitAgentEvent: vi.fn().mockResolvedValue({ id: "evt-1" }),
+    mockQueueDeferredEmbeddingSync: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -60,13 +61,13 @@ vi.mock("../src/services/agent-events", () => ({
   emitAgentEvent: mockEmitAgentEvent,
 }));
 
-// Mock derived sync dependencies (ESCO, embedding, Typesense) as no-ops
-vi.mock("../src/services/esco", () => ({
-  syncCandidateEscoSkills: vi.fn().mockResolvedValue(undefined),
+vi.mock("../src/lib/event-bus", () => ({
+  queueDeferredEmbeddingSync: mockQueueDeferredEmbeddingSync,
 }));
 
-vi.mock("../src/services/embedding", () => ({
-  embedCandidate: vi.fn().mockResolvedValue(undefined),
+// Mock remaining synchronous derived sync dependency as a no-op
+vi.mock("../src/services/esco", () => ({
+  syncCandidateEscoSkills: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("../src/services/search-index/typesense-sync", () => ({
@@ -124,18 +125,18 @@ describe("candidate auto-match event emission", () => {
 
     // Mock: insert().values().returning() → [fakeCandidate]
     mockDb.returning.mockResolvedValueOnce([fakeCandidate]);
-    // Mock: select().from().where().limit() for getCandidateById in runCandidateDerivedSync
-    const limitFn = vi.fn().mockResolvedValue([fakeCandidate]);
-    const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
-    const fromFn = vi.fn().mockReturnValue({ where: whereFn });
-    mockDb.select.mockReturnValueOnce({ from: fromFn });
-
     await createCandidate({
       name: "Jan de Vries",
       skills: ["TypeScript", "React"],
       role: "Frontend Developer",
     });
 
+    expect(mockQueueDeferredEmbeddingSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: "candidate",
+        entityId: "cand-123",
+      }),
+    );
     expect(mockEmitAgentEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         sourceAgent: "intake",
@@ -169,13 +170,14 @@ describe("candidate auto-match event emission", () => {
     };
 
     mockDb.returning.mockResolvedValueOnce([fakeCandidate]);
-    const limitFn = vi.fn().mockResolvedValue([fakeCandidate]);
-    const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
-    const fromFn = vi.fn().mockReturnValue({ where: whereFn });
-    mockDb.select.mockReturnValueOnce({ from: fromFn });
-
     await createCandidate({ name: "Kees Bakker" });
 
+    expect(mockQueueDeferredEmbeddingSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: "candidate",
+        entityId: "cand-456",
+      }),
+    );
     expect(mockEmitAgentEvent).not.toHaveBeenCalled();
   });
 
@@ -203,13 +205,14 @@ describe("candidate auto-match event emission", () => {
     };
 
     mockDb.returning.mockResolvedValueOnce([fakeCandidate]);
-    const limitFn = vi.fn().mockResolvedValue([fakeCandidate]);
-    const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
-    const fromFn = vi.fn().mockReturnValue({ where: whereFn });
-    mockDb.select.mockReturnValueOnce({ from: fromFn });
-
     await createCandidate({ name: "Piet Jansen", skills: [] });
 
+    expect(mockQueueDeferredEmbeddingSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: "candidate",
+        entityId: "cand-789",
+      }),
+    );
     expect(mockEmitAgentEvent).not.toHaveBeenCalled();
   });
 
@@ -242,17 +245,17 @@ describe("candidate auto-match event emission", () => {
     const updateSetFn = vi.fn().mockReturnValue({ where: updateWhereFn });
     mockDb.update.mockReturnValueOnce({ set: updateSetFn });
 
-    // Mock: select().from().where().limit() for getCandidateById in runCandidateDerivedSync
-    const limitFn = vi.fn().mockResolvedValue([updatedCandidate]);
-    const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
-    const fromFn = vi.fn().mockReturnValue({ where: whereFn });
-    mockDb.select.mockReturnValueOnce({ from: fromFn });
-
     await updateCandidate("cand-100", {
       skills: ["Python", "Django"],
       role: "Backend Developer",
     });
 
+    expect(mockQueueDeferredEmbeddingSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: "candidate",
+        entityId: "cand-100",
+      }),
+    );
     expect(mockEmitAgentEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         sourceAgent: "intake",
@@ -290,13 +293,14 @@ describe("candidate auto-match event emission", () => {
     const updateSetFn = vi.fn().mockReturnValue({ where: updateWhereFn });
     mockDb.update.mockReturnValueOnce({ set: updateSetFn });
 
-    const limitFn = vi.fn().mockResolvedValue([updatedCandidate]);
-    const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
-    const fromFn = vi.fn().mockReturnValue({ where: whereFn });
-    mockDb.select.mockReturnValueOnce({ from: fromFn });
-
     await updateCandidate("cand-200", { location: "Amsterdam" });
 
+    expect(mockQueueDeferredEmbeddingSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityType: "candidate",
+        entityId: "cand-200",
+      }),
+    );
     expect(mockEmitAgentEvent).not.toHaveBeenCalled();
   });
 });

--- a/tests/candidate-dedup.test.ts
+++ b/tests/candidate-dedup.test.ts
@@ -40,9 +40,9 @@ describe("Candidate deduplication", () => {
     expect(source).toContain("existing.location");
   });
 
-  it("enrichCandidateFromCV refreshes candidate embeddings after CV updates", () => {
+  it("enrichCandidateFromCV queues deferred candidate indexing after CV updates", () => {
     const source = readFile("src/services/candidates.ts");
-    expect(source).toContain('const { embedCandidate } = await import("./embedding")');
-    expect(source).toContain("await embedCandidate(candidate.id)");
+    expect(source).toContain("void queueDeferredEmbeddingSync({");
+    expect(source).toContain('source: "candidate:cv-enrichment"');
   });
 });

--- a/tests/deferred-embedding-pipeline.test.ts
+++ b/tests/deferred-embedding-pipeline.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockTrigger,
+  mockRunDeferredEmbeddingSync,
+  mockRevalidatePath,
+  mockRevalidateTag,
+  mockLoggerInfo,
+  mockLoggerError,
+  mockMetadata,
+} = vi.hoisted(() => {
+  const mockMetadata = {
+    set: vi.fn(),
+  };
+  mockMetadata.set.mockReturnValue(mockMetadata);
+
+  return {
+    mockTrigger: vi.fn().mockResolvedValue({ id: "queued-run-1" }),
+    mockRunDeferredEmbeddingSync: vi.fn(),
+    mockRevalidatePath: vi.fn(),
+    mockRevalidateTag: vi.fn(),
+    mockLoggerInfo: vi.fn(),
+    mockLoggerError: vi.fn(),
+    mockMetadata,
+  };
+});
+
+vi.mock("@trigger.dev/sdk", () => ({
+  tasks: { trigger: mockTrigger },
+  task: <T extends Record<string, unknown>>(config: T) => config,
+  logger: {
+    info: mockLoggerInfo,
+    error: mockLoggerError,
+  },
+  metadata: mockMetadata,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: mockRevalidatePath,
+  revalidateTag: mockRevalidateTag,
+}));
+
+vi.mock("../src/services/embedding", () => ({
+  runDeferredEmbeddingSync: mockRunDeferredEmbeddingSync,
+}));
+
+import { queueDeferredEmbeddingSync } from "../src/lib/event-bus";
+import { deferEmbeddingSyncTask } from "../trigger/defer-embedding-sync";
+
+describe("deferred embedding pipeline", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMetadata.set.mockReturnValue(mockMetadata);
+    mockTrigger.mockResolvedValue({ id: "queued-run-1" });
+  });
+
+  it("queues the background embedding task through Trigger.dev", async () => {
+    await queueDeferredEmbeddingSync({
+      entityType: "candidate",
+      entityId: "cand-123",
+      source: "candidate:create",
+    });
+
+    expect(mockTrigger).toHaveBeenCalledWith("defer-embedding-sync", {
+      entityType: "candidate",
+      entityId: "cand-123",
+      source: "candidate:create",
+    });
+  });
+
+  it("swallows queue failures so the primary mutation can still return", async () => {
+    mockTrigger.mockRejectedValueOnce(new Error("trigger offline"));
+
+    await expect(
+      queueDeferredEmbeddingSync({
+        entityType: "job",
+        entityId: "job-456",
+        source: "job:update",
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("revalidates candidate surfaces after a successful deferred sync", async () => {
+    mockRunDeferredEmbeddingSync.mockResolvedValueOnce({
+      entityType: "candidate",
+      entityId: "cand-123",
+      source: "candidate:create",
+      embedded: true,
+      indexed: true,
+      embeddingStatus: "ready",
+    });
+
+    const result = await deferEmbeddingSyncTask.run(
+      {
+        entityType: "candidate",
+        entityId: "cand-123",
+        source: "candidate:create",
+      },
+      { ctx: { run: { id: "task-run-1" } } },
+    );
+
+    expect(mockRunDeferredEmbeddingSync).toHaveBeenCalledWith({
+      entityType: "candidate",
+      entityId: "cand-123",
+      source: "candidate:create",
+    });
+    expect(mockRevalidateTag).toHaveBeenCalledWith("candidates", "default");
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/kandidaten");
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/kandidaten/cand-123");
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/overzicht");
+    expect(result).toMatchObject({
+      entityType: "candidate",
+      entityId: "cand-123",
+      embeddingStatus: "ready",
+    });
+  });
+
+  it("revalidates vacancy surfaces after a successful deferred sync", async () => {
+    mockRunDeferredEmbeddingSync.mockResolvedValueOnce({
+      entityType: "job",
+      entityId: "job-456",
+      source: "job:update",
+      embedded: true,
+      indexed: true,
+      embeddingStatus: "ready",
+    });
+
+    await deferEmbeddingSyncTask.run(
+      {
+        entityType: "job",
+        entityId: "job-456",
+        source: "job:update",
+      },
+      { ctx: { run: { id: "task-run-2" } } },
+    );
+
+    expect(mockRevalidateTag).toHaveBeenCalledWith("jobs", "default");
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/vacatures");
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/vacatures/job-456");
+    expect(mockRevalidatePath).toHaveBeenCalledWith("/overzicht");
+  });
+});

--- a/tests/harness/auto-resolve-threads.test.ts
+++ b/tests/harness/auto-resolve-threads.test.ts
@@ -9,11 +9,7 @@ import { classifyThreads, run } from "@/scripts/harness/auto-resolve-threads";
 // Fixtures
 // ---------------------------------------------------------------------------
 
-function makeThread(
-  id: string,
-  isResolved: boolean,
-  logins: string[],
-) {
+function makeThread(id: string, isResolved: boolean, logins: string[]) {
   return {
     id,
     isResolved,
@@ -29,9 +25,7 @@ function makeThread(
 
 describe("classifyThreads", () => {
   it("classifies bot-only unresolved threads as botOnly", () => {
-    const threads = [
-      makeThread("T1", false, ["review-bot[bot]", "github-actions"]),
-    ];
+    const threads = [makeThread("T1", false, ["review-bot[bot]", "github-actions"])];
 
     const { botOnly, withHumans, alreadyResolved } = classifyThreads(threads);
 
@@ -42,9 +36,7 @@ describe("classifyThreads", () => {
   });
 
   it("classifies threads with human comments as withHumans", () => {
-    const threads = [
-      makeThread("T2", false, ["review-bot[bot]", "human-dev"]),
-    ];
+    const threads = [makeThread("T2", false, ["review-bot[bot]", "human-dev"])];
 
     const { botOnly, withHumans } = classifyThreads(threads);
 
@@ -54,9 +46,7 @@ describe("classifyThreads", () => {
   });
 
   it("classifies already-resolved threads separately", () => {
-    const threads = [
-      makeThread("T3", true, ["review-bot[bot]"]),
-    ];
+    const threads = [makeThread("T3", true, ["review-bot[bot]"])];
 
     const { botOnly, withHumans, alreadyResolved } = classifyThreads(threads);
 
@@ -76,10 +66,10 @@ describe("classifyThreads", () => {
 
   it("correctly handles mixed thread types", () => {
     const threads = [
-      makeThread("T4", false, ["ci-bot[bot]"]),                  // bot-only
-      makeThread("T5", false, ["ci-bot[bot]", "developer"]),     // has human
-      makeThread("T6", true, ["ci-bot[bot]"]),                   // already resolved
-      makeThread("T7", false, ["github-actions"]),               // bot-only (known bot)
+      makeThread("T4", false, ["ci-bot[bot]"]), // bot-only
+      makeThread("T5", false, ["ci-bot[bot]", "developer"]), // has human
+      makeThread("T6", true, ["ci-bot[bot]"]), // already resolved
+      makeThread("T7", false, ["github-actions"]), // bot-only (known bot)
     ];
 
     const { botOnly, withHumans, alreadyResolved } = classifyThreads(threads);
@@ -114,8 +104,8 @@ describe("run", () => {
     });
 
     mockExecSync
-      .mockReturnValueOnce(graphqlResponse)  // fetch threads
-      .mockReturnValueOnce("{}");            // resolve T10
+      .mockReturnValueOnce(graphqlResponse) // fetch threads
+      .mockReturnValueOnce("{}"); // resolve T10
 
     const result = await run(42, "TestOwner", "test-repo");
 
@@ -137,9 +127,7 @@ describe("run", () => {
   });
 
   it("does nothing when all threads are already resolved", async () => {
-    const threads = [
-      makeThread("T20", true, ["lint-bot[bot]"]),
-    ];
+    const threads = [makeThread("T20", true, ["lint-bot[bot]"])];
 
     const graphqlResponse = JSON.stringify({
       data: {

--- a/tests/harness/code-factory-integration.test.ts
+++ b/tests/harness/code-factory-integration.test.ts
@@ -1,0 +1,159 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = path.resolve(__dirname, "../..");
+const WORKFLOW_DIR = path.join(ROOT, ".github", "workflows");
+
+const NEW_WORKFLOWS = [
+  ".github/workflows/ce-review-symphony.yml",
+  ".github/workflows/symphony-ci-hooks.yml",
+] as const;
+
+const NEW_SCRIPTS = [
+  "scripts/harness/pr-comment-writer.ts",
+  "scripts/harness/sha-discipline.ts",
+  "scripts/harness/auto-resolve-threads.ts",
+] as const;
+
+function resolveFromRoot(relativePath: string): string {
+  return path.join(ROOT, relativePath);
+}
+
+function readText(relativePath: string): string {
+  return fs.readFileSync(resolveFromRoot(relativePath), "utf8");
+}
+
+function collectWorkflowFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const results: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectWorkflowFiles(fullPath));
+      continue;
+    }
+
+    if (entry.name.endsWith(".yml") || entry.name.endsWith(".yaml")) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+async function assertWorkflowTriggers(
+  workflowPath: string,
+  expectedOnKeys: string[],
+  expectations: Record<string, { types?: string[]; workflows?: string[] }>,
+): Promise<void> {
+  // Load the YAML parser lazily so Vitest doesn't trip over static package
+  // resolution in this workspace.
+  const yaml = await import("yaml");
+  const parsed = yaml.parse(fs.readFileSync(resolveFromRoot(workflowPath), "utf8")) as {
+    on?: Record<string, unknown>;
+  };
+
+  expect(parsed.on, `${workflowPath} must define an 'on' trigger block`).toBeDefined();
+  expect(Object.keys(parsed.on ?? {}).sort()).toEqual([...expectedOnKeys].sort());
+
+  for (const [triggerName, triggerExpectation] of Object.entries(expectations)) {
+    const trigger = parsed.on?.[triggerName] as {
+      types?: string[];
+      workflows?: string[];
+    };
+
+    expect(trigger, `${workflowPath} must include the '${triggerName}' trigger`).toBeDefined();
+
+    if (triggerExpectation.types) {
+      expect(trigger.types).toEqual(triggerExpectation.types);
+    }
+
+    if (triggerExpectation.workflows) {
+      expect(trigger.workflows).toEqual(triggerExpectation.workflows);
+    }
+  }
+}
+
+describe("code factory integration", () => {
+  it("includes the new workflow files", () => {
+    for (const workflowPath of NEW_WORKFLOWS) {
+      expect(
+        fs.existsSync(resolveFromRoot(workflowPath)),
+        `Expected workflow file to exist: ${workflowPath}`,
+      ).toBe(true);
+    }
+  });
+
+  it("uses the expected triggers in ce-review-symphony.yml", () => {
+    return assertWorkflowTriggers(".github/workflows/ce-review-symphony.yml", ["pull_request"], {
+      pull_request: {
+        types: ["opened", "synchronize", "ready_for_review"],
+      },
+    });
+  });
+
+  it("uses the expected triggers in symphony-ci-hooks.yml", () => {
+    return assertWorkflowTriggers(
+      ".github/workflows/symphony-ci-hooks.yml",
+      ["pull_request", "workflow_run"],
+      {
+        pull_request: {
+          types: ["synchronize"],
+        },
+        workflow_run: {
+          workflows: ["CI"],
+          types: ["completed"],
+        },
+      },
+    );
+  });
+
+  it("includes the new harness scripts", () => {
+    for (const scriptPath of NEW_SCRIPTS) {
+      expect(
+        fs.existsSync(resolveFromRoot(scriptPath)),
+        `Expected harness script to exist: ${scriptPath}`,
+      ).toBe(true);
+    }
+  });
+
+  it("keeps hasUiFiles in risk-policy-gate.ts", () => {
+    expect(readText("scripts/harness/risk-policy-gate.ts")).toContain("hasUiFiles");
+  });
+
+  it("documents the terminal failure policy in WORKFLOW.md", () => {
+    expect(readText("WORKFLOW.md")).toContain("Terminal failure policy");
+  });
+
+  it("requires HTML comment markers in workflow files that create PR comments", () => {
+    const workflowFiles = collectWorkflowFiles(WORKFLOW_DIR);
+    const violations: string[] = [];
+
+    // Only check workflows that actually create/update PR comments via API
+    const commentCreationPatterns = [
+      "issues.createComment",
+      "issues.updateComment",
+      "issues/comments",
+      "createComment",
+      "upsertPrComment",
+    ];
+
+    for (const filePath of workflowFiles) {
+      const source = fs.readFileSync(filePath, "utf8");
+      const createsComments = commentCreationPatterns.some((p) => source.includes(p));
+
+      if (!createsComments) continue;
+
+      if (!/<!--[\s\S]*?-->/.test(source)) {
+        violations.push(path.relative(ROOT, filePath));
+      }
+    }
+
+    expect(
+      violations,
+      `Workflow files that create PR comments must contain an HTML comment marker:\n${violations.join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/tests/harness/pr-comment-writer.test.ts
+++ b/tests/harness/pr-comment-writer.test.ts
@@ -96,7 +96,9 @@ describe("upsertPrComment", () => {
     // Verify the PATCH call references the correct comment ID
     expect(mockExecSync).toHaveBeenNthCalledWith(
       2,
-      expect.stringContaining(`-X PATCH repos/${BASE_OPTIONS.owner}/${BASE_OPTIONS.repo}/issues/comments/77`),
+      expect.stringContaining(
+        `-X PATCH repos/${BASE_OPTIONS.owner}/${BASE_OPTIONS.repo}/issues/comments/77`,
+      ),
       expect.any(Object),
     );
   });

--- a/tests/harness/sha-discipline.test.ts
+++ b/tests/harness/sha-discipline.test.ts
@@ -25,9 +25,7 @@ describe("markStaleComments", () => {
   const NEW_SHA = "abc1234";
 
   it("marks stale bot comments when SHA changes", () => {
-    const comments = [
-      makeComment(1, "Review feedback\n<!-- sha:oldsha999 -->", "some-app[bot]"),
-    ];
+    const comments = [makeComment(1, "Review feedback\n<!-- sha:oldsha999 -->", "some-app[bot]")];
 
     const { toUpdate, skipped } = markStaleComments(comments, NEW_SHA);
 
@@ -40,9 +38,7 @@ describe("markStaleComments", () => {
   });
 
   it("skips non-bot comments", () => {
-    const comments = [
-      makeComment(2, "Human review\n<!-- sha:oldsha999 -->", "human-reviewer"),
-    ];
+    const comments = [makeComment(2, "Human review\n<!-- sha:oldsha999 -->", "human-reviewer")];
 
     const { toUpdate, skipped } = markStaleComments(comments, NEW_SHA);
 
@@ -51,9 +47,7 @@ describe("markStaleComments", () => {
   });
 
   it("skips comments without SHA tags", () => {
-    const comments = [
-      makeComment(3, "Just a regular comment with no SHA tag", "some-app[bot]"),
-    ];
+    const comments = [makeComment(3, "Just a regular comment with no SHA tag", "some-app[bot]")];
 
     const { toUpdate, skipped } = markStaleComments(comments, NEW_SHA);
 
@@ -69,9 +63,7 @@ describe("markStaleComments", () => {
   });
 
   it("skips bot comments whose SHA already matches the new HEAD", () => {
-    const comments = [
-      makeComment(4, `Up-to-date\n<!-- sha:${NEW_SHA} -->`, "github-actions"),
-    ];
+    const comments = [makeComment(4, `Up-to-date\n<!-- sha:${NEW_SHA} -->`, "github-actions")];
 
     const { toUpdate, skipped } = markStaleComments(comments, NEW_SHA);
 
@@ -91,9 +83,7 @@ describe("markStaleComments", () => {
   });
 
   it("recognizes github-actions as a known bot", () => {
-    const comments = [
-      makeComment(6, "CI feedback\n<!-- sha:oldsha999 -->", "github-actions"),
-    ];
+    const comments = [makeComment(6, "CI feedback\n<!-- sha:oldsha999 -->", "github-actions")];
 
     const { toUpdate } = markStaleComments(comments, NEW_SHA);
 
@@ -139,9 +129,7 @@ describe("run", () => {
   });
 
   it("does nothing when all comments are up-to-date", async () => {
-    const comments = [
-      makeComment(20, "Current review\n<!-- sha:currentsha -->", "ci-bot[bot]"),
-    ];
+    const comments = [makeComment(20, "Current review\n<!-- sha:currentsha -->", "ci-bot[bot]")];
 
     mockExecSync.mockReturnValueOnce(JSON.stringify(comments));
 

--- a/tests/kandidaten-service-parity.test.ts
+++ b/tests/kandidaten-service-parity.test.ts
@@ -22,12 +22,12 @@ describe("kandidaten shared service wiring", () => {
     expect(source).toContain("countCandidates({");
   });
 
-  it("awaits candidate derived sync inline (no setTimeout — safe for serverless)", () => {
+  it("queues candidate embedding sync instead of awaiting it inline", () => {
     const source = readFile("src", "services", "candidates.ts");
 
     expect(source).not.toContain("setTimeout");
-    expect(source).not.toContain("scheduleCandidateDerivedSync");
-    expect(source).toContain("async function runCandidateDerivedSync(candidateId: string)");
-    expect(source).toContain("await runCandidateDerivedSync(candidate.id)");
+    expect(source).not.toContain("runCandidateDerivedSync");
+    expect(source).toContain("void queueDeferredEmbeddingSync({");
+    expect(source).toContain('entityType: "candidate"');
   });
 });

--- a/trigger/defer-embedding-sync.ts
+++ b/trigger/defer-embedding-sync.ts
@@ -1,0 +1,98 @@
+import { logger, metadata, task } from "@trigger.dev/sdk";
+import { revalidatePath, revalidateTag } from "next/cache";
+import { publish } from "@/src/lib/event-bus";
+import {
+  type DeferredEmbeddingSyncPayload,
+  runDeferredEmbeddingSync,
+} from "@/src/services/embedding";
+
+function revalidateEntity(payload: DeferredEmbeddingSyncPayload) {
+  switch (payload.entityType) {
+    case "candidate":
+      revalidateTag("candidates", "default");
+      revalidatePath("/kandidaten");
+      revalidatePath(`/kandidaten/${payload.entityId}`);
+      revalidatePath("/overzicht");
+      break;
+    case "job":
+      revalidateTag("jobs", "default");
+      revalidatePath("/vacatures");
+      revalidatePath(`/vacatures/${payload.entityId}`);
+      revalidatePath("/overzicht");
+      break;
+  }
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+export const deferEmbeddingSyncTask = task({
+  id: "defer-embedding-sync",
+  retry: {
+    maxAttempts: 3,
+    factor: 2,
+    minTimeoutInMs: 1000,
+    maxTimeoutInMs: 10_000,
+    randomize: true,
+  },
+  maxDuration: 30,
+  run: async (payload: DeferredEmbeddingSyncPayload, { ctx }) => {
+    metadata
+      .set("status", "started")
+      .set("entityType", payload.entityType)
+      .set("entityId", payload.entityId)
+      .set("source", payload.source ?? null);
+
+    publish("embedding:started", {
+      ...payload,
+      runId: ctx.run.id,
+    });
+
+    try {
+      const result = await runDeferredEmbeddingSync(payload);
+      revalidateEntity(payload);
+
+      metadata
+        .set("status", "completed")
+        .set("embeddingStatus", result.embeddingStatus)
+        .set("embedded", result.embedded)
+        .set("indexed", result.indexed);
+
+      publish("embedding:completed", {
+        ...result,
+        runId: ctx.run.id,
+      });
+
+      logger.info("Deferred embedding sync voltooid", {
+        entityType: payload.entityType,
+        entityId: payload.entityId,
+        embeddingStatus: result.embeddingStatus,
+        embedded: result.embedded,
+        indexed: result.indexed,
+        runId: ctx.run.id,
+      });
+
+      return result;
+    } catch (error) {
+      const message = toErrorMessage(error);
+      metadata.set("status", "failed").set("error", message);
+
+      publish("embedding:failed", {
+        ...payload,
+        error: message,
+        runId: ctx.run.id,
+      });
+
+      logger.error("Deferred embedding sync mislukt", {
+        entityType: payload.entityType,
+        entityId: payload.entityId,
+        error: message,
+        runId: ctx.run.id,
+      });
+
+      throw error;
+    }
+  },
+});


### PR DESCRIPTION
## Summary
- move candidate and vacancy embedding/index work out of the synchronous write path
- add a Trigger.dev `defer-embedding-sync` task plus an event-bus queue helper
- return `embeddingStatus: "pending"` immediately and show subtle `Indexeren…` badges on candidate and vacancy cards

## Validation
- `pnpm test -- --run tests/deferred-embedding-pipeline.test.ts tests/candidate-auto-match-event.test.ts tests/kandidaten-service-parity.test.ts tests/candidate-dedup.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm tsx scripts/harness/entropy-check.ts` (warnings only, 0 critical)

## Blocker
- Runtime `/kandidaten` and `/vacatures` validation is blocked in this repo copy because `pnpm dev` fails with missing `DATABASE_URL` in `.env.local`, so screenshot/browser proof is not attached yet.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual "Indexeren…" loading badge added to candidate and job listings to show when embeddings are being generated.
  * Embedding/indexing now runs asynchronously in the background so create/update actions no longer block the UI; listings and pages refresh when indexing completes.

* **Chores**
  * Updated code quality tool configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->