### PR TITLE
RJC-63: move Typesense bootstrap off hot paths

### DIFF
--- a/app/api/gezondheid/route.ts
+++ b/app/api/gezondheid/route.ts
@@ -1,11 +1,18 @@
 import type { NextRequest } from "next/server";
 import { withApiHandler } from "@/src/lib/api-handler";
 import { getHealth } from "@/src/services/scrapers";
+import { ensureTypesenseCollections } from "@/src/services/search-index/typesense-client";
 
 export const dynamic = "force-dynamic";
 
 export const GET = withApiHandler(
   async (_request: NextRequest) => {
+    try {
+      await ensureTypesenseCollections();
+    } catch (error) {
+      console.error("[Gezondheid] Typesense bootstrap mislukt:", error);
+    }
+
     const health = await getHealth();
     return Response.json(health, {
       headers: { "Cache-Control": "no-cache" },

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   "scripts": {
     "dev": "next dev --hostname ${HOSTNAME:-0.0.0.0} --port ${PORT:-3002}",
     "build": "next build",
+    "postbuild": "pnpm search:bootstrap",
     "start": "next start --hostname ${HOSTNAME:-0.0.0.0} --port ${PORT:-3001}",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -95,6 +96,7 @@
     "track:ai-costs": "npx ccusage",
     "baseline:metrics": "tsx scripts/baseline-metrics.ts",
     "benchmark:hybrid-search": "tsx scripts/benchmark-hybrid-search.ts",
+    "search:bootstrap": "tsx scripts/bootstrap-typesense.ts",
     "search:reindex": "tsx scripts/reindex-typesense.ts",
     "metrics:esco-rollout": "tsx scripts/esco-rollout-snapshot.ts",
     "metrics:esco-rollout:compare": "tsx scripts/esco-rollout-compare.ts",

--- a/scripts/bootstrap-typesense.ts
+++ b/scripts/bootstrap-typesense.ts
@@ -1,0 +1,38 @@
+import { getTypesenseConfig } from "../src/lib/typesense";
+import { ensureTypesenseCollections } from "../src/services/search-index/typesense-client";
+
+async function main() {
+  const config = getTypesenseConfig();
+  if (!config) {
+    console.log(
+      JSON.stringify(
+        {
+          skipped: true,
+          reason: "Typesense is niet geconfigureerd.",
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  try {
+    await ensureTypesenseCollections();
+
+    console.log(
+      JSON.stringify(
+        {
+          bootstrapped: true,
+          collections: config.collections,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    console.warn("[Typesense bootstrap] Postbuild bootstrap mislukt:", error);
+  }
+}
+
+await main();

--- a/scripts/harness/auto-resolve-threads.ts
+++ b/scripts/harness/auto-resolve-threads.ts
@@ -166,7 +166,9 @@ async function main(): Promise<void> {
 }
 
 // Only run when executed directly (not when imported in tests)
-const isDirectRun = process.argv[1]?.endsWith("auto-resolve-threads.ts") || process.argv[1]?.includes("auto-resolve-threads");
+const isDirectRun =
+  process.argv[1]?.endsWith("auto-resolve-threads.ts") ||
+  process.argv[1]?.includes("auto-resolve-threads");
 if (isDirectRun) {
   main().catch((err) => {
     console.error(`[auto-resolve-threads] Onverwerkte fout: ${err}`);

--- a/scripts/harness/pr-comment-writer.ts
+++ b/scripts/harness/pr-comment-writer.ts
@@ -43,12 +43,7 @@ function findMarkedComment(comments: GitHubComment[], marker: string): GitHubCom
   return comments.find((c) => c.body.includes(marker));
 }
 
-function createComment(
-  owner: string,
-  repo: string,
-  prNumber: number,
-  body: string,
-): GitHubComment {
+function createComment(owner: string, repo: string, prNumber: number, body: string): GitHubComment {
   const raw = execSync(
     `gh api -X POST repos/${owner}/${repo}/issues/${prNumber}/comments --field body='${escapeShellArg(body)}' --jq '{id: .id, body: .body}'`,
     { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },

--- a/scripts/harness/sha-discipline.ts
+++ b/scripts/harness/sha-discipline.ts
@@ -94,7 +94,12 @@ export function markStaleComments(
 // Main
 // ---------------------------------------------------------------------------
 
-export async function run(prNumber: number, newHeadSha: string, owner: string, repo: string): Promise<ShaDisciplineResult> {
+export async function run(
+  prNumber: number,
+  newHeadSha: string,
+  owner: string,
+  repo: string,
+): Promise<ShaDisciplineResult> {
   const comments = fetchComments(owner, repo, prNumber);
   const { toUpdate, skipped } = markStaleComments(comments, newHeadSha);
 
@@ -136,7 +141,8 @@ async function main(): Promise<void> {
 }
 
 // Only run when executed directly (not when imported in tests)
-const isDirectRun = process.argv[1]?.endsWith("sha-discipline.ts") || process.argv[1]?.includes("sha-discipline");
+const isDirectRun =
+  process.argv[1]?.endsWith("sha-discipline.ts") || process.argv[1]?.includes("sha-discipline");
 if (isDirectRun) {
   main().catch((err) => {
     console.error(`[sha-discipline] Onverwerkte fout: ${err}`);

--- a/scripts/reindex-typesense.ts
+++ b/scripts/reindex-typesense.ts
@@ -2,9 +2,11 @@ import { and, asc, db, isNull } from "../src/db";
 import { candidates, jobs } from "../src/db/schema";
 import { getTypesenseConfig } from "../src/lib/typesense";
 import { getVisibleVacancyCondition } from "../src/services/jobs/filters";
-import { dropTypesenseCollection } from "../src/services/search-index/typesense-client";
 import {
+  dropTypesenseCollection,
   ensureTypesenseCollections,
+} from "../src/services/search-index/typesense-client";
+import {
   upsertCandidatesByIds,
   upsertJobsByIds,
 } from "../src/services/search-index/typesense-sync";

--- a/src/services/search-index/typesense-client.ts
+++ b/src/services/search-index/typesense-client.ts
@@ -2,6 +2,8 @@ import { getTypesenseConfig } from "../../lib/typesense";
 import { TYPESENSE_CANDIDATES_SCHEMA, TYPESENSE_JOBS_SCHEMA } from "./typesense-schema";
 
 type TypesenseMethod = "GET" | "POST" | "PUT" | "DELETE";
+export type TypesenseCollection = "jobs" | "candidates";
+type TypesenseCollectionState = "unknown" | "exists" | "missing";
 
 type TypesenseRequestOptions = {
   body?: BodyInit;
@@ -11,7 +13,47 @@ type TypesenseRequestOptions = {
   skipNotFound?: boolean;
 };
 
-const ensuredCollections = new Map<string, Promise<void>>();
+type TypesenseCollectionCacheEntry = {
+  bootstrapPromise?: Promise<void>;
+  state: TypesenseCollectionState;
+};
+
+const collectionBootstrapCache = new Map<string, TypesenseCollectionCacheEntry>();
+
+export class TypesenseRequestError extends Error {
+  body: string;
+  status: number;
+
+  constructor(status: number, body: string) {
+    super(`Typesense request failed (${status}): ${body}`);
+    this.name = "TypesenseRequestError";
+    this.body = body;
+    this.status = status;
+  }
+}
+
+function getCollectionSchema(collection: TypesenseCollection, name: string) {
+  if (collection === "jobs") {
+    return { ...TYPESENSE_JOBS_SCHEMA, name };
+  }
+
+  return { ...TYPESENSE_CANDIDATES_SCHEMA, name };
+}
+
+function getCollectionCacheContext(collection: TypesenseCollection) {
+  const config = getTypesenseConfig();
+  if (!config) return null;
+
+  const collectionName = config.collections[collection];
+  const cacheKey = `${collection}:${collectionName}`;
+  const cacheEntry = collectionBootstrapCache.get(cacheKey) ?? { state: "unknown" as const };
+
+  if (!collectionBootstrapCache.has(cacheKey)) {
+    collectionBootstrapCache.set(cacheKey, cacheEntry);
+  }
+
+  return { cacheEntry, cacheKey, collectionName };
+}
 
 function buildUrl(path: string, searchParams?: URLSearchParams) {
   const config = getTypesenseConfig();
@@ -47,7 +89,7 @@ export async function typesenseRequest<T>(
 
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(`Typesense request failed (${response.status}): ${text}`);
+    throw new TypesenseRequestError(response.status, text);
   }
 
   if (response.status === 204) {
@@ -67,16 +109,48 @@ export async function typesenseRequest<T>(
   return JSON.parse(text) as T;
 }
 
-function getCollectionSchema(collection: "jobs" | "candidates", name: string) {
-  if (collection === "jobs") {
-    return { ...TYPESENSE_JOBS_SCHEMA, name };
+export function isTypesenseCollectionKnownMissing(collection: TypesenseCollection) {
+  return getCollectionCacheContext(collection)?.cacheEntry.state === "missing";
+}
+
+export function markTypesenseCollectionMissing(collection: TypesenseCollection) {
+  const context = getCollectionCacheContext(collection);
+  if (!context) return;
+
+  context.cacheEntry.bootstrapPromise = undefined;
+  context.cacheEntry.state = "missing";
+}
+
+function markTypesenseCollectionExists(collection: TypesenseCollection) {
+  const context = getCollectionCacheContext(collection);
+  if (!context) return;
+
+  context.cacheEntry.bootstrapPromise = undefined;
+  context.cacheEntry.state = "exists";
+}
+
+export function resetTypesenseCollectionCache(collection?: TypesenseCollection) {
+  if (!collection) {
+    collectionBootstrapCache.clear();
+    return;
   }
 
-  return { ...TYPESENSE_CANDIDATES_SCHEMA, name };
+  const context = getCollectionCacheContext(collection);
+  if (!context) return;
+
+  collectionBootstrapCache.delete(context.cacheKey);
+}
+
+export function isTypesenseCollectionMissingError(error: unknown) {
+  if (!(error instanceof TypesenseRequestError)) return false;
+  if (error.status !== 404) return false;
+
+  const normalizedBody = error.body.toLocaleLowerCase("en-US");
+  return normalizedBody.includes("collection") || normalizedBody.includes("not found");
 }
 
 /** Drop a Typesense collection so it can be recreated fresh (used by reindex). */
-export async function dropTypesenseCollection(collection: "jobs" | "candidates") {
+export async function dropTypesenseCollection(collection: TypesenseCollection) {
   const config = getTypesenseConfig();
   if (!config) return;
 
@@ -86,39 +160,56 @@ export async function dropTypesenseCollection(collection: "jobs" | "candidates")
     skipNotFound: true,
   });
 
-  // Clear the memoized bootstrap promise so ensureTypesenseCollection recreates it.
-  for (const [key] of ensuredCollections) {
-    if (key.startsWith(`${collection}:`)) ensuredCollections.delete(key);
-  }
+  markTypesenseCollectionMissing(collection);
 }
 
-export async function ensureTypesenseCollection(collection: "jobs" | "candidates") {
-  const config = getTypesenseConfig();
-  if (!config) return;
+export async function ensureTypesenseCollection(collection: TypesenseCollection) {
+  const context = getCollectionCacheContext(collection);
+  if (!context) return;
 
-  const collectionName = config.collections[collection];
-  const cacheKey = `${collection}:${collectionName}`;
+  if (context.cacheEntry.state === "exists") {
+    return;
+  }
 
-  const existing = ensuredCollections.get(cacheKey);
-  if (existing) return existing;
+  if (context.cacheEntry.bootstrapPromise) {
+    return context.cacheEntry.bootstrapPromise;
+  }
 
   const promise = (async () => {
-    const found = await typesenseRequest(`/collections/${collectionName}`, { skipNotFound: true });
+    const found = await typesenseRequest(`/collections/${context.collectionName}`, {
+      skipNotFound: true,
+    });
     if (!found) {
       await typesenseRequest("/collections", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(getCollectionSchema(collection, collectionName)),
+        body: JSON.stringify(getCollectionSchema(collection, context.collectionName)),
       });
     }
+
+    markTypesenseCollectionExists(collection);
   })();
 
-  ensuredCollections.set(cacheKey, promise);
+  context.cacheEntry.bootstrapPromise = promise;
+  collectionBootstrapCache.set(context.cacheKey, context.cacheEntry);
 
   try {
     await promise;
   } catch (err) {
-    ensuredCollections.delete(cacheKey);
+    if (context.cacheEntry.bootstrapPromise === promise) {
+      context.cacheEntry.bootstrapPromise = undefined;
+      context.cacheEntry.state = "unknown";
+    }
     throw err;
+  } finally {
+    if (context.cacheEntry.bootstrapPromise === promise) {
+      context.cacheEntry.bootstrapPromise = undefined;
+    }
   }
+}
+
+export async function ensureTypesenseCollections() {
+  if (!getTypesenseConfig()) return;
+
+  await Promise.all([ensureTypesenseCollection("jobs"), ensureTypesenseCollection("candidates")]);
 }

--- a/src/services/search-index/typesense-search.ts
+++ b/src/services/search-index/typesense-search.ts
@@ -3,7 +3,13 @@ import { getTypesenseConfig, isTypesenseEnabled } from "../../lib/typesense";
 import type { SearchCandidatesOptions } from "../candidates";
 import type { ListJobsSortBy } from "../jobs/filters";
 import type { HybridSearchOptions } from "../jobs/search";
-import { typesenseRequest } from "./typesense-client";
+import {
+  isTypesenseCollectionKnownMissing,
+  isTypesenseCollectionMissingError,
+  markTypesenseCollectionMissing,
+  type TypesenseCollection,
+  typesenseRequest,
+} from "./typesense-client";
 
 type TypesenseSearchResponse<TDocument> = {
   found?: number;
@@ -138,16 +144,27 @@ export function canUseTypesenseForCandidates(opts: SearchCandidatesOptions = {})
 }
 
 async function searchCollectionByIds<TDocument extends { id: string }>(
-  collection: "jobs" | "candidates",
+  collection: TypesenseCollection,
   params: URLSearchParams,
 ): Promise<SearchIdsResult | null> {
   const config = getTypesenseConfig();
   if (!config) return null;
+  if (isTypesenseCollectionKnownMissing(collection)) return null;
 
-  const response = await typesenseRequest<TypesenseSearchResponse<TDocument>>(
-    `/collections/${config.collections[collection]}/documents/search`,
-    { searchParams: params },
-  );
+  let response: TypesenseSearchResponse<TDocument> | null;
+  try {
+    response = await typesenseRequest<TypesenseSearchResponse<TDocument>>(
+      `/collections/${config.collections[collection]}/documents/search`,
+      { searchParams: params },
+    );
+  } catch (error) {
+    if (isTypesenseCollectionMissingError(error)) {
+      markTypesenseCollectionMissing(collection);
+      return null;
+    }
+
+    throw error;
+  }
 
   if (!response) {
     return { ids: [], total: 0 };

--- a/src/services/search-index/typesense-sync.ts
+++ b/src/services/search-index/typesense-sync.ts
@@ -2,7 +2,13 @@ import { and, db, inArray, isNull } from "../../db";
 import { candidates, jobs } from "../../db/schema";
 import { getTypesenseConfig, isTypesenseEnabled } from "../../lib/typesense";
 import { getVisibleVacancyCondition } from "../jobs/filters";
-import { ensureTypesenseCollection, typesenseRequest } from "./typesense-client";
+import {
+  isTypesenseCollectionKnownMissing,
+  isTypesenseCollectionMissingError,
+  markTypesenseCollectionMissing,
+  type TypesenseCollection,
+  typesenseRequest,
+} from "./typesense-client";
 import { toTypesenseCandidateDocument, toTypesenseJobDocument } from "./typesense-documents";
 
 function chunk<T>(items: T[], size = 25): T[][] {
@@ -19,42 +25,56 @@ function asStringArray(value: unknown): string[] {
     : [];
 }
 
-async function importDocuments(collection: "jobs" | "candidates", documents: object[]) {
+async function importDocuments(collection: TypesenseCollection, documents: object[]) {
   if (!isTypesenseEnabled() || documents.length === 0) return;
+  if (isTypesenseCollectionKnownMissing(collection)) return;
 
-  await ensureTypesenseCollection(collection);
   const config = getTypesenseConfig();
   if (!config) return;
 
   const payload = documents.map((document) => JSON.stringify(document)).join("\n");
-  await typesenseRequest(`/collections/${config.collections[collection]}/documents/import`, {
-    method: "POST",
-    headers: { "Content-Type": "text/plain" },
-    searchParams: new URLSearchParams({ action: "upsert" }),
-    body: payload,
-  });
+
+  try {
+    await typesenseRequest(`/collections/${config.collections[collection]}/documents/import`, {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      searchParams: new URLSearchParams({ action: "upsert" }),
+      body: payload,
+    });
+  } catch (error) {
+    if (isTypesenseCollectionMissingError(error)) {
+      markTypesenseCollectionMissing(collection);
+      return;
+    }
+
+    throw error;
+  }
 }
 
-async function deleteDocuments(collection: "jobs" | "candidates", ids: string[]) {
+async function deleteDocuments(collection: TypesenseCollection, ids: string[]) {
   if (!isTypesenseEnabled() || ids.length === 0) return;
+  if (isTypesenseCollectionKnownMissing(collection)) return;
 
-  await ensureTypesenseCollection(collection);
   const config = getTypesenseConfig();
   if (!config) return;
 
-  await Promise.all(
-    ids.map((id) =>
-      typesenseRequest(
-        `/collections/${config.collections[collection]}/documents/${encodeURIComponent(id)}`,
-        { method: "DELETE", skipNotFound: true },
+  try {
+    await Promise.all(
+      ids.map((id) =>
+        typesenseRequest(
+          `/collections/${config.collections[collection]}/documents/${encodeURIComponent(id)}`,
+          { method: "DELETE", skipNotFound: true },
+        ),
       ),
-    ),
-  );
-}
+    );
+  } catch (error) {
+    if (isTypesenseCollectionMissingError(error)) {
+      markTypesenseCollectionMissing(collection);
+      return;
+    }
 
-export async function ensureTypesenseCollections() {
-  if (!isTypesenseEnabled()) return;
-  await Promise.all([ensureTypesenseCollection("jobs"), ensureTypesenseCollection("candidates")]);
+    throw error;
+  }
 }
 
 export async function upsertJobsByIds(ids: string[]) {

--- a/tests/api-gezondheid-route.test.ts
+++ b/tests/api-gezondheid-route.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEnsureTypesenseCollections, mockGetHealth } = vi.hoisted(() => ({
+  mockEnsureTypesenseCollections: vi.fn(),
+  mockGetHealth: vi.fn(),
+}));
+
+vi.mock("@/src/services/search-index/typesense-client", () => ({
+  ensureTypesenseCollections: mockEnsureTypesenseCollections,
+}));
+
+vi.mock("@/src/services/scrapers", () => ({
+  getHealth: mockGetHealth,
+}));
+
+import { GET } from "../app/api/gezondheid/route";
+
+describe("GET /api/gezondheid", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetHealth.mockResolvedValue({ overall: "gezond", data: [] });
+  });
+
+  it("boots Typesense collections before returning health", async () => {
+    const response = await GET(new Request("http://localhost/api/gezondheid") as never);
+
+    expect(mockEnsureTypesenseCollections).toHaveBeenCalledTimes(1);
+    expect(mockGetHealth).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-cache");
+    await expect(response.json()).resolves.toEqual({ overall: "gezond", data: [] });
+  });
+
+  it("returns health even when Typesense bootstrap fails", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockEnsureTypesenseCollections.mockRejectedValueOnce(new Error("typesense offline"));
+
+    const response = await GET(new Request("http://localhost/api/gezondheid") as never);
+
+    expect(response.status).toBe(200);
+    expect(mockGetHealth).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[Gezondheid] Typesense bootstrap mislukt:",
+      expect.any(Error),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/tests/harness/auto-resolve-threads.test.ts
+++ b/tests/harness/auto-resolve-threads.test.ts
@@ -9,11 +9,7 @@ import { classifyThreads, run } from "@/scripts/harness/auto-resolve-threads";
 // Fixtures
 // ---------------------------------------------------------------------------
 
-function makeThread(
-  id: string,
-  isResolved: boolean,
-  logins: string[],
-) {
+function makeThread(id: string, isResolved: boolean, logins: string[]) {
   return {
     id,
     isResolved,
@@ -29,9 +25,7 @@ function makeThread(
 
 describe("classifyThreads", () => {
   it("classifies bot-only unresolved threads as botOnly", () => {
-    const threads = [
-      makeThread("T1", false, ["review-bot[bot]", "github-actions"]),
-    ];
+    const threads = [makeThread("T1", false, ["review-bot[bot]", "github-actions"])];
 
     const { botOnly, withHumans, alreadyResolved } = classifyThreads(threads);
 
@@ -42,9 +36,7 @@ describe("classifyThreads", () => {
   });
 
   it("classifies threads with human comments as withHumans", () => {
-    const threads = [
-      makeThread("T2", false, ["review-bot[bot]", "human-dev"]),
-    ];
+    const threads = [makeThread("T2", false, ["review-bot[bot]", "human-dev"])];
 
     const { botOnly, withHumans } = classifyThreads(threads);
 
@@ -54,9 +46,7 @@ describe("classifyThreads", () => {
   });
 
   it("classifies already-resolved threads separately", () => {
-    const threads = [
-      makeThread("T3", true, ["review-bot[bot]"]),
-    ];
+    const threads = [makeThread("T3", true, ["review-bot[bot]"])];
 
     const { botOnly, withHumans, alreadyResolved } = classifyThreads(threads);
 
@@ -76,10 +66,10 @@ describe("classifyThreads", () => {
 
   it("correctly handles mixed thread types", () => {
     const threads = [
-      makeThread("T4", false, ["ci-bot[bot]"]),                  // bot-only
-      makeThread("T5", false, ["ci-bot[bot]", "developer"]),     // has human
-      makeThread("T6", true, ["ci-bot[bot]"]),                   // already resolved
-      makeThread("T7", false, ["github-actions"]),               // bot-only (known bot)
+      makeThread("T4", false, ["ci-bot[bot]"]), // bot-only
+      makeThread("T5", false, ["ci-bot[bot]", "developer"]), // has human
+      makeThread("T6", true, ["ci-bot[bot]"]), // already resolved
+      makeThread("T7", false, ["github-actions"]), // bot-only (known bot)
     ];
 
     const { botOnly, withHumans, alreadyResolved } = classifyThreads(threads);
@@ -114,8 +104,8 @@ describe("run", () => {
     });
 
     mockExecSync
-      .mockReturnValueOnce(graphqlResponse)  // fetch threads
-      .mockReturnValueOnce("{}");            // resolve T10
+      .mockReturnValueOnce(graphqlResponse) // fetch threads
+      .mockReturnValueOnce("{}"); // resolve T10
 
     const result = await run(42, "TestOwner", "test-repo");
 
@@ -137,9 +127,7 @@ describe("run", () => {
   });
 
   it("does nothing when all threads are already resolved", async () => {
-    const threads = [
-      makeThread("T20", true, ["lint-bot[bot]"]),
-    ];
+    const threads = [makeThread("T20", true, ["lint-bot[bot]"])];
 
     const graphqlResponse = JSON.stringify({
       data: {

--- a/tests/harness/pr-comment-writer.test.ts
+++ b/tests/harness/pr-comment-writer.test.ts
@@ -96,7 +96,9 @@ describe("upsertPrComment", () => {
     // Verify the PATCH call references the correct comment ID
     expect(mockExecSync).toHaveBeenNthCalledWith(
       2,
-      expect.stringContaining(`-X PATCH repos/${BASE_OPTIONS.owner}/${BASE_OPTIONS.repo}/issues/comments/77`),
+      expect.stringContaining(
+        `-X PATCH repos/${BASE_OPTIONS.owner}/${BASE_OPTIONS.repo}/issues/comments/77`,
+      ),
       expect.any(Object),
     );
   });

--- a/tests/harness/sha-discipline.test.ts
+++ b/tests/harness/sha-discipline.test.ts
@@ -25,9 +25,7 @@ describe("markStaleComments", () => {
   const NEW_SHA = "abc1234";
 
   it("marks stale bot comments when SHA changes", () => {
-    const comments = [
-      makeComment(1, "Review feedback\n<!-- sha:oldsha999 -->", "some-app[bot]"),
-    ];
+    const comments = [makeComment(1, "Review feedback\n<!-- sha:oldsha999 -->", "some-app[bot]")];
 
     const { toUpdate, skipped } = markStaleComments(comments, NEW_SHA);
 
@@ -40,9 +38,7 @@ describe("markStaleComments", () => {
   });
 
   it("skips non-bot comments", () => {
-    const comments = [
-      makeComment(2, "Human review\n<!-- sha:oldsha999 -->", "human-reviewer"),
-    ];
+    const comments = [makeComment(2, "Human review\n<!-- sha:oldsha999 -->", "human-reviewer")];
 
     const { toUpdate, skipped } = markStaleComments(comments, NEW_SHA);
 
@@ -51,9 +47,7 @@ describe("markStaleComments", () => {
   });
 
   it("skips comments without SHA tags", () => {
-    const comments = [
-      makeComment(3, "Just a regular comment with no SHA tag", "some-app[bot]"),
-    ];
+    const comments = [makeComment(3, "Just a regular comment with no SHA tag", "some-app[bot]")];
 
     const { toUpdate, skipped } = markStaleComments(comments, NEW_SHA);
 
@@ -69,9 +63,7 @@ describe("markStaleComments", () => {
   });
 
   it("skips bot comments whose SHA already matches the new HEAD", () => {
-    const comments = [
-      makeComment(4, `Up-to-date\n<!-- sha:${NEW_SHA} -->`, "github-actions"),
-    ];
+    const comments = [makeComment(4, `Up-to-date\n<!-- sha:${NEW_SHA} -->`, "github-actions")];
 
     const { toUpdate, skipped } = markStaleComments(comments, NEW_SHA);
 
@@ -91,9 +83,7 @@ describe("markStaleComments", () => {
   });
 
   it("recognizes github-actions as a known bot", () => {
-    const comments = [
-      makeComment(6, "CI feedback\n<!-- sha:oldsha999 -->", "github-actions"),
-    ];
+    const comments = [makeComment(6, "CI feedback\n<!-- sha:oldsha999 -->", "github-actions")];
 
     const { toUpdate } = markStaleComments(comments, NEW_SHA);
 
@@ -139,9 +129,7 @@ describe("run", () => {
   });
 
   it("does nothing when all comments are up-to-date", async () => {
-    const comments = [
-      makeComment(20, "Current review\n<!-- sha:currentsha -->", "ci-bot[bot]"),
-    ];
+    const comments = [makeComment(20, "Current review\n<!-- sha:currentsha -->", "ci-bot[bot]")];
 
     mockExecSync.mockReturnValueOnce(JSON.stringify(comments));
 

--- a/tests/typesense-bootstrap-config.test.ts
+++ b/tests/typesense-bootstrap-config.test.ts
@@ -1,0 +1,14 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("typesense bootstrap build wiring", () => {
+  it("runs bootstrap as a postbuild step", () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.resolve(__dirname, "../package.json"), "utf-8"),
+    ) as { scripts?: Record<string, string> };
+
+    expect(packageJson.scripts?.postbuild).toBe("pnpm search:bootstrap");
+    expect(packageJson.scripts?.["search:bootstrap"]).toBe("tsx scripts/bootstrap-typesense.ts");
+  });
+});

--- a/tests/typesense-client.test.ts
+++ b/tests/typesense-client.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetTypesenseConfig } = vi.hoisted(() => ({
+  mockGetTypesenseConfig: vi.fn(),
+}));
+
+vi.mock("../src/lib/typesense", () => ({
+  getTypesenseConfig: mockGetTypesenseConfig,
+}));
+
+import {
+  ensureTypesenseCollection,
+  isTypesenseCollectionKnownMissing,
+  markTypesenseCollectionMissing,
+  resetTypesenseCollectionCache,
+} from "../src/services/search-index/typesense-client";
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("typesense client bootstrap cache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetTypesenseCollectionCache();
+    mockGetTypesenseConfig.mockReturnValue({
+      url: "https://typesense.example.com",
+      apiKey: "secret-key",
+      collections: {
+        jobs: "motian_jobs_preview",
+        candidates: "motian_candidates_preview",
+      },
+    });
+  });
+
+  afterEach(() => {
+    resetTypesenseCollectionCache();
+    vi.unstubAllGlobals();
+  });
+
+  it("caches successful collection existence checks across repeated bootstraps", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ name: "motian_jobs_preview" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await ensureTypesenseCollection("jobs");
+    await ensureTypesenseCollection("jobs");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(isTypesenseCollectionKnownMissing("jobs")).toBe(false);
+  });
+
+  it("allows explicit bootstrap to recover after a collection was previously marked missing", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(jsonResponse({ name: "motian_jobs_preview" }, 201));
+    vi.stubGlobal("fetch", fetchMock);
+
+    markTypesenseCollectionMissing("jobs");
+    expect(isTypesenseCollectionKnownMissing("jobs")).toBe(true);
+
+    await ensureTypesenseCollection("jobs");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(isTypesenseCollectionKnownMissing("jobs")).toBe(false);
+  });
+});

--- a/tests/typesense-search.test.ts
+++ b/tests/typesense-search.test.ts
@@ -1,8 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockGetTypesenseConfig, mockIsTypesenseEnabled, mockTypesenseRequest } = vi.hoisted(() => ({
+const {
+  mockGetTypesenseConfig,
+  mockIsTypesenseCollectionKnownMissing,
+  mockIsTypesenseEnabled,
+  mockIsTypesenseCollectionMissingError,
+  mockMarkTypesenseCollectionMissing,
+  mockTypesenseRequest,
+} = vi.hoisted(() => ({
   mockGetTypesenseConfig: vi.fn(),
+  mockIsTypesenseCollectionKnownMissing: vi.fn(),
   mockIsTypesenseEnabled: vi.fn(),
+  mockIsTypesenseCollectionMissingError: vi.fn(),
+  mockMarkTypesenseCollectionMissing: vi.fn(),
   mockTypesenseRequest: vi.fn(),
 }));
 
@@ -12,6 +22,9 @@ vi.mock("../src/lib/typesense", () => ({
 }));
 
 vi.mock("../src/services/search-index/typesense-client", () => ({
+  isTypesenseCollectionKnownMissing: mockIsTypesenseCollectionKnownMissing,
+  isTypesenseCollectionMissingError: mockIsTypesenseCollectionMissingError,
+  markTypesenseCollectionMissing: mockMarkTypesenseCollectionMissing,
   typesenseRequest: mockTypesenseRequest,
 }));
 
@@ -26,6 +39,8 @@ describe("typesense search", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsTypesenseEnabled.mockReturnValue(true);
+    mockIsTypesenseCollectionKnownMissing.mockReturnValue(false);
+    mockIsTypesenseCollectionMissingError.mockReturnValue(false);
     mockGetTypesenseConfig.mockReturnValue({
       url: "https://typesense.example.com",
       apiKey: "secret-key",
@@ -116,6 +131,34 @@ describe("typesense search", () => {
 
     expect(result).toBeNull();
     expect(mockTypesenseRequest).not.toHaveBeenCalled();
+  });
+
+  it("skips vacature typesense search when the collection is already marked missing", async () => {
+    mockIsTypesenseCollectionKnownMissing.mockReturnValue(true);
+
+    const result = await searchJobIdsByTypesense("java developer", {
+      platform: "opdrachtoverheid",
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(result).toBeNull();
+    expect(mockTypesenseRequest).not.toHaveBeenCalled();
+  });
+
+  it("marks vacature collections missing and returns null when Typesense reports a missing collection", async () => {
+    const error = new Error("collection missing");
+    mockTypesenseRequest.mockRejectedValue(error);
+    mockIsTypesenseCollectionMissingError.mockReturnValue(true);
+
+    const result = await searchJobIdsByTypesense("java developer", {
+      platform: "opdrachtoverheid",
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(result).toBeNull();
+    expect(mockMarkTypesenseCollectionMissing).toHaveBeenCalledWith("jobs");
   });
 
   it("builds kandidaat search params and returns ids plus total", async () => {

--- a/tests/typesense-sync.test.ts
+++ b/tests/typesense-sync.test.ts
@@ -4,7 +4,9 @@ const {
   mockSelect,
   mockFrom,
   mockWhere,
-  mockEnsureTypesenseCollection,
+  mockIsTypesenseCollectionKnownMissing,
+  mockIsTypesenseCollectionMissingError,
+  mockMarkTypesenseCollectionMissing,
   mockTypesenseRequest,
   mockIsTypesenseEnabled,
   mockGetTypesenseConfig,
@@ -12,7 +14,9 @@ const {
   mockSelect: vi.fn(),
   mockFrom: vi.fn(),
   mockWhere: vi.fn(),
-  mockEnsureTypesenseCollection: vi.fn(),
+  mockIsTypesenseCollectionKnownMissing: vi.fn(),
+  mockIsTypesenseCollectionMissingError: vi.fn(),
+  mockMarkTypesenseCollectionMissing: vi.fn(),
   mockTypesenseRequest: vi.fn(),
   mockIsTypesenseEnabled: vi.fn(),
   mockGetTypesenseConfig: vi.fn(),
@@ -37,7 +41,9 @@ vi.mock("../src/services/jobs/filters", () => ({
 }));
 
 vi.mock("../src/services/search-index/typesense-client", () => ({
-  ensureTypesenseCollection: mockEnsureTypesenseCollection,
+  isTypesenseCollectionKnownMissing: mockIsTypesenseCollectionKnownMissing,
+  isTypesenseCollectionMissingError: mockIsTypesenseCollectionMissingError,
+  markTypesenseCollectionMissing: mockMarkTypesenseCollectionMissing,
   typesenseRequest: mockTypesenseRequest,
 }));
 
@@ -59,6 +65,8 @@ describe("typesense sync", () => {
       where: mockWhere,
     });
     mockIsTypesenseEnabled.mockReturnValue(true);
+    mockIsTypesenseCollectionKnownMissing.mockReturnValue(false);
+    mockIsTypesenseCollectionMissingError.mockReturnValue(false);
     mockGetTypesenseConfig.mockReturnValue({
       url: "https://typesense.example.com",
       apiKey: "secret-key",
@@ -75,7 +83,6 @@ describe("typesense sync", () => {
     await upsertJobsByIds(["job-1"]);
 
     expect(mockWhere).not.toHaveBeenCalled();
-    expect(mockEnsureTypesenseCollection).not.toHaveBeenCalled();
     expect(mockTypesenseRequest).not.toHaveBeenCalled();
   });
 
@@ -93,7 +100,6 @@ describe("typesense sync", () => {
 
     await upsertJobsByIds(["job-1", "job-2"]);
 
-    expect(mockEnsureTypesenseCollection).toHaveBeenCalledWith("jobs");
     expect(mockTypesenseRequest).toHaveBeenNthCalledWith(
       1,
       "/collections/motian_jobs_preview/documents/import",
@@ -136,7 +142,6 @@ describe("typesense sync", () => {
 
     await upsertCandidatesByIds(["candidate-1"]);
 
-    expect(mockEnsureTypesenseCollection).toHaveBeenCalledWith("candidates");
     expect(mockTypesenseRequest).toHaveBeenCalledWith(
       "/collections/motian_candidates_preview/documents/import",
       expect.objectContaining({
@@ -162,5 +167,35 @@ describe("typesense sync", () => {
       "/collections/motian_candidates_preview/documents/candidate-1",
       { method: "DELETE", skipNotFound: true },
     );
+  });
+
+  it("skips hot-path sync work when a collection is already known missing", async () => {
+    mockIsTypesenseCollectionKnownMissing.mockReturnValue(true);
+
+    await upsertJobsByIds(["job-1"]);
+    await deleteCandidatesByIds(["candidate-1"]);
+
+    expect(mockTypesenseRequest).not.toHaveBeenCalled();
+  });
+
+  it("marks job collections missing when Typesense import reports a missing collection", async () => {
+    mockWhere.mockResolvedValue([
+      {
+        id: "job-1",
+        title: "Senior Java Developer",
+        searchText: "Senior Java Developer",
+        platform: "opdrachtoverheid",
+        status: "open",
+        categories: ["ICT"],
+      },
+    ]);
+
+    const missingCollectionError = new Error("missing collection");
+    mockTypesenseRequest.mockRejectedValue(missingCollectionError);
+    mockIsTypesenseCollectionMissingError.mockReturnValue(true);
+
+    await upsertJobsByIds(["job-1"]);
+
+    expect(mockMarkTypesenseCollectionMissing).toHaveBeenCalledWith("jobs");
   });
 });


### PR DESCRIPTION
## Summary
- centralize Typesense collection bootstrap state in the client layer and keep bootstrap on explicit entrypoints only
- remove hot-path ensure calls from sync/search flows and short-circuit when a collection is known missing
- add health-route, build-hook, and regression-test coverage for graceful DB fallback when Typesense is unavailable

## Validation
- `pnpm exec vitest run tests/typesense-search.test.ts tests/typesense-sync.test.ts tests/typesense-client.test.ts tests/api-gezondheid-route.test.ts tests/typesense-bootstrap-config.test.ts`
- `pnpm exec biome check app/api/gezondheid/route.ts src/services/search-index/typesense-client.ts src/services/search-index/typesense-search.ts src/services/search-index/typesense-sync.ts scripts/bootstrap-typesense.ts scripts/reindex-typesense.ts tests/typesense-client.test.ts tests/typesense-search.test.ts tests/typesense-sync.test.ts tests/api-gezondheid-route.test.ts tests/typesense-bootstrap-config.test.ts package.json`
- `pnpm exec tsc --noEmit`
- `pnpm search:bootstrap`

## Blockers
- `pnpm lint` still reports pre-existing unrelated Biome issues already present on `main`
- full `pnpm build` and live `/api/gezondheid` validation require valid `DATABASE_URL` credentials in this workspace; with placeholder credentials the route reaches the new bootstrap step, then fails on DB auth

## Links
- Linear: https://linear.app/rcjt-studio/issue/RJC-63/lazy-typesense-bootstrap-move-ensurecollection-off-hot-paths

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
