### PR TITLE
RJC-66: optimize fonts and remote company logos

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -38,9 +38,9 @@
   --sidebar-accent-foreground: oklch(0.3012 0 0);
   --sidebar-border: oklch(0.8434 0.0231 87.1621);
   --sidebar-ring: oklch(0.3012 0 0);
-  --font-sans: "Inter", sans-serif;
-  --font-serif: "Playfair Display", serif;
-  --font-mono: "JetBrains Mono", monospace;
+  --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", serif;
+  --font-mono: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
   --radius: 0.5rem;
   --shadow-x: 0px;
   --shadow-y: 4px;
@@ -93,9 +93,9 @@
   --sidebar-accent-foreground: oklch(0.8520 0.0205 100.6306);
   --sidebar-border: oklch(0.2931 0 0);
   --sidebar-ring: oklch(0.8520 0.0205 100.6306);
-  --font-sans: "Inter", sans-serif;
-  --font-serif: "Playfair Display", serif;
-  --font-mono: "JetBrains Mono", monospace;
+  --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-serif: ui-serif, Georgia, Cambria, "Times New Roman", serif;
+  --font-mono: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
   --radius: 0.5rem;
   --shadow-x: 0px;
   --shadow-y: 6px;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,21 +8,27 @@ import { SidebarLayout } from "@/components/sidebar-layout";
 import { Providers } from "./providers";
 
 const inter = Inter({
-  subsets: ["latin"],
+  subsets: ["latin", "latin-ext"],
   variable: "--font-sans",
   display: "swap",
+  fallback: ["system-ui", "arial", "sans-serif"],
+  preload: true,
 });
 
 const playfair = Playfair_Display({
-  subsets: ["latin"],
+  subsets: ["latin", "latin-ext"],
   variable: "--font-serif",
   display: "swap",
+  fallback: ["Georgia", "Times New Roman", "serif"],
+  preload: false,
 });
 
 const jetbrainsMono = JetBrains_Mono({
-  subsets: ["latin"],
+  subsets: ["latin", "latin-ext"],
   variable: "--font-mono",
   display: "swap",
+  fallback: ["ui-monospace", "SFMono-Regular", "Consolas", "monospace"],
+  preload: false,
 });
 
 export const metadata: Metadata = {
@@ -32,14 +38,16 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="nl" suppressHydrationWarning>
+    <html
+      lang="nl"
+      suppressHydrationWarning
+      className={`${inter.variable} ${playfair.variable} ${jetbrainsMono.variable}`}
+    >
       <head>
         <Script src="/suppress-vendor-noise.js" strategy="beforeInteractive" />
         <Script src="/theme-init.js" strategy="beforeInteractive" />
       </head>
-      <body
-        className={`${inter.variable} ${playfair.variable} ${jetbrainsMono.variable} min-h-screen bg-background antialiased`}
-      >
+      <body className="min-h-screen bg-background antialiased">
         <Providers>
           <SidebarLayout>{children}</SidebarLayout>
           <RouteShellOverlays />

--- a/app/vacatures/[id]/page.tsx
+++ b/app/vacatures/[id]/page.tsx
@@ -16,6 +16,7 @@ import dynamic from "next/dynamic";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
+import { CompanyLogo } from "@/components/company-logo";
 import { DroppableVacancy } from "@/components/droppable-vacancy";
 import { LinkCandidatesDialog } from "@/components/link-candidates-dialog";
 import { OpdrachtDetailEndClientFilter } from "@/components/opdracht-detail-end-client-filter";
@@ -616,10 +617,22 @@ async function OpdrachtDetailContent({ params, searchParams }: Props) {
                   <JsonViewer data={job as unknown as Record<string, unknown>} />
                 </div>
               </div>
-              <h1 className="text-xl font-bold text-foreground">{job.title}</h1>
-              {job.company ? (
-                <p className="mt-1 text-sm text-muted-foreground">{job.company}</p>
-              ) : null}
+              <div className="flex items-start gap-3">
+                <CompanyLogo
+                  src={job.companyLogoUrl}
+                  companyName={job.company}
+                  size={56}
+                  sizes="56px"
+                  priority
+                  blur
+                />
+                <div className="min-w-0">
+                  <h1 className="text-xl font-bold text-foreground">{job.title}</h1>
+                  {job.company ? (
+                    <p className="mt-1 text-sm text-muted-foreground">{job.company}</p>
+                  ) : null}
+                </div>
+              </div>
             </div>
 
             <div className="mt-4 flex flex-wrap gap-x-5 gap-y-2 text-sm text-muted-foreground">

--- a/components/company-logo.tsx
+++ b/components/company-logo.tsx
@@ -1,0 +1,65 @@
+import { Building2 } from "lucide-react";
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+import { isSvgImageUrl, normalizeRemoteImageUrl } from "@/src/lib/image-utils";
+
+const BLUR_PLACEHOLDER =
+  "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2NCIgaGVpZ2h0PSI2NCIgdmlld0JveD0iMCAwIDY0IDY0IiBwcmVzZXJ2ZUFzcGVjdFJhdGlvPSJub25lIj48cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIGZpbGw9IiNlZWVlZWUiLz48L3N2Zz4=";
+
+type CompanyLogoProps = {
+  src?: string | null;
+  companyName?: string | null;
+  size?: number;
+  sizes?: string;
+  priority?: boolean;
+  blur?: boolean;
+  className?: string;
+  imageClassName?: string;
+};
+
+export function CompanyLogo({
+  src,
+  companyName,
+  size = 40,
+  sizes,
+  priority = false,
+  blur = false,
+  className,
+  imageClassName,
+}: CompanyLogoProps) {
+  const resolvedSrc = normalizeRemoteImageUrl(src);
+  const label = companyName?.trim() || "Onbekend bedrijf";
+  const containerClassName = cn(
+    "shrink-0 overflow-hidden rounded-lg border border-border/70 bg-background/70 shadow-sm",
+    className,
+  );
+
+  if (!resolvedSrc) {
+    return (
+      <div
+        aria-hidden="true"
+        className={cn(containerClassName, "flex items-center justify-center text-muted-foreground")}
+        style={{ width: size, height: size }}
+      >
+        <Building2 className="h-4 w-4" />
+      </div>
+    );
+  }
+
+  return (
+    <div className={containerClassName} style={{ width: size, height: size }}>
+      <Image
+        src={resolvedSrc}
+        alt={`${label} logo`}
+        width={size}
+        height={size}
+        sizes={sizes ?? `${size}px`}
+        priority={priority}
+        unoptimized={isSvgImageUrl(resolvedSrc)}
+        placeholder={blur ? "blur" : "empty"}
+        blurDataURL={blur ? BLUR_PLACEHOLDER : undefined}
+        className={cn("size-full object-contain p-1.5", imageClassName)}
+      />
+    </div>
+  );
+}

--- a/components/job-card.tsx
+++ b/components/job-card.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, Building2, Calendar, Clock, Euro, MapPin, Users } from "lucide-react";
 import Link from "next/link";
+import { CompanyLogo } from "@/components/company-logo";
 import { Badge } from "@/components/ui/badge";
 
 interface JobCardProps {
@@ -7,6 +8,7 @@ interface JobCardProps {
     id: string;
     title: string;
     company: string | null;
+    companyLogoUrl?: string | null;
     location: string | null;
     platform: string;
     contractType: string | null;
@@ -39,9 +41,25 @@ export function JobCard({ job, pipelineCount }: JobCardProps) {
         className={`bg-card border rounded-lg p-4 hover:border-primary/40 hover:bg-accent transition-colors cursor-pointer ${deadlineUrgent ? "border-orange-400/60" : "border-border"}`}
       >
         <div className="flex items-start justify-between gap-2 mb-3">
-          <h3 className="text-sm font-semibold text-foreground line-clamp-2 leading-snug">
-            {job.title}
-          </h3>
+          <div className="flex min-w-0 items-start gap-3">
+            <CompanyLogo
+              src={job.companyLogoUrl}
+              companyName={job.company}
+              size={40}
+              sizes="40px"
+            />
+            <div className="min-w-0">
+              <h3 className="text-sm font-semibold text-foreground line-clamp-2 leading-snug">
+                {job.title}
+              </h3>
+              {job.company && (
+                <p className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Building2 className="h-3.5 w-3.5 shrink-0" />
+                  <span className="line-clamp-1">{job.company}</span>
+                </p>
+              )}
+            </div>
+          </div>
           <div className="flex items-center gap-1.5 shrink-0">
             {pipelineCount != null && pipelineCount > 0 && (
               <Badge
@@ -62,12 +80,6 @@ export function JobCard({ job, pipelineCount }: JobCardProps) {
         </div>
 
         <div className="flex flex-wrap gap-x-4 gap-y-1.5 text-sm text-muted-foreground mb-3">
-          {job.company && (
-            <span className="flex items-center gap-1.5">
-              <Building2 className="h-3.5 w-3.5" />
-              {job.company}
-            </span>
-          )}
           {job.location && (
             <span className="flex items-center gap-1.5">
               <MapPin className="h-3.5 w-3.5" />

--- a/components/job-list-item.tsx
+++ b/components/job-list-item.tsx
@@ -1,5 +1,6 @@
 import { ArrowRight, BriefcaseBusiness, Building2, Clock, MapPin, Users } from "lucide-react";
 import Link from "next/link";
+import { CompanyLogo } from "@/components/company-logo";
 import { DroppableVacancy } from "@/components/droppable-vacancy";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -11,6 +12,7 @@ interface JobListItemProps {
     id: string;
     title: string;
     company: string | null;
+    companyLogoUrl?: string | null;
     location: string | null;
     platform: string;
     workArrangement: string | null;
@@ -123,16 +125,24 @@ export function JobListItem({
             )}
           >
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
-              <div className="min-w-0">
-                <h3 className="text-base font-semibold leading-tight text-foreground line-clamp-2 wrap-break-word sm:text-lg">
-                  {job.title}
-                </h3>
-                <p className="mt-1 flex min-w-0 items-start gap-1.5 text-sm text-muted-foreground">
-                  <Building2 className="h-3.5 w-3.5 shrink-0" />
-                  <span className="max-w-full whitespace-normal wrap-break-word">
-                    {job.company || "Onbekend"}
-                  </span>
-                </p>
+              <div className="flex min-w-0 items-start gap-3">
+                <CompanyLogo
+                  src={job.companyLogoUrl}
+                  companyName={job.company}
+                  size={44}
+                  sizes="44px"
+                />
+                <div className="min-w-0">
+                  <h3 className="text-base font-semibold leading-tight text-foreground line-clamp-2 wrap-break-word sm:text-lg">
+                    {job.title}
+                  </h3>
+                  <p className="mt-1 flex min-w-0 items-start gap-1.5 text-sm text-muted-foreground">
+                    <Building2 className="h-3.5 w-3.5 shrink-0" />
+                    <span className="max-w-full whitespace-normal wrap-break-word">
+                      {job.company || "Onbekend"}
+                    </span>
+                  </p>
+                </div>
               </div>
               <div className="flex w-full min-w-0 flex-wrap items-center gap-2 sm:w-auto sm:shrink-0 sm:flex-col sm:items-end">
                 <span className="inline-flex max-w-full whitespace-normal wrap-break-word items-center rounded-full border border-primary/30 bg-primary/10 px-2.5 py-1 text-left text-xs font-medium capitalize text-primary sm:px-3">
@@ -217,12 +227,24 @@ export function JobListItem({
             isActive && "bg-card border-l-[3px] border-l-primary",
           )}
         >
-          <h4 className="mb-1 text-[13px] font-semibold leading-snug text-foreground line-clamp-2 wrap-break-word">
-            {job.title}
-          </h4>
-          <p className="mb-1.5 max-w-full whitespace-normal wrap-break-word text-xs text-muted-foreground">
-            {job.company || "Onbekend"}
-          </p>
+          <div className="mb-1.5 flex min-w-0 items-start gap-2.5">
+            <CompanyLogo
+              src={job.companyLogoUrl}
+              companyName={job.company}
+              size={32}
+              sizes="32px"
+              className="rounded-md"
+              imageClassName="p-1"
+            />
+            <div className="min-w-0">
+              <h4 className="mb-1 text-[13px] font-semibold leading-snug text-foreground line-clamp-2 wrap-break-word">
+                {job.title}
+              </h4>
+              <p className="max-w-full whitespace-normal wrap-break-word text-xs text-muted-foreground">
+                {job.company || "Onbekend"}
+              </p>
+            </div>
+          </div>
           {job.location && (
             <p className="mb-1.5 flex min-w-0 items-start gap-1 text-xs text-muted-foreground">
               <MapPin className="h-3 w-3 shrink-0" />

--- a/components/sidebar/sidebar-types.ts
+++ b/components/sidebar/sidebar-types.ts
@@ -8,6 +8,7 @@ export interface SidebarJob {
   id: string;
   title: string;
   company: string | null;
+  companyLogoUrl?: string | null;
   location: string | null;
   platform: string;
   workArrangement: string | null;

--- a/next.config.ts
+++ b/next.config.ts
@@ -56,6 +56,15 @@ const nextConfig: NextConfig = {
     imageSizes: [16, 32, 48, 64, 96, 128, 256],
     minimumCacheTTL: 86_400, // Cache optimized images for 24 hours
     formats: ["image/avif", "image/webp"],
+    // Company logos are scraped from multiple external sources, so the allowlist
+    // must support arbitrary HTTP(S) hosts while still keeping SVG delivery safe.
+    remotePatterns: [
+      { protocol: "https", hostname: "**", pathname: "/**" },
+      { protocol: "http", hostname: "**", pathname: "/**" },
+    ],
+    dangerouslyAllowSVG: true,
+    contentDispositionType: "attachment",
+    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
   },
 };
 

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -1,0 +1,26 @@
+export function normalizeRemoteImageUrl(value?: string | null): string | null {
+  const candidate = value?.trim();
+  if (!candidate) return null;
+
+  const absolute = candidate.startsWith("//") ? `https:${candidate}` : candidate;
+
+  try {
+    const url = new URL(absolute);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return null;
+    }
+
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function isSvgImageUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.pathname.toLowerCase().endsWith(".svg");
+  } catch {
+    return false;
+  }
+}

--- a/src/services/jobs/deduplication.ts
+++ b/src/services/jobs/deduplication.ts
@@ -297,6 +297,7 @@ export async function loadJobPageRowsByIds(ids: string[]) {
       id: jobs.id,
       title: jobs.title,
       company: sql<string | null>`coalesce(${jobs.endClient}, ${jobs.company})`,
+      companyLogoUrl: jobs.companyLogoUrl,
       location: sql<string | null>`coalesce(${jobs.location}, ${jobs.province})`,
       platform: jobs.platform,
       workArrangement: jobs.workArrangement,

--- a/src/services/jobs/page-query.ts
+++ b/src/services/jobs/page-query.ts
@@ -22,6 +22,7 @@ export type JobPageRow = {
   id: string;
   title: string;
   company: string | null;
+  companyLogoUrl: string | null;
   location: string | null;
   platform: string;
   workArrangement: string | null;

--- a/tests/image-utils.test.ts
+++ b/tests/image-utils.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { isSvgImageUrl, normalizeRemoteImageUrl } from "@/src/lib/image-utils";
+
+describe("image-utils", () => {
+  it("normalizes absolute and protocol-relative remote URLs", () => {
+    expect(normalizeRemoteImageUrl("https://cdn.example.com/logo.png")).toBe(
+      "https://cdn.example.com/logo.png",
+    );
+    expect(normalizeRemoteImageUrl("//cdn.example.com/logo.png")).toBe(
+      "https://cdn.example.com/logo.png",
+    );
+  });
+
+  it("rejects non-http urls and relative paths", () => {
+    expect(normalizeRemoteImageUrl("javascript:alert(1)")).toBeNull();
+    expect(normalizeRemoteImageUrl("/assets/logo.png")).toBeNull();
+    expect(normalizeRemoteImageUrl("")).toBeNull();
+  });
+
+  it("detects remote svg images", () => {
+    expect(isSvgImageUrl("https://cdn.example.com/logo.svg")).toBe(true);
+    expect(isSvgImageUrl("https://cdn.example.com/logo.png")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- switch the root font setup to `next/font/google` latin + latin-ext subsets on the html root with swap/fallback behavior and reduced preload scope
- add a shared `CompanyLogo` component backed by `next/image`, plus URL normalization/tests for remote company logo sources
- thread `companyLogoUrl` through vacancy list/detail surfaces and configure Next image remote handling for scraped logos

## Validation
- `pnpm exec biome check app/layout.tsx app/globals.css next.config.ts 'app/vacatures/[id]/page.tsx' components/company-logo.tsx components/job-card.tsx components/job-list-item.tsx components/sidebar/sidebar-types.ts src/lib/image-utils.ts src/services/jobs/page-query.ts src/services/jobs/deduplication.ts tests/image-utils.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm test`

## Blockers
- `pnpm lint` still fails on pre-existing unrelated repo issues in `app/api/feed/vacatures/route.ts`, `biome.json`, and harness formatting files/tests.
- `pnpm build` and runtime/browser verification still require a real `DATABASE_URL`; `vercel env pull` for `motian-0ed97889acb8` only provided `VERCEL_OIDC_TOKEN`, so the build blocks while prerendering `/agents`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Company logos now display alongside job titles in listings and job detail pages.

* **Style**
  * Updated font rendering to use optimized system fonts for improved performance.

* **Chores**
  * Enhanced image optimization and remote image handling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->