### PR TITLE
Complete shared list virtualization for kandidaten, vacatures, and chat

### DIFF
--- a/app/kandidaten/page.tsx
+++ b/app/kandidaten/page.tsx
@@ -1,13 +1,11 @@
-import { Euro, MapPin, Search, UserPlus, Users, Zap } from "lucide-react";
-import Link from "next/link";
+import { Search, UserPlus, Users, Zap } from "lucide-react";
 import { Suspense } from "react";
 import { AddCandidateWizard } from "@/components/add-candidate-wizard";
-import { DraggableCandidate } from "@/components/draggable-candidate";
+import { CandidateResultsList } from "@/components/candidate-results-list";
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
 import { KPICard } from "@/components/shared/kpi-card";
 import { Pagination } from "@/components/shared/pagination";
-import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { parsePagination } from "@/src/lib/pagination";
 import { countCandidates, listCandidates, searchCandidates } from "@/src/services/candidates";
@@ -30,12 +28,6 @@ interface Props {
 
 const DEFAULT_PER_PAGE = 20;
 const MAX_PER_PAGE = 50;
-
-const availabilityLabels: Record<string, string> = {
-  direct: "Direct beschikbaar",
-  "1_maand": "Binnen 1 maand",
-  "3_maanden": "Binnen 3 maanden",
-};
 
 function KandidatenSkeleton() {
   return (
@@ -207,96 +199,7 @@ async function KandidatenContent({ searchParams }: Props) {
             subtitle="Pas je zoekopdracht of filters aan"
           />
         ) : (
-          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-            {candidateRows.map((candidate) => {
-              const skills = Array.isArray(candidate.skills) ? (candidate.skills as string[]) : [];
-
-              return (
-                <DraggableCandidate
-                  key={candidate.id}
-                  candidateId={candidate.id}
-                  candidateName={candidate.name}
-                >
-                  <Link href={`/kandidaten/${candidate.id}`}>
-                    <div className="bg-card border border-border rounded-lg p-3 sm:p-4 hover:border-primary/40 hover:bg-accent transition-colors cursor-pointer pl-6">
-                      {/* Name + source */}
-                      <div className="flex items-start justify-between gap-2 mb-2 sm:mb-3">
-                        <div>
-                          <h3 className="text-sm font-semibold text-foreground leading-snug">
-                            {candidate.name}
-                          </h3>
-                          {candidate.role && (
-                            <p className="text-xs text-muted-foreground mt-0.5">{candidate.role}</p>
-                          )}
-                        </div>
-                        {candidate.source && (
-                          <Badge
-                            variant="outline"
-                            className="shrink-0 text-[10px] capitalize border-border text-muted-foreground bg-transparent"
-                          >
-                            {candidate.source}
-                          </Badge>
-                        )}
-                      </div>
-
-                      {/* Meta */}
-                      <div className="flex flex-wrap gap-x-4 gap-y-1.5 text-sm text-muted-foreground mb-2 sm:mb-3">
-                        {candidate.location && (
-                          <span className="flex items-center gap-1.5">
-                            <MapPin className="h-3.5 w-3.5" />
-                            {candidate.location}
-                          </span>
-                        )}
-                        {candidate.hourlyRate && (
-                          <span className="flex items-center gap-1.5">
-                            <Euro className="h-3.5 w-3.5" />
-                            {candidate.hourlyRate}/uur
-                          </span>
-                        )}
-                      </div>
-
-                      {/* Skills */}
-                      {skills.length > 0 && (
-                        <div className="flex flex-wrap gap-1.5 mb-2 sm:mb-3">
-                          {skills.slice(0, 5).map((skill) => (
-                            <Badge
-                              key={`${candidate.id}-${skill}`}
-                              variant="outline"
-                              className="bg-primary/10 text-primary border-primary/20 text-[10px]"
-                            >
-                              {skill}
-                            </Badge>
-                          ))}
-                          {skills.length > 5 && (
-                            <Badge
-                              variant="outline"
-                              className="text-[10px] border-border text-muted-foreground bg-transparent"
-                            >
-                              +{skills.length - 5}
-                            </Badge>
-                          )}
-                        </div>
-                      )}
-
-                      {/* Availability badge */}
-                      {candidate.availability && (
-                        <Badge
-                          variant="outline"
-                          className={
-                            candidate.availability === "direct"
-                              ? "bg-primary/10 text-primary border-primary/20 text-[10px]"
-                              : "text-[10px] border-border text-muted-foreground bg-transparent"
-                          }
-                        >
-                          {availabilityLabels[candidate.availability] ?? candidate.availability}
-                        </Badge>
-                      )}
-                    </div>
-                  </Link>
-                </DraggableCandidate>
-              );
-            })}
-          </div>
+          <CandidateResultsList candidates={candidateRows} />
         )}
 
         {/* Pagination */}

--- a/components/candidate-results-list.tsx
+++ b/components/candidate-results-list.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { Euro, MapPin } from "lucide-react";
+import Link from "next/link";
+import { DraggableCandidate } from "@/components/draggable-candidate";
+import { VirtualList } from "@/components/shared/virtual-list";
+import { Badge } from "@/components/ui/badge";
+import { useIsMobile } from "@/hooks/use-mobile";
+
+const MOBILE_VIRTUALIZATION_THRESHOLD = 18;
+const MOBILE_CANDIDATE_ESTIMATE = 236;
+
+const availabilityLabels: Record<string, string> = {
+  direct: "Direct beschikbaar",
+  "1_maand": "Binnen 1 maand",
+  "3_maanden": "Binnen 3 maanden",
+};
+
+export type CandidateResultsListItem = {
+  id: string;
+  name: string;
+  role: string | null;
+  source: string | null;
+  location: string | null;
+  hourlyRate: number | null;
+  availability: string | null;
+  skills: unknown;
+};
+
+function CandidateResultCard({ candidate }: { candidate: CandidateResultsListItem }) {
+  const skills = Array.isArray(candidate.skills) ? (candidate.skills as string[]) : [];
+
+  return (
+    <DraggableCandidate candidateId={candidate.id} candidateName={candidate.name}>
+      <Link href={`/kandidaten/${candidate.id}`}>
+        <div className="bg-card border border-border rounded-lg p-3 sm:p-4 hover:border-primary/40 hover:bg-accent transition-colors cursor-pointer pl-6">
+          <div className="flex items-start justify-between gap-2 mb-2 sm:mb-3">
+            <div>
+              <h3 className="text-sm font-semibold text-foreground leading-snug">
+                {candidate.name}
+              </h3>
+              {candidate.role && (
+                <p className="text-xs text-muted-foreground mt-0.5">{candidate.role}</p>
+              )}
+            </div>
+            {candidate.source && (
+              <Badge
+                variant="outline"
+                className="shrink-0 text-[10px] capitalize border-border text-muted-foreground bg-transparent"
+              >
+                {candidate.source}
+              </Badge>
+            )}
+          </div>
+
+          <div className="flex flex-wrap gap-x-4 gap-y-1.5 text-sm text-muted-foreground mb-2 sm:mb-3">
+            {candidate.location && (
+              <span className="flex items-center gap-1.5">
+                <MapPin className="h-3.5 w-3.5" />
+                {candidate.location}
+              </span>
+            )}
+            {candidate.hourlyRate && (
+              <span className="flex items-center gap-1.5">
+                <Euro className="h-3.5 w-3.5" />
+                {candidate.hourlyRate}/uur
+              </span>
+            )}
+          </div>
+
+          {skills.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mb-2 sm:mb-3">
+              {skills.slice(0, 5).map((skill) => (
+                <Badge
+                  key={`${candidate.id}-${skill}`}
+                  variant="outline"
+                  className="bg-primary/10 text-primary border-primary/20 text-[10px]"
+                >
+                  {skill}
+                </Badge>
+              ))}
+              {skills.length > 5 && (
+                <Badge
+                  variant="outline"
+                  className="text-[10px] border-border text-muted-foreground bg-transparent"
+                >
+                  +{skills.length - 5}
+                </Badge>
+              )}
+            </div>
+          )}
+
+          {candidate.availability && (
+            <Badge
+              variant="outline"
+              className={
+                candidate.availability === "direct"
+                  ? "bg-primary/10 text-primary border-primary/20 text-[10px]"
+                  : "text-[10px] border-border text-muted-foreground bg-transparent"
+              }
+            >
+              {availabilityLabels[candidate.availability] ?? candidate.availability}
+            </Badge>
+          )}
+        </div>
+      </Link>
+    </DraggableCandidate>
+  );
+}
+
+export function CandidateResultsList({ candidates }: { candidates: CandidateResultsListItem[] }) {
+  const isMobile = useIsMobile();
+  const shouldVirtualize = isMobile && candidates.length > MOBILE_VIRTUALIZATION_THRESHOLD;
+
+  if (shouldVirtualize) {
+    return (
+      <VirtualList
+        items={candidates}
+        getItemKey={(candidate) => candidate.id}
+        estimateSize={() => MOBILE_CANDIDATE_ESTIMATE}
+        scrollMode="parent"
+        gap={12}
+        className="min-h-0"
+        renderItem={(candidate) => <CandidateResultCard candidate={candidate} />}
+      />
+    );
+  }
+
+  return (
+    <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+      {candidates.map((candidate) => (
+        <CandidateResultCard key={candidate.id} candidate={candidate} />
+      ))}
+    </div>
+  );
+}

--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -21,6 +21,7 @@ import {
   Users,
 } from "lucide-react";
 import { Suspense, useCallback, useId, useState } from "react";
+import { VirtualList } from "@/components/shared/virtual-list";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import {
@@ -121,6 +122,10 @@ const DEFAULT_EMPTY_STATE_PROMPTS: ChatSuggestion[] = [
     toneClassName: "bg-cyan-500/10 text-cyan-600 dark:text-cyan-400",
   },
 ];
+
+const CHAT_HISTORY_VIRTUALIZATION_THRESHOLD = 50;
+const CHAT_MESSAGE_GAP = 32;
+const CHAT_MESSAGE_ESTIMATE = 180;
 
 function ReasoningBlock({ text, state }: { text: string; state?: "streaming" | "done" }) {
   const hasContent = text.length > 0;
@@ -305,6 +310,174 @@ function AssistantMessageActions({
   );
 }
 
+function ChatMessageItem({
+  message,
+  currentOrigin,
+  onRetry,
+}: {
+  message: UIMessage;
+  currentOrigin?: string | null;
+  onRetry?: (messageId: string) => void;
+}) {
+  return (
+    <Message from={message.role}>
+      <MessageContent>
+        {message.parts.map((part, partIndex) => {
+          const partKey = `${message.id}-${partIndex}`;
+
+          if (part.type === "text") {
+            if (message.role === "user") {
+              return (
+                <p key={partKey} className="whitespace-pre-wrap leading-relaxed">
+                  {part.text}
+                </p>
+              );
+            }
+
+            return (
+              <MessageResponse
+                key={partKey}
+                allowedTags={CHAT_MESSAGE_ALLOWED_TAGS}
+                components={CHAT_MESSAGE_COMPONENTS}
+              >
+                {rewriteChatJobLinks(part.text, currentOrigin)}
+              </MessageResponse>
+            );
+          }
+
+          if (part.type === "reasoning") {
+            const reasoningPart = part as {
+              type: "reasoning";
+              text: string;
+              state?: "streaming" | "done";
+            };
+
+            return (
+              <ReasoningBlock key={partKey} text={reasoningPart.text} state={reasoningPart.state} />
+            );
+          }
+
+          if (part.type === "source-url") {
+            const sourcePart = part as {
+              type: "source-url";
+              sourceId: string;
+              url: string;
+              title?: string;
+            };
+
+            return (
+              <SourceUrlBlock
+                key={partKey}
+                url={sourcePart.url}
+                title={sourcePart.title ?? sourcePart.url}
+              />
+            );
+          }
+
+          if (part.type === "source-document") {
+            const docPart = part as {
+              type: "source-document";
+              sourceId: string;
+              mediaType: string;
+              title: string;
+            };
+
+            return (
+              <SourceDocumentBlock
+                key={partKey}
+                title={docPart.title}
+                mediaType={docPart.mediaType}
+              />
+            );
+          }
+
+          if (isToolUIPart(part)) {
+            const toolPart = part as {
+              type: string;
+              toolName?: string;
+              state: string;
+              input?: unknown;
+              output?: unknown;
+            };
+            const name = toolPart.toolName ?? getToolName(part);
+            const entry = name ? GENUI_REGISTRY[name] : undefined;
+            const isErrorOutput =
+              toolPart.output && typeof toolPart.output === "object" && "error" in toolPart.output;
+
+            if (toolPart.state === "output-error") {
+              const messageText =
+                toolPart.output &&
+                typeof toolPart.output === "object" &&
+                "error" in toolPart.output &&
+                typeof (toolPart.output as { error: unknown }).error === "string"
+                  ? (toolPart.output as { error: string }).error
+                  : "Er is iets misgegaan bij deze actie.";
+              return <ToolErrorBlock key={partKey} message={messageText} />;
+            }
+
+            if (
+              toolPart.state === "output-available" &&
+              toolPart.output !== undefined &&
+              isA2UIEnvelope(toolPart.output)
+            ) {
+              const resolved = resolveA2UIComponent(toolPart.output);
+              if (resolved.entry) {
+                const GenUICard = resolved.entry.component;
+                return (
+                  <Suspense
+                    key={partKey}
+                    fallback={<GenUILoadingSkeleton label={resolved.entry.label} />}
+                  >
+                    <div>
+                      <GenUICard output={resolved.props} />
+                      {resolved.actions && resolved.actions.length > 0 && (
+                        <A2UIActionBar actions={resolved.actions} />
+                      )}
+                    </div>
+                  </Suspense>
+                );
+              }
+              return <A2UIFallback key={partKey} envelope={toolPart.output} />;
+            }
+
+            if (toolPart.state === "output-available" && entry && toolPart.output !== undefined) {
+              if (isErrorOutput) {
+                const messageText =
+                  typeof (toolPart.output as { error: unknown }).error === "string"
+                    ? (toolPart.output as { error: string }).error
+                    : "Niet gevonden.";
+                return <ToolErrorBlock key={partKey} message={messageText} />;
+              }
+
+              const GenUICard = entry.component;
+              return (
+                <Suspense key={partKey} fallback={<GenUILoadingSkeleton label={entry.label} />}>
+                  <GenUICard output={toolPart.output} />
+                </Suspense>
+              );
+            }
+
+            return (
+              <ChatToolCall
+                key={partKey}
+                toolName={name}
+                state={toolPart.state}
+                input={toolPart.input}
+                output={toolPart.output}
+              />
+            );
+          }
+
+          return null;
+        })}
+      </MessageContent>
+      {message.role === "assistant" && (
+        <AssistantMessageActions message={message} onRetry={onRetry} />
+      )}
+    </Message>
+  );
+}
+
 export function ChatMessages({
   messages,
   status,
@@ -324,6 +497,8 @@ export function ChatMessages({
   const hasUserMessage = messages.some((message) => message.role === "user");
   const isWidget = layout === "widget";
   const showFollowUpPrompts = hasUserMessage && status === "ready" && followUpPrompts.length > 0;
+  const shouldVirtualizeHistory =
+    hasUserMessage && messages.length > CHAT_HISTORY_VIRTUALIZATION_THRESHOLD;
 
   return (
     <Conversation className="flex-1" aria-label={conversationLabel}>
@@ -360,177 +535,28 @@ export function ChatMessages({
           </div>
         ) : null}
 
-        {messages.map((message) => (
-          <Message key={message.id} from={message.role}>
-            <MessageContent>
-              {message.parts.map((part, partIndex) => {
-                const partKey = `${message.id}-${partIndex}`;
-
-                if (part.type === "text") {
-                  if (message.role === "user") {
-                    return (
-                      <p key={partKey} className="whitespace-pre-wrap leading-relaxed">
-                        {part.text}
-                      </p>
-                    );
-                  }
-
-                  return (
-                    <MessageResponse
-                      key={partKey}
-                      allowedTags={CHAT_MESSAGE_ALLOWED_TAGS}
-                      components={CHAT_MESSAGE_COMPONENTS}
-                    >
-                      {rewriteChatJobLinks(part.text, currentOrigin)}
-                    </MessageResponse>
-                  );
-                }
-
-                if (part.type === "reasoning") {
-                  const reasoningPart = part as {
-                    type: "reasoning";
-                    text: string;
-                    state?: "streaming" | "done";
-                  };
-
-                  return (
-                    <ReasoningBlock
-                      key={partKey}
-                      text={reasoningPart.text}
-                      state={reasoningPart.state}
-                    />
-                  );
-                }
-
-                if (part.type === "source-url") {
-                  const sourcePart = part as {
-                    type: "source-url";
-                    sourceId: string;
-                    url: string;
-                    title?: string;
-                  };
-
-                  return (
-                    <SourceUrlBlock
-                      key={partKey}
-                      url={sourcePart.url}
-                      title={sourcePart.title ?? sourcePart.url}
-                    />
-                  );
-                }
-
-                if (part.type === "source-document") {
-                  const docPart = part as {
-                    type: "source-document";
-                    sourceId: string;
-                    mediaType: string;
-                    title: string;
-                  };
-
-                  return (
-                    <SourceDocumentBlock
-                      key={partKey}
-                      title={docPart.title}
-                      mediaType={docPart.mediaType}
-                    />
-                  );
-                }
-
-                if (isToolUIPart(part)) {
-                  const toolPart = part as {
-                    type: string;
-                    toolName?: string;
-                    state: string;
-                    input?: unknown;
-                    output?: unknown;
-                  };
-                  const name = toolPart.toolName ?? getToolName(part);
-                  const entry = name ? GENUI_REGISTRY[name] : undefined;
-                  const isErrorOutput =
-                    toolPart.output &&
-                    typeof toolPart.output === "object" &&
-                    "error" in toolPart.output;
-
-                  if (toolPart.state === "output-error") {
-                    const messageText =
-                      toolPart.output &&
-                      typeof toolPart.output === "object" &&
-                      "error" in toolPart.output &&
-                      typeof (toolPart.output as { error: unknown }).error === "string"
-                        ? (toolPart.output as { error: string }).error
-                        : "Er is iets misgegaan bij deze actie.";
-                    return <ToolErrorBlock key={partKey} message={messageText} />;
-                  }
-
-                  // ── A2UI envelope detection ──
-                  if (
-                    toolPart.state === "output-available" &&
-                    toolPart.output !== undefined &&
-                    isA2UIEnvelope(toolPart.output)
-                  ) {
-                    const resolved = resolveA2UIComponent(toolPart.output);
-                    if (resolved.entry) {
-                      const GenUICard = resolved.entry.component;
-                      return (
-                        <Suspense
-                          key={partKey}
-                          fallback={<GenUILoadingSkeleton label={resolved.entry.label} />}
-                        >
-                          <div>
-                            <GenUICard output={resolved.props} />
-                            {resolved.actions && resolved.actions.length > 0 && (
-                              <A2UIActionBar actions={resolved.actions} />
-                            )}
-                          </div>
-                        </Suspense>
-                      );
-                    }
-                    return <A2UIFallback key={partKey} envelope={toolPart.output} />;
-                  }
-
-                  if (
-                    toolPart.state === "output-available" &&
-                    entry &&
-                    toolPart.output !== undefined
-                  ) {
-                    if (isErrorOutput) {
-                      const messageText =
-                        typeof (toolPart.output as { error: unknown }).error === "string"
-                          ? (toolPart.output as { error: string }).error
-                          : "Niet gevonden.";
-                      return <ToolErrorBlock key={partKey} message={messageText} />;
-                    }
-
-                    const GenUICard = entry.component;
-                    return (
-                      <Suspense
-                        key={partKey}
-                        fallback={<GenUILoadingSkeleton label={entry.label} />}
-                      >
-                        <GenUICard output={toolPart.output} />
-                      </Suspense>
-                    );
-                  }
-
-                  return (
-                    <ChatToolCall
-                      key={partKey}
-                      toolName={name}
-                      state={toolPart.state}
-                      input={toolPart.input}
-                      output={toolPart.output}
-                    />
-                  );
-                }
-
-                return null;
-              })}
-            </MessageContent>
-            {message.role === "assistant" && (
-              <AssistantMessageActions message={message} onRetry={onRetry} />
+        {shouldVirtualizeHistory ? (
+          <VirtualList
+            items={messages}
+            getItemKey={(message) => message.id}
+            estimateSize={() => CHAT_MESSAGE_ESTIMATE}
+            gap={CHAT_MESSAGE_GAP}
+            scrollMode="parent"
+            className="min-h-0"
+            renderItem={(message) => (
+              <ChatMessageItem message={message} currentOrigin={currentOrigin} onRetry={onRetry} />
             )}
-          </Message>
-        ))}
+          />
+        ) : (
+          messages.map((message) => (
+            <ChatMessageItem
+              key={message.id}
+              message={message}
+              currentOrigin={currentOrigin}
+              onRetry={onRetry}
+            />
+          ))
+        )}
 
         {showFollowUpPrompts ? (
           <section className="mt-2 flex flex-col gap-3 rounded-2xl border border-dashed border-border/70 bg-muted/20 p-3 sm:p-4">

--- a/components/shared/virtual-list.tsx
+++ b/components/shared/virtual-list.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
+
+const DEFAULT_MOBILE_OVERSCAN = 4;
+const DEFAULT_DESKTOP_OVERSCAN = 6;
+
+type ScrollMode = "self" | "parent";
+
+export function resolveVirtualListOverscan(overscan: number | undefined, isMobile: boolean) {
+  return overscan ?? (isMobile ? DEFAULT_MOBILE_OVERSCAN : DEFAULT_DESKTOP_OVERSCAN);
+}
+
+function findScrollParent(node: HTMLElement | null): HTMLElement | null {
+  let current = node?.parentElement ?? null;
+
+  while (current) {
+    const style = window.getComputedStyle(current);
+    const overflowY = style.overflowY;
+    if (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") {
+      return current;
+    }
+    current = current.parentElement;
+  }
+
+  return null;
+}
+
+function measureScrollMargin(node: HTMLElement, scrollElement: HTMLElement) {
+  const nodeRect = node.getBoundingClientRect();
+  const scrollRect = scrollElement.getBoundingClientRect();
+  return nodeRect.top - scrollRect.top + scrollElement.scrollTop;
+}
+
+export interface VirtualListProps<T> {
+  items: readonly T[];
+  renderItem: (item: T, index: number) => ReactNode;
+  getItemKey?: (item: T, index: number) => string | number;
+  estimateSize?: (item: T, index: number) => number;
+  overscan?: number;
+  gap?: number;
+  scrollMode?: ScrollMode;
+  smoothScroll?: boolean;
+  className?: string;
+  contentClassName?: string;
+  itemClassName?: string;
+}
+
+export function VirtualList<T>({
+  items,
+  renderItem,
+  getItemKey,
+  estimateSize,
+  overscan,
+  gap = 0,
+  scrollMode = "self",
+  smoothScroll = true,
+  className,
+  contentClassName,
+  itemClassName,
+}: VirtualListProps<T>) {
+  const isMobile = useIsMobile();
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const selfScrollRef = useRef<HTMLDivElement | null>(null);
+  const [parentScrollElement, setParentScrollElement] = useState<HTMLElement | null>(null);
+  const [scrollMargin, setScrollMargin] = useState(0);
+
+  const resolvedOverscan = resolveVirtualListOverscan(overscan, isMobile);
+
+  const updateParentScrollState = useCallback(() => {
+    if (scrollMode !== "parent") return;
+    const root = rootRef.current;
+    if (!root) return;
+
+    const nextScrollParent = findScrollParent(root);
+    setParentScrollElement(nextScrollParent);
+
+    if (nextScrollParent) {
+      setScrollMargin(measureScrollMargin(root, nextScrollParent));
+    }
+  }, [scrollMode]);
+
+  const setRootRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      rootRef.current = node;
+      if (scrollMode === "parent" && node) {
+        const nextScrollParent = findScrollParent(node);
+        setParentScrollElement(nextScrollParent);
+        if (nextScrollParent) {
+          setScrollMargin(measureScrollMargin(node, nextScrollParent));
+        }
+      }
+    },
+    [scrollMode],
+  );
+
+  useEffect(() => {
+    if (scrollMode !== "parent") return undefined;
+    updateParentScrollState();
+
+    const root = rootRef.current;
+    const scrollElement = parentScrollElement;
+
+    const handleResize = () => updateParentScrollState();
+    window.addEventListener("resize", handleResize);
+
+    let resizeObserver: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== "undefined" && root && scrollElement) {
+      resizeObserver = new ResizeObserver(handleResize);
+      resizeObserver.observe(root);
+      resizeObserver.observe(scrollElement);
+    }
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      resizeObserver?.disconnect();
+    };
+  }, [parentScrollElement, scrollMode, updateParentScrollState]);
+
+  const scrollElement = scrollMode === "parent" ? parentScrollElement : selfScrollRef.current;
+
+  useEffect(() => {
+    if (!smoothScroll || !scrollElement) return undefined;
+
+    const previousScrollBehavior = scrollElement.style.scrollBehavior;
+    scrollElement.style.scrollBehavior = "smooth";
+
+    return () => {
+      scrollElement.style.scrollBehavior = previousScrollBehavior;
+    };
+  }, [scrollElement, smoothScroll]);
+
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => scrollElement,
+    estimateSize: (index) => estimateSize?.(items[index] as T, index) ?? 160,
+    getItemKey: (index) => getItemKey?.(items[index] as T, index) ?? index,
+    overscan: resolvedOverscan,
+    gap,
+    scrollMargin: scrollMode === "parent" ? scrollMargin : 0,
+    measureElement: (element) => element?.getBoundingClientRect().height ?? 0,
+  });
+
+  const virtualItems = virtualizer.getVirtualItems();
+  const isParentModeReady = scrollMode === "self" || parentScrollElement !== null;
+
+  const absoluteItems = useMemo(
+    () =>
+      virtualItems.map((virtualItem) => {
+        const item = items[virtualItem.index] as T;
+        const itemKey = getItemKey?.(item, virtualItem.index) ?? virtualItem.key;
+        const translateY =
+          scrollMode === "parent" ? virtualItem.start - scrollMargin : virtualItem.start;
+
+        return (
+          <div
+            key={itemKey}
+            ref={virtualizer.measureElement}
+            data-index={virtualItem.index}
+            data-virtual-list-item="true"
+            className={cn("absolute left-0 top-0 w-full", itemClassName)}
+            style={{ transform: `translateY(${translateY}px)` }}
+          >
+            {renderItem(item, virtualItem.index)}
+          </div>
+        );
+      }),
+    [
+      getItemKey,
+      itemClassName,
+      items,
+      renderItem,
+      scrollMargin,
+      scrollMode,
+      virtualItems,
+      virtualizer.measureElement,
+    ],
+  );
+
+  if (scrollMode === "parent" && !isParentModeReady) {
+    return (
+      <div ref={setRootRef} className={className}>
+        {items.map((item, index) => (
+          <div key={getItemKey?.(item, index) ?? index}>{renderItem(item, index)}</div>
+        ))}
+      </div>
+    );
+  }
+
+  const virtualizedContent = (
+    <div
+      data-virtual-list="true"
+      className={cn("relative w-full", contentClassName)}
+      style={{ height: `${virtualizer.getTotalSize()}px` }}
+    >
+      {absoluteItems}
+    </div>
+  );
+
+  if (scrollMode === "parent") {
+    return (
+      <div ref={setRootRef} className={className}>
+        {virtualizedContent}
+      </div>
+    );
+  }
+
+  return (
+    <div ref={setRootRef} className="min-h-0 flex-1">
+      <div ref={selfScrollRef} className={cn("min-h-0 flex-1 overflow-y-auto", className)}>
+        {virtualizedContent}
+      </div>
+    </div>
+  );
+}

--- a/components/sidebar/sidebar-job-list.tsx
+++ b/components/sidebar/sidebar-job-list.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
 /**
  * Job list with ScrollArea, supporting both compact (dark) and overview (card) variants.
  */
 import { JobListItem } from "@/components/job-list-item";
+import { VirtualList } from "@/components/shared/virtual-list";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { useIsMobile } from "@/hooks/use-mobile";
 import type { SidebarJob } from "./sidebar-types";
 
 interface SidebarJobListProps {
@@ -16,75 +15,37 @@ interface SidebarJobListProps {
   variant: "compact" | "overview";
 }
 
-const COMPACT_ITEM_HEIGHT = 110;
-const OVERVIEW_ITEM_HEIGHT = 260;
-const OVERSCAN = 6;
-
-function MobileVirtualizedJobList({
-  jobs,
-  activeId,
-  buildDetailHref,
-  variant,
-}: SidebarJobListProps) {
-  const itemHeight = variant === "compact" ? COMPACT_ITEM_HEIGHT : OVERVIEW_ITEM_HEIGHT;
-  const [scrollTop, setScrollTop] = useState(0);
-  const [viewportHeight, setViewportHeight] = useState(0);
-
-  const onScroll = useCallback((event: React.UIEvent<HTMLDivElement>) => {
-    const target = event.currentTarget;
-    setScrollTop(target.scrollTop);
-    setViewportHeight(target.clientHeight);
-  }, []);
-
-  const { topOffset, visibleJobs } = useMemo(() => {
-    const firstVisible = Math.floor(scrollTop / itemHeight);
-    const visibleCount = Math.ceil((viewportHeight || itemHeight) / itemHeight);
-    const start = Math.max(0, firstVisible - OVERSCAN);
-    const end = Math.min(jobs.length, firstVisible + visibleCount + OVERSCAN);
-
-    return {
-      topOffset: start * itemHeight,
-      visibleJobs: jobs.slice(start, end),
-    };
-  }, [jobs, itemHeight, scrollTop, viewportHeight]);
-
-  const totalHeight = jobs.length * itemHeight;
-  const wrapperClassName =
-    variant === "compact"
-      ? "min-h-0 flex-1 overflow-y-auto bg-[#050506]"
-      : "min-h-0 flex-1 overflow-y-auto";
-
-  return (
-    <div className={wrapperClassName} onScroll={onScroll}>
-      <div style={{ height: totalHeight, position: "relative" }}>
-        <div style={{ transform: `translateY(${topOffset}px)` }}>
-          {visibleJobs.map((job) => (
-            <JobListItem
-              key={job.id}
-              job={job}
-              isActive={job.id === activeId}
-              variant={variant === "overview" ? "card" : "compact"}
-              hasPipeline={job.hasPipeline}
-              pipelineCount={job.pipelineCount}
-              href={buildDetailHref(job.id)}
-            />
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
+const VIRTUALIZATION_THRESHOLD = 18;
+const COMPACT_ITEM_ESTIMATE = 112;
+const OVERVIEW_ITEM_ESTIMATE = 252;
 
 export function SidebarJobList({ jobs, activeId, buildDetailHref, variant }: SidebarJobListProps) {
-  const isMobile = useIsMobile();
+  const shouldVirtualize = jobs.length > VIRTUALIZATION_THRESHOLD;
 
-  if (isMobile && jobs.length > 18) {
+  const renderJob = (job: SidebarJob) => (
+    <JobListItem
+      key={job.id}
+      job={job}
+      isActive={job.id === activeId}
+      variant={variant === "overview" ? "card" : "compact"}
+      hasPipeline={job.hasPipeline}
+      pipelineCount={job.pipelineCount}
+      href={buildDetailHref(job.id)}
+    />
+  );
+
+  if (shouldVirtualize) {
     return (
-      <MobileVirtualizedJobList
-        jobs={jobs}
-        activeId={activeId}
-        buildDetailHref={buildDetailHref}
-        variant={variant}
+      <VirtualList
+        items={jobs}
+        getItemKey={(job) => job.id}
+        estimateSize={() =>
+          variant === "overview" ? OVERVIEW_ITEM_ESTIMATE : COMPACT_ITEM_ESTIMATE
+        }
+        gap={variant === "overview" ? 16 : 0}
+        scrollMode="self"
+        className={variant === "compact" ? "bg-[#050506]" : "min-w-0"}
+        renderItem={(job) => renderJob(job)}
       />
     );
   }
@@ -95,16 +56,7 @@ export function SidebarJobList({ jobs, activeId, buildDetailHref, variant }: Sid
         {jobs.length === 0 ? (
           <div className="px-4 py-8 text-center text-sm text-white/45">Geen vacatures gevonden</div>
         ) : (
-          jobs.map((job) => (
-            <JobListItem
-              key={job.id}
-              job={job}
-              isActive={job.id === activeId}
-              hasPipeline={job.hasPipeline}
-              pipelineCount={job.pipelineCount}
-              href={buildDetailHref(job.id)}
-            />
-          ))
+          jobs.map((job) => renderJob(job))
         )}
       </ScrollArea>
     );
@@ -117,19 +69,7 @@ export function SidebarJobList({ jobs, activeId, buildDetailHref, variant }: Sid
           Geen vacatures gevonden voor deze filters.
         </div>
       ) : (
-        <div className="space-y-3 pb-4 sm:space-y-4">
-          {jobs.map((job) => (
-            <JobListItem
-              key={job.id}
-              job={job}
-              isActive={job.id === activeId}
-              variant="card"
-              hasPipeline={job.hasPipeline}
-              pipelineCount={job.pipelineCount}
-              href={buildDetailHref(job.id)}
-            />
-          ))}
-        </div>
+        <div className="space-y-3 pb-4 sm:space-y-4">{jobs.map((job) => renderJob(job))}</div>
       )}
     </ScrollArea>
   );

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@streamdown/mermaid": "^1.0.2",
     "@t3-oss/env-nextjs": "^0.13.11",
     "@tanstack/react-query": "^5.96.2",
+    "@tanstack/react-virtual": "^3.13.23",
     "@trigger.dev/react-hooks": "^4.4.3",
     "@trigger.dev/sdk": "4.4.3",
     "@types/react": "^19.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.96.2
         version: 5.96.2(react@19.2.4)
+      '@tanstack/react-virtual':
+        specifier: ^3.13.23
+        version: 3.13.23(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@trigger.dev/react-hooks':
         specifier: ^4.4.3
         version: 4.4.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -3953,6 +3956,15 @@ packages:
     resolution: {integrity: sha512-sYyzzJT4G0g02azzJ8o55VFFV31XvFpdUpG+unxS0vSaYsJnSPKGoI6WdPwUucJL1wpgGfwfmntNX/Ub1uOViA==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-virtual@3.13.23':
+    resolution: {integrity: sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.13.23':
+    resolution: {integrity: sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -13172,6 +13184,14 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.96.2
       react: 19.2.4
+
+  '@tanstack/react-virtual@3.13.23(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.23
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@tanstack/virtual-core@3.13.23': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/tests/list-virtualization.test.ts
+++ b/tests/list-virtualization.test.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveVirtualListOverscan } from "../components/shared/virtual-list";
+
+const ROOT = path.resolve(__dirname, "..");
+
+function readFile(...segments: string[]) {
+  return fs.readFileSync(path.join(ROOT, ...segments), "utf-8");
+}
+
+describe("shared list virtualization", () => {
+  it("defaults overscan to a mobile-friendly window while allowing overrides", () => {
+    expect(resolveVirtualListOverscan(undefined, true)).toBe(4);
+    expect(resolveVirtualListOverscan(undefined, false)).toBe(6);
+    expect(resolveVirtualListOverscan(5, true)).toBe(5);
+  });
+
+  it("wires kandidaten, vacatures, and chat through the shared VirtualList", () => {
+    const virtualList = readFile("components", "shared", "virtual-list.tsx");
+    const kandidatenPage = readFile("app", "kandidaten", "page.tsx");
+    const candidateResults = readFile("components", "candidate-results-list.tsx");
+    const sidebarJobList = readFile("components", "sidebar", "sidebar-job-list.tsx");
+    const chatMessages = readFile("components", "chat", "chat-messages.tsx");
+
+    expect(virtualList).toContain("useVirtualizer");
+    expect(virtualList).toContain("measureElement");
+    expect(virtualList).toContain('scrollElement.style.scrollBehavior = "smooth"');
+
+    expect(kandidatenPage).toContain("CandidateResultsList");
+    expect(candidateResults).toContain("MOBILE_VIRTUALIZATION_THRESHOLD = 18");
+    expect(candidateResults).toContain('scrollMode="parent"');
+    expect(candidateResults).toContain("<VirtualList");
+
+    expect(sidebarJobList).toContain("VirtualList");
+    expect(sidebarJobList).not.toContain("MobileVirtualizedJobList");
+    expect(sidebarJobList).toContain("VIRTUALIZATION_THRESHOLD = 18");
+
+    expect(chatMessages).toContain("CHAT_HISTORY_VIRTUALIZATION_THRESHOLD = 50");
+    expect(chatMessages).toContain("<ChatMessageItem");
+    expect(chatMessages).toContain("<VirtualList");
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared `VirtualList` built on `@tanstack/react-virtual`
- move kandidaten card rendering behind a mobile-first virtualized results component
- replace the vacature sidebar's bespoke list windowing and virtualize long chat histories when message count exceeds 50

## Validation
- `pnpm exec biome check app/kandidaten/page.tsx components/candidate-results-list.tsx components/shared/virtual-list.tsx components/sidebar/sidebar-job-list.tsx components/chat/chat-messages.tsx tests/list-virtualization.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm test -- tests/list-virtualization.test.ts`
- `pnpm test`

## Blocker
- Runtime screenshots and a real-data production build are blocked in this worktree because no valid `DATABASE_URL` is configured here. The workpad on `RJC-64` contains the exact failure output and unblock details.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
