### PR TITLE
Make GenUI chat cards mobile-first and eager-load core recruiter surfaces

### DIFF
--- a/app/api/feed/vacatures/route.ts
+++ b/app/api/feed/vacatures/route.ts
@@ -56,7 +56,6 @@ export async function GET(request: Request) {
       headers.set("Content-Type", "application/rss+xml; charset=utf-8");
       return new Response(toJobRss(feedJobs), { headers });
 
-    case "xml":
     default:
       headers.set("Content-Type", "application/xml; charset=utf-8");
       return new Response(toJobXml(feedJobs), { headers });

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/components/chat/genui/action-card.tsx
+++ b/components/chat/genui/action-card.tsx
@@ -41,7 +41,7 @@ export const MatchCreatedCard = memo(function MatchCreatedCard({ output }: { out
         <span className="text-xs text-muted-foreground capitalize">{output.status}</span>
       </div>
       {!actionTaken && output.status === "pending" && (
-        <div className="flex items-center gap-2 mt-3">
+        <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
           <ActionButton
             label="Goedkeuren"
             variant="primary"

--- a/components/chat/genui/action-primitives.tsx
+++ b/components/chat/genui/action-primitives.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { type Check, CheckCircle2, Loader2, XCircle } from "lucide-react";
 import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { genuiTouchTargetClassName } from "./genui-utils";
 
 export type ActionState = "idle" | "loading" | "success" | "error";
 
@@ -48,8 +50,10 @@ export function ActionButton({
   onClick: () => void;
   disabled?: boolean;
 }) {
-  const base =
-    "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors";
+  const base = cn(
+    "inline-flex items-center justify-center gap-2 transition-colors",
+    genuiTouchTargetClassName,
+  );
   const variants = {
     primary: "bg-primary text-primary-foreground hover:bg-primary/90",
     destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
@@ -60,9 +64,9 @@ export function ActionButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className={`${base} ${variants[variant]} disabled:opacity-50`}
+      className={cn(base, variants[variant], "disabled:opacity-50")}
     >
-      <Icon className="h-3.5 w-3.5" />
+      <Icon className="h-4 w-4" />
       {label}
     </button>
   );

--- a/components/chat/genui/canvas-embed.tsx
+++ b/components/chat/genui/canvas-embed.tsx
@@ -2,13 +2,23 @@
 import { Maximize2, Minimize2, Network } from "lucide-react";
 import dynamic from "next/dynamic";
 import { memo, useCallback, useState } from "react";
-import { getToolErrorMessage, isToolError } from "./genui-utils";
+import { cn } from "@/lib/utils";
+import { GenUILoadingSkeleton } from "./genui-loading-skeleton";
+import {
+  genuiIconButtonClassName,
+  getToolErrorMessage,
+  isToolError,
+  useGenUIMobile,
+} from "./genui-utils";
 import { ToolErrorBlock } from "./tool-error-block";
 
 const MatchNetworkCanvas = dynamic(
   () =>
     import("../../canvas/match-network-canvas").then((m) => ({ default: m.MatchNetworkCanvas })),
-  { ssr: false, loading: () => <div className="h-[400px] animate-pulse rounded-lg bg-muted" /> },
+  {
+    ssr: false,
+    loading: () => <GenUILoadingSkeleton label="Canvas" className="h-[320px]" rows={4} />,
+  },
 );
 
 const CanvasSidebar = dynamic(
@@ -36,6 +46,7 @@ function isCanvasOutput(o: unknown): o is CanvasOutput {
 }
 
 export const CanvasEmbed = memo(function CanvasEmbed({ output }: { output: unknown }) {
+  const isMobile = useGenUIMobile();
   const [expanded, setExpanded] = useState(false);
   const [sidebar, setSidebar] = useState<{
     type: "kandidaat" | "vacature";
@@ -70,7 +81,10 @@ export const CanvasEmbed = memo(function CanvasEmbed({ output }: { output: unkno
 
   return (
     <div
-      className={`my-2 rounded-lg border border-border bg-card overflow-hidden relative ${expanded ? "h-[600px]" : "h-[400px]"}`}
+      className={cn(
+        "relative my-2 overflow-hidden rounded-lg border border-border bg-card",
+        expanded ? (isMobile ? "h-[460px]" : "h-[600px]") : isMobile ? "h-[320px]" : "h-[400px]",
+      )}
     >
       <div className="flex items-center justify-between border-b border-border px-3 py-2">
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -80,7 +94,7 @@ export const CanvasEmbed = memo(function CanvasEmbed({ output }: { output: unkno
         <button
           type="button"
           onClick={() => setExpanded(!expanded)}
-          className="rounded p-1 hover:bg-muted"
+          className={cn(genuiIconButtonClassName, "hover:bg-muted")}
           title={expanded ? "Verkleinen" : "Vergroten"}
         >
           {expanded ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}

--- a/components/chat/genui/comparison-table.tsx
+++ b/components/chat/genui/comparison-table.tsx
@@ -1,7 +1,12 @@
 "use client";
 import { Columns3 } from "lucide-react";
 import { memo } from "react";
-import { getToolErrorMessage, isToolError } from "./genui-utils";
+import {
+  genuiDisclosureSummaryClassName,
+  getToolErrorMessage,
+  isToolError,
+  useGenUIMobile,
+} from "./genui-utils";
 import { ToolErrorBlock } from "./tool-error-block";
 
 type ComparisonOutput = {
@@ -23,6 +28,8 @@ function isComparisonOutput(o: unknown): o is ComparisonOutput {
 }
 
 export const ComparisonTable = memo(function ComparisonTable({ output }: { output: unknown }) {
+  const isMobile = useGenUIMobile();
+
   if (isToolError(output)) {
     return (
       <ToolErrorBlock message={getToolErrorMessage(output, "Vergelijking niet beschikbaar")} />
@@ -35,6 +42,46 @@ export const ComparisonTable = memo(function ComparisonTable({ output }: { outpu
         <div className="flex items-center gap-2">
           <Columns3 className="h-4 w-4" />
           <span>Geen gegevens om te vergelijken</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (isMobile) {
+    return (
+      <div className="my-2 rounded-lg border border-border bg-card p-3">
+        {output.title && (
+          <div className="mb-3 flex items-center gap-2">
+            <Columns3 className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="text-xs font-semibold text-foreground">{output.title}</span>
+          </div>
+        )}
+        <div className="space-y-2">
+          {output.items.map((item) => (
+            <details
+              key={item.label}
+              className="rounded-md border border-border/70 bg-background/70"
+            >
+              <summary className={genuiDisclosureSummaryClassName}>
+                <span>{item.label}</span>
+                <span className="text-xs font-normal text-muted-foreground">
+                  {output.columns.length} waarden
+                </span>
+              </summary>
+              <div className="space-y-2 border-t border-border/70 p-3">
+                {output.columns.map((col) => (
+                  <div key={col} className="rounded-md bg-muted/30 p-3">
+                    <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                      {col}
+                    </p>
+                    <p className="mt-1 break-words text-sm text-foreground">
+                      {String(item.values[col] ?? "—")}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </details>
+          ))}
         </div>
       </div>
     );

--- a/components/chat/genui/cv-intake-card.tsx
+++ b/components/chat/genui/cv-intake-card.tsx
@@ -3,7 +3,16 @@
 import { Download, Target, User } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
-import { getToolErrorMessage, isToolError } from "./genui-utils";
+import { cn } from "@/lib/utils";
+import {
+  genuiDesktopClampClassName,
+  genuiDisclosureSummaryClassName,
+  genuiMobileWrapClassName,
+  genuiTouchTargetClassName,
+  getToolErrorMessage,
+  isToolError,
+  useGenUIMobile,
+} from "./genui-utils";
 import { ToolErrorBlock } from "./tool-error-block";
 
 type CvIntakeOutput = {
@@ -69,6 +78,7 @@ const recommendationConfig: Record<string, { label: string; icon: string; classe
 };
 
 export function CvIntakeCard({ output }: { output: unknown }) {
+  const isMobile = useGenUIMobile();
   const [downloading, setDownloading] = useState(false);
 
   if (isToolError(output))
@@ -112,9 +122,11 @@ export function CvIntakeCard({ output }: { output: unknown }) {
             <User className="h-4 w-4 text-muted-foreground" />
           </div>
           <div className="min-w-0 flex-1">
-            <p className="text-sm font-semibold text-foreground truncate">{output.candidateName}</p>
+            <p className={`text-sm font-semibold text-foreground ${genuiMobileWrapClassName}`}>
+              {output.candidateName}
+            </p>
             {output.candidateRole && (
-              <p className="text-xs text-muted-foreground truncate mt-0.5">
+              <p className={`mt-0.5 text-xs text-muted-foreground ${genuiMobileWrapClassName}`}>
                 {output.candidateRole}
               </p>
             )}
@@ -158,11 +170,15 @@ export function CvIntakeCard({ output }: { output: unknown }) {
                       </span>
                     </div>
                     <div className="min-w-0 flex-1">
-                      <p className="text-xs font-medium text-foreground truncate">
+                      <p
+                        className={`text-xs font-medium text-foreground ${genuiMobileWrapClassName}`}
+                      >
                         {match.jobTitle}
                       </p>
                       {match.company && (
-                        <p className="text-[10px] text-muted-foreground truncate">
+                        <p
+                          className={`text-[10px] text-muted-foreground ${genuiMobileWrapClassName}`}
+                        >
                           {match.company}
                         </p>
                       )}
@@ -175,11 +191,23 @@ export function CvIntakeCard({ output }: { output: unknown }) {
                           </span>
                         )}
                       </div>
-                      {match.reasoning && (
-                        <p className="text-[10px] text-muted-foreground mt-0.5 line-clamp-1">
-                          {match.reasoning}
-                        </p>
-                      )}
+                      {match.reasoning &&
+                        (isMobile ? (
+                          <details className="mt-1 rounded-md border border-border/70 bg-muted/20">
+                            <summary className={genuiDisclosureSummaryClassName}>
+                              Matchmotivatie
+                            </summary>
+                            <p className="border-t border-border/70 p-3 text-[10px] leading-5 text-muted-foreground">
+                              {match.reasoning}
+                            </p>
+                          </details>
+                        ) : (
+                          <p
+                            className={`mt-0.5 text-[10px] text-muted-foreground ${genuiDesktopClampClassName}`}
+                          >
+                            {match.reasoning}
+                          </p>
+                        ))}
                     </div>
                   </div>
                 </div>
@@ -195,7 +223,10 @@ export function CvIntakeCard({ output }: { output: unknown }) {
           type="button"
           onClick={handleDownloadCv}
           disabled={downloading}
-          className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors border border-border text-foreground hover:bg-accent disabled:opacity-50"
+          className={cn(
+            "inline-flex items-center gap-1.5 border border-border text-foreground hover:bg-accent disabled:opacity-50",
+            genuiTouchTargetClassName,
+          )}
         >
           <Download className="h-3.5 w-3.5" />
           {downloading ? "Laden..." : "Download CV"}

--- a/components/chat/genui/genui-loading-skeleton.tsx
+++ b/components/chat/genui/genui-loading-skeleton.tsx
@@ -1,15 +1,47 @@
 "use client";
 
-export function GenUILoadingSkeleton({ label }: { label: string }) {
+import { cn } from "@/lib/utils";
+
+export function GenUILoadingSkeleton({
+  label,
+  className,
+  rows = 2,
+}: {
+  label: string;
+  className?: string;
+  rows?: number;
+}) {
+  const rowTemplates = [
+    { id: "primary", widthClass: "w-full" },
+    { id: "secondary", widthClass: "w-4/5" },
+    { id: "tertiary", widthClass: "w-3/4" },
+    { id: "quaternary", widthClass: "w-2/3" },
+  ];
+  const bodyRows =
+    rows <= 1
+      ? [{ id: "tail", widthClass: "w-1/2" }]
+      : [...rowTemplates.slice(0, Math.max(rows - 1, 1)), { id: "tail", widthClass: "w-1/2" }];
+
   return (
-    <div className="my-1.5 animate-pulse rounded-lg border border-border bg-card p-4">
-      <div className="flex items-center gap-2">
-        <div className="h-4 w-4 rounded bg-muted" />
-        <span className="text-xs text-muted-foreground">{label} laden...</span>
-      </div>
-      <div className="mt-2 space-y-2">
-        <div className="h-3 w-3/4 rounded bg-muted" />
-        <div className="h-3 w-1/2 rounded bg-muted" />
+    <div
+      className={cn(
+        "my-1.5 overflow-hidden rounded-lg border border-border bg-card p-4",
+        className,
+      )}
+    >
+      <div className="animate-pulse">
+        <div className="flex min-h-11 items-center gap-3">
+          <div className="h-5 w-5 rounded-full bg-muted" />
+          <span className="text-sm text-muted-foreground">{label} laden...</span>
+        </div>
+        <div className="mt-3 space-y-2">
+          {bodyRows.map((row) => (
+            <div
+              key={`${label}-${row.id}`}
+              className={cn("h-3 rounded-full bg-muted", row.widthClass)}
+            />
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/components/chat/genui/genui-utils.ts
+++ b/components/chat/genui/genui-utils.ts
@@ -1,3 +1,6 @@
+import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
+
 /** Check if tool output is an error response. */
 export function isToolError(o: unknown): o is { error: unknown } {
   return typeof o === "object" && o !== null && "error" in o;
@@ -88,3 +91,34 @@ export const platformStatusLabels: Record<string, string> = {
   needs_implementation: "Implementatie nodig",
   cancelled: "Geannuleerd",
 };
+
+/** Shared touch-target sizing so mobile interactions stay above 44px. */
+export const genuiTouchTargetClassName =
+  "min-h-11 min-w-11 rounded-md px-3 py-2 text-sm font-medium";
+
+/** Shared inline CTA styling for list expansion and detail disclosure. */
+export const genuiInlineActionClassName = cn(
+  "inline-flex items-center gap-2 text-left text-primary transition-colors hover:bg-accent hover:text-foreground",
+  genuiTouchTargetClassName,
+);
+
+/** Shared icon-button sizing for card controls and disclosure toggles. */
+export const genuiIconButtonClassName =
+  "inline-flex min-h-11 min-w-11 items-center justify-center rounded-full transition-colors";
+
+/** Shared summary row styling for native details/summary disclosure. */
+export const genuiDisclosureSummaryClassName = cn(
+  "flex w-full cursor-pointer list-none items-center justify-between gap-3 text-left text-sm font-medium text-foreground",
+  genuiTouchTargetClassName,
+);
+
+/** Shared card text behavior: wrap on mobile, clamp on wider breakpoints only. */
+export const genuiMobileWrapClassName = "break-words sm:truncate";
+
+/** Shared one-line copy clamp: full text on mobile, clamp only from small screens upward. */
+export const genuiDesktopClampClassName = "break-words sm:line-clamp-1";
+
+/** Use the existing shell/mobile breakpoint for GenUI layout switches. */
+export function useGenUIMobile() {
+  return useIsMobile();
+}

--- a/components/chat/genui/insight-chart.tsx
+++ b/components/chat/genui/insight-chart.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { BarChart3 } from "lucide-react";
-import { memo } from "react";
+import { memo, useEffect, useState } from "react";
 import {
   Bar,
   BarChart,
@@ -15,7 +15,8 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { getToolErrorMessage, isToolError } from "./genui-utils";
+import { GenUILoadingSkeleton } from "./genui-loading-skeleton";
+import { getToolErrorMessage, isToolError, useGenUIMobile } from "./genui-utils";
 import { ToolErrorBlock } from "./tool-error-block";
 
 type ChartDataItem = Record<string, unknown>;
@@ -65,6 +66,13 @@ function getKeys(data: AnalyseOutput) {
 }
 
 export const InsightChart = memo(function InsightChart({ output }: { output: unknown }) {
+  const isMobile = useGenUIMobile();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
   if (isToolError(output))
     return <ToolErrorBlock message={getToolErrorMessage(output, "Analyse niet beschikbaar")} />;
   if (!isAnalyseOutput(output)) return null;
@@ -79,15 +87,27 @@ export const InsightChart = memo(function InsightChart({ output }: { output: unk
     );
   }
 
+  if (!mounted) {
+    return (
+      <GenUILoadingSkeleton
+        label={output.title ?? "Analyse"}
+        className={isMobile ? "min-h-[220px]" : "min-h-[260px]"}
+        rows={3}
+      />
+    );
+  }
+
   const chartType = inferChartType(output);
   const { xKey, yKey } = getKeys(output);
+  const chartHeight = isMobile ? 200 : 240;
+  const axisFontSize = isMobile ? 10 : 11;
 
   return (
     <div className="my-2 rounded-lg border border-border bg-card p-4">
       {output.title && (
         <h4 className="text-sm font-semibold text-foreground mb-3">{output.title}</h4>
       )}
-      <div style={{ width: "100%", height: 240 }}>
+      <div className="min-w-0" style={{ width: "100%", height: chartHeight }}>
         <ResponsiveContainer width="100%" height="100%">
           {chartType === "pie" ? (
             <PieChart>
@@ -97,7 +117,7 @@ export const InsightChart = memo(function InsightChart({ output }: { output: unk
                 nameKey={xKey}
                 cx="50%"
                 cy="50%"
-                outerRadius={80}
+                outerRadius={isMobile ? 60 : 80}
                 label={(entry) => String((entry as unknown as Record<string, unknown>)[xKey])}
               >
                 {output.data.map((entry, i) => (
@@ -109,16 +129,24 @@ export const InsightChart = memo(function InsightChart({ output }: { output: unk
           ) : chartType === "line" ? (
             <LineChart data={output.data}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-              <XAxis dataKey={xKey} tick={{ fontSize: 11 }} className="text-muted-foreground" />
-              <YAxis tick={{ fontSize: 11 }} className="text-muted-foreground" />
+              <XAxis
+                dataKey={xKey}
+                tick={{ fontSize: axisFontSize }}
+                className="text-muted-foreground"
+              />
+              <YAxis tick={{ fontSize: axisFontSize }} className="text-muted-foreground" />
               <Tooltip />
               <Line type="monotone" dataKey={yKey} stroke="#6366f1" strokeWidth={2} dot={false} />
             </LineChart>
           ) : (
             <BarChart data={output.data}>
               <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-              <XAxis dataKey={xKey} tick={{ fontSize: 11 }} className="text-muted-foreground" />
-              <YAxis tick={{ fontSize: 11 }} className="text-muted-foreground" />
+              <XAxis
+                dataKey={xKey}
+                tick={{ fontSize: axisFontSize }}
+                className="text-muted-foreground"
+              />
+              <YAxis tick={{ fontSize: axisFontSize }} className="text-muted-foreground" />
               <Tooltip />
               <Bar dataKey={yKey} fill="#6366f1" radius={[4, 4, 0, 0]} />
             </BarChart>

--- a/components/chat/genui/interview-list.tsx
+++ b/components/chat/genui/interview-list.tsx
@@ -2,7 +2,13 @@
 import { Calendar, Clock, MapPin, Video } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
-import { formatDateTime, getToolErrorMessage, isToolError } from "./genui-utils";
+import {
+  formatDateTime,
+  genuiInlineActionClassName,
+  genuiMobileWrapClassName,
+  getToolErrorMessage,
+  isToolError,
+} from "./genui-utils";
 import { ToolErrorBlock } from "./tool-error-block";
 
 type InterviewItem = {
@@ -87,17 +93,19 @@ export function InterviewListCard({ output }: { output: unknown }) {
       </div>
       <div className="space-y-1.5">
         {visible.map((item) => (
-          <Link key={item.id} href={`/interviews/${item.id}`}>
+          <Link key={item.id} href={`/interviews/${item.id}`} className="block">
             <div className="rounded-lg border border-border bg-card p-3 transition-colors hover:border-primary/40 hover:bg-accent cursor-pointer">
               <div className="flex items-start gap-3">
                 <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted">
                   {typeIcon(item.type)}
                 </div>
                 <div className="min-w-0 flex-1">
-                  <div className="flex items-center justify-between gap-2">
-                    <div className="flex items-center gap-2">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex flex-wrap items-center gap-2">
                       {item.type && (
-                        <span className="text-xs font-medium text-foreground">
+                        <span
+                          className={`text-xs font-medium text-foreground ${genuiMobileWrapClassName}`}
+                        >
                           {typeLabels[item.type] ?? item.type}
                         </span>
                       )}
@@ -112,7 +120,7 @@ export function InterviewListCard({ output }: { output: unknown }) {
                     {(() => {
                       const dt = formatDateTime(item.scheduledAt);
                       return dt ? (
-                        <span className="text-[10px] text-muted-foreground whitespace-nowrap">
+                        <span className="text-[10px] text-muted-foreground sm:whitespace-nowrap">
                           {dt}
                         </span>
                       ) : null;
@@ -120,10 +128,14 @@ export function InterviewListCard({ output }: { output: unknown }) {
                   </div>
                   <div className="flex flex-wrap gap-x-3 gap-y-0.5 mt-1">
                     {item.interviewer && (
-                      <span className="text-xs text-muted-foreground">{item.interviewer}</span>
+                      <span className={`text-xs text-muted-foreground ${genuiMobileWrapClassName}`}>
+                        {item.interviewer}
+                      </span>
                     )}
                     {item.location && (
-                      <span className="text-xs text-muted-foreground flex items-center gap-1">
+                      <span
+                        className={`flex items-center gap-1 text-xs text-muted-foreground ${genuiMobileWrapClassName}`}
+                      >
                         <MapPin className="h-2.5 w-2.5" />
                         {item.location}
                       </span>
@@ -139,7 +151,7 @@ export function InterviewListCard({ output }: { output: unknown }) {
         <button
           type="button"
           onClick={() => setShowAll(true)}
-          className="text-xs text-primary hover:underline"
+          className={genuiInlineActionClassName}
         >
           + {output.interviews.length - MAX_VISIBLE} meer tonen
         </button>

--- a/components/chat/genui/interview-prep-card.tsx
+++ b/components/chat/genui/interview-prep-card.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { ClipboardList, ShieldCheck, Sparkles } from "lucide-react";
+import { ChevronDown, ClipboardList, ShieldCheck, Sparkles } from "lucide-react";
 import { memo } from "react";
-import { getToolErrorMessage, isToolError } from "./genui-utils";
+import {
+  genuiDisclosureSummaryClassName,
+  getToolErrorMessage,
+  isToolError,
+  useGenUIMobile,
+} from "./genui-utils";
 import { ToolErrorBlock } from "./tool-error-block";
 
 type ClarificationOutput = {
@@ -77,6 +82,8 @@ function BulletList({ items }: { items: string[] }) {
 }
 
 export const InterviewPrepCard = memo(function InterviewPrepCard({ output }: { output: unknown }) {
+  const isMobile = useGenUIMobile();
+
   if (isToolError(output)) {
     return (
       <ToolErrorBlock
@@ -118,6 +125,22 @@ export const InterviewPrepCard = memo(function InterviewPrepCard({ output }: { o
   if (!isReadyOutput(output)) return null;
 
   const { artifact } = output;
+  const scorecardContent = (
+    <div className="mt-2 space-y-2">
+      {artifact.scorecardCriteria.map((criterion) => (
+        <div
+          key={criterion.criterion}
+          className="rounded-md border border-border/70 bg-muted/30 p-3"
+        >
+          <p className="text-sm font-medium text-foreground">{criterion.criterion}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Goed signaal: {criterion.whatGoodLooksLike}
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">Red flag: {criterion.redFlag}</p>
+        </div>
+      ))}
+    </div>
+  );
 
   return (
     <div className="my-1.5 rounded-lg border border-border bg-card p-4">
@@ -172,23 +195,20 @@ export const InterviewPrepCard = memo(function InterviewPrepCard({ output }: { o
         </div>
       </div>
 
-      <div className="mt-4 rounded-md border border-border/70 bg-background/70 p-3">
-        <p className="text-sm font-semibold text-foreground">Scorecardcriteria</p>
-        <div className="mt-2 space-y-2">
-          {artifact.scorecardCriteria.map((criterion) => (
-            <div
-              key={criterion.criterion}
-              className="rounded-md border border-border/70 bg-muted/30 p-3"
-            >
-              <p className="text-sm font-medium text-foreground">{criterion.criterion}</p>
-              <p className="mt-1 text-xs text-muted-foreground">
-                Goed signaal: {criterion.whatGoodLooksLike}
-              </p>
-              <p className="mt-1 text-xs text-muted-foreground">Red flag: {criterion.redFlag}</p>
-            </div>
-          ))}
+      {isMobile ? (
+        <details className="mt-4 rounded-md border border-border/70 bg-background/70">
+          <summary className={genuiDisclosureSummaryClassName}>
+            <span>Scorecardcriteria</span>
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          </summary>
+          <div className="border-t border-border/70 p-3">{scorecardContent}</div>
+        </details>
+      ) : (
+        <div className="mt-4 rounded-md border border-border/70 bg-background/70 p-3">
+          <p className="text-sm font-semibold text-foreground">Scorecardcriteria</p>
+          {scorecardContent}
         </div>
-      </div>
+      )}
 
       <div className="mt-4 grid gap-4 lg:grid-cols-2">
         <div className="rounded-md border border-border/70 bg-background/70 p-3">
@@ -205,15 +225,34 @@ export const InterviewPrepCard = memo(function InterviewPrepCard({ output }: { o
         </div>
       </div>
 
-      <div className="mt-4 rounded-md border border-border/70 bg-background/70 p-3">
-        <p className="text-sm font-semibold text-foreground">Writeback payload</p>
-        <p className="mt-1 text-xs text-muted-foreground">Type: {artifact.writebackPayload.type}</p>
-        <p className="text-xs text-muted-foreground">
-          Job: {artifact.writebackPayload.linkedJobId ?? "geen"} · Kandidaat:{" "}
-          {artifact.writebackPayload.linkedCandidateId ?? "geen"} · Match:{" "}
-          {artifact.writebackPayload.linkedMatchId ?? "geen"}
-        </p>
-      </div>
+      {isMobile ? (
+        <details className="mt-4 rounded-md border border-border/70 bg-background/70">
+          <summary className={genuiDisclosureSummaryClassName}>
+            <span>Writeback payload</span>
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          </summary>
+          <div className="space-y-1 border-t border-border/70 p-3">
+            <p className="text-xs text-muted-foreground">Type: {artifact.writebackPayload.type}</p>
+            <p className="text-xs text-muted-foreground">
+              Job: {artifact.writebackPayload.linkedJobId ?? "geen"} · Kandidaat:{" "}
+              {artifact.writebackPayload.linkedCandidateId ?? "geen"} · Match:{" "}
+              {artifact.writebackPayload.linkedMatchId ?? "geen"}
+            </p>
+          </div>
+        </details>
+      ) : (
+        <div className="mt-4 rounded-md border border-border/70 bg-background/70 p-3">
+          <p className="text-sm font-semibold text-foreground">Writeback payload</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Type: {artifact.writebackPayload.type}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Job: {artifact.writebackPayload.linkedJobId ?? "geen"} · Kandidaat:{" "}
+            {artifact.writebackPayload.linkedCandidateId ?? "geen"} · Match:{" "}
+            {artifact.writebackPayload.linkedMatchId ?? "geen"}
+          </p>
+        </div>
+      )}
     </div>
   );
 });

--- a/components/chat/genui/kandidaat-card.tsx
+++ b/components/chat/genui/kandidaat-card.tsx
@@ -2,7 +2,7 @@
 
 import { User } from "lucide-react";
 import Link from "next/link";
-import { getToolErrorMessage, isToolError } from "./genui-utils";
+import { genuiMobileWrapClassName, getToolErrorMessage, isToolError } from "./genui-utils";
 import { ToolErrorBlock } from "./tool-error-block";
 
 type CandidateOutput = {
@@ -21,19 +21,25 @@ export function KandidaatGenUICard({ output }: { output: unknown }) {
     return <ToolErrorBlock message={getToolErrorMessage(output, "Kandidaat niet gevonden")} />;
   if (!isCandidateOutput(output)) return null;
   return (
-    <Link href={`/kandidaten/${output.id}`}>
+    <Link href={`/kandidaten/${output.id}`} className="block">
       <div className="my-1.5 rounded-lg border border-border bg-card p-4 transition-colors hover:border-primary/40 hover:bg-accent cursor-pointer">
         <div className="flex items-start gap-3">
           <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted">
             <User className="h-4 w-4 text-muted-foreground" />
           </div>
           <div className="min-w-0 flex-1">
-            <p className="text-sm font-semibold text-foreground truncate">{output.name}</p>
+            <p className={`text-sm font-semibold text-foreground ${genuiMobileWrapClassName}`}>
+              {output.name}
+            </p>
             {output.role && (
-              <p className="text-xs text-muted-foreground truncate mt-0.5">{output.role}</p>
+              <p className={`mt-0.5 text-xs text-muted-foreground ${genuiMobileWrapClassName}`}>
+                {output.role}
+              </p>
             )}
             {output.email && (
-              <p className="text-xs text-muted-foreground truncate mt-0.5">{output.email}</p>
+              <p className={`mt-0.5 text-xs text-muted-foreground ${genuiMobileWrapClassName}`}>
+                {output.email}
+              </p>
             )}
           </div>
         </div>

--- a/components/chat/genui/kandidaat-list.tsx
+++ b/components/chat/genui/kandidaat-list.tsx
@@ -2,7 +2,12 @@
 import { User, Users } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
-import { getToolErrorMessage, isToolError } from "./genui-utils";
+import {
+  genuiInlineActionClassName,
+  genuiMobileWrapClassName,
+  getToolErrorMessage,
+  isToolError,
+} from "./genui-utils";
 import { ToolErrorBlock } from "./tool-error-block";
 
 type KandidaatItem = {
@@ -56,20 +61,26 @@ export function KandidaatListCard({ output }: { output: unknown }) {
       </div>
       <div className="space-y-1.5">
         {visible.map((item) => (
-          <Link key={item.id} href={`/kandidaten/${item.id}`}>
+          <Link key={item.id} href={`/kandidaten/${item.id}`} className="block">
             <div className="rounded-lg border border-border bg-card p-3 transition-colors hover:border-primary/40 hover:bg-accent cursor-pointer">
               <div className="flex items-start gap-3">
                 <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted">
                   <User className="h-3.5 w-3.5 text-muted-foreground" />
                 </div>
                 <div className="min-w-0 flex-1">
-                  <p className="text-sm font-semibold text-foreground truncate">{item.name}</p>
+                  <p
+                    className={`text-sm font-semibold text-foreground ${genuiMobileWrapClassName}`}
+                  >
+                    {item.name}
+                  </p>
                   <div className="flex flex-wrap gap-x-3 gap-y-0.5 mt-0.5">
                     {item.role && (
-                      <span className="text-xs text-muted-foreground truncate">{item.role}</span>
+                      <span className={`text-xs text-muted-foreground ${genuiMobileWrapClassName}`}>
+                        {item.role}
+                      </span>
                     )}
                     {item.location && (
-                      <span className="text-xs text-muted-foreground truncate">
+                      <span className={`text-xs text-muted-foreground ${genuiMobileWrapClassName}`}>
                         {item.location}
                       </span>
                     )}
@@ -87,7 +98,7 @@ export function KandidaatListCard({ output }: { output: unknown }) {
         <button
           type="button"
           onClick={() => setShowAll(true)}
-          className="text-xs text-primary hover:underline"
+          className={genuiInlineActionClassName}
         >
           + {output.kandidaten.length - MAX_VISIBLE} meer tonen
         </button>

--- a/components/chat/genui/match-card.tsx
+++ b/components/chat/genui/match-card.tsx
@@ -2,7 +2,12 @@
 
 import { Link2 } from "lucide-react";
 import Link from "next/link";
-import { getToolErrorMessage, isToolError, matchStatusLabels } from "./genui-utils";
+import {
+  genuiMobileWrapClassName,
+  getToolErrorMessage,
+  isToolError,
+  matchStatusLabels,
+} from "./genui-utils";
 import { ToolErrorBlock } from "./tool-error-block";
 
 type MatchOutput = {
@@ -33,19 +38,21 @@ export function MatchGenUICard({ output }: { output: unknown }) {
       ? "Open vacaturecontext →"
       : "Open kandidaten →";
   return (
-    <Link href={href}>
+    <Link href={href} className="block">
       <div className="my-1.5 rounded-lg border border-border bg-card p-4 transition-colors hover:border-primary/40 hover:bg-accent cursor-pointer">
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2 min-w-0">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex min-w-0 items-center gap-2">
             <Link2 className="h-4 w-4 shrink-0 text-muted-foreground" />
-            <div>
+            <div className="min-w-0">
               <p className="text-sm font-semibold text-foreground">
                 Match — score {Math.round(output.matchScore)}%
               </p>
-              <p className="text-xs text-muted-foreground mt-0.5">Status: {statusLabel}</p>
+              <p className={`mt-0.5 text-xs text-muted-foreground ${genuiMobileWrapClassName}`}>
+                Status: {statusLabel}
+              </p>
             </div>
           </div>
-          <span className="text-xs text-muted-foreground shrink-0">{ctaLabel}</span>
+          <span className="text-sm font-medium text-muted-foreground sm:shrink-0">{ctaLabel}</span>
         </div>
       </div>
     </Link>

--- a/components/chat/genui/match-list.tsx
+++ b/components/chat/genui/match-list.tsx
@@ -2,7 +2,14 @@
 import { GitCompareArrows, Target } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
-import { getToolErrorMessage, isToolError, matchStatusLabels } from "./genui-utils";
+import {
+  genuiDesktopClampClassName,
+  genuiInlineActionClassName,
+  genuiMobileWrapClassName,
+  getToolErrorMessage,
+  isToolError,
+  matchStatusLabels,
+} from "./genui-utils";
 import { ToolErrorBlock } from "./tool-error-block";
 
 type MatchItem = {
@@ -70,23 +77,23 @@ export function MatchListCard({ output }: { output: unknown }) {
       </div>
       <div className="space-y-1.5">
         {visible.map((item) => (
-          <Link key={item.id} href={`/kandidaten/${item.candidateId}/matches`}>
+          <Link key={item.id} href={`/kandidaten/${item.candidateId}/matches`} className="block">
             <div className="rounded-lg border border-border bg-card p-3 transition-colors hover:border-primary/40 hover:bg-accent cursor-pointer">
-              <div className="flex items-center gap-3">
+              <div className="flex items-start gap-3">
                 <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 border-current">
                   <span className={`text-sm font-bold ${scoreColor(item.matchScore)}`}>
                     {Math.round(item.matchScore)}
                   </span>
                 </div>
                 <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
                     <Target className="h-3 w-3 text-muted-foreground" />
-                    <p className="text-xs text-muted-foreground truncate">
+                    <p className={`text-xs text-muted-foreground ${genuiMobileWrapClassName}`}>
                       Kandidaat {item.candidateId.slice(0, 8)}... &rarr; Opdracht{" "}
                       {item.jobId.slice(0, 8)}...
                     </p>
                   </div>
-                  <div className="flex items-center gap-2 mt-1">
+                  <div className="mt-1 flex flex-wrap items-center gap-2">
                     <span
                       className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${statusColors[item.status] ?? statusColors.pending}`}
                     >
@@ -99,7 +106,9 @@ export function MatchListCard({ output }: { output: unknown }) {
                     )}
                   </div>
                   {item.reasoning && (
-                    <p className="text-[11px] text-muted-foreground mt-1 line-clamp-1">
+                    <p
+                      className={`mt-1 text-[11px] text-muted-foreground ${genuiDesktopClampClassName}`}
+                    >
                       {item.reasoning}
                     </p>
                   )}
@@ -113,7 +122,7 @@ export function MatchListCard({ output }: { output: unknown }) {
         <button
           type="button"
           onClick={() => setShowAll(true)}
-          className="text-xs text-primary hover:underline"
+          className={genuiInlineActionClassName}
         >
           + {output.matches.length - MAX_VISIBLE} meer tonen
         </button>

--- a/components/chat/genui/opdracht-list.tsx
+++ b/components/chat/genui/opdracht-list.tsx
@@ -2,7 +2,12 @@
 import { Briefcase } from "lucide-react";
 import { useState } from "react";
 import { JobCard } from "@/components/job-card";
-import { getToolErrorMessage, isToolError, toDate } from "./genui-utils";
+import {
+  genuiInlineActionClassName,
+  getToolErrorMessage,
+  isToolError,
+  toDate,
+} from "./genui-utils";
 import { ToolErrorBlock } from "./tool-error-block";
 
 type OpdrachtItem = {
@@ -84,7 +89,7 @@ export function OpdrachtListCard({ output }: { output: unknown }) {
         <button
           type="button"
           onClick={() => setShowAll(true)}
-          className="text-xs text-primary hover:underline"
+          className={genuiInlineActionClassName}
         >
           + {output.opdrachten.length - MAX_VISIBLE} meer tonen
         </button>

--- a/components/chat/genui/pipeline-funnel.tsx
+++ b/components/chat/genui/pipeline-funnel.tsx
@@ -1,7 +1,8 @@
 "use client";
 import { GitBranch } from "lucide-react";
 import { memo } from "react";
-import { getToolErrorMessage, isToolError } from "./genui-utils";
+import { cn } from "@/lib/utils";
+import { getToolErrorMessage, isToolError, useGenUIMobile } from "./genui-utils";
 import { ToolErrorBlock } from "./tool-error-block";
 
 type StageStats = {
@@ -32,6 +33,8 @@ const STAGE_CONFIG = [
 ];
 
 export const PipelineFunnel = memo(function PipelineFunnel({ output }: { output: unknown }) {
+  const isMobile = useGenUIMobile();
+
   if (isToolError(output))
     return <ToolErrorBlock message={getToolErrorMessage(output, "Pipeline niet beschikbaar")} />;
   if (!isFunnelOutput(output)) return null;
@@ -50,15 +53,29 @@ export const PipelineFunnel = memo(function PipelineFunnel({ output }: { output:
           const count = output.stages[key];
           const pct = maxCount > 0 ? (count / maxCount) * 100 : 0;
           return (
-            <div key={key} className="flex items-center gap-3">
-              <span className="text-xs text-muted-foreground w-24 shrink-0">{label}</span>
-              <div className="flex-1 h-5 bg-muted rounded-full overflow-hidden">
+            <div
+              key={key}
+              className={cn(
+                isMobile
+                  ? "rounded-md border border-border/70 bg-background/70 p-3"
+                  : "flex items-center gap-3",
+              )}
+            >
+              <div
+                className={cn(
+                  "flex items-center",
+                  isMobile ? "mb-2 justify-between gap-3" : "w-24 shrink-0 gap-3",
+                )}
+              >
+                <span className="text-xs text-muted-foreground">{label}</span>
+                <span className="text-xs font-medium text-foreground">{count}</span>
+              </div>
+              <div className="h-5 flex-1 overflow-hidden rounded-full bg-muted">
                 <div
                   className={`h-full ${color} rounded-full transition-all`}
                   style={{ width: `${Math.max(pct, 2)}%` }}
                 />
               </div>
-              <span className="text-xs font-medium text-foreground w-8 text-right">{count}</span>
             </div>
           );
         })}

--- a/components/chat/genui/platform-card.tsx
+++ b/components/chat/genui/platform-card.tsx
@@ -6,8 +6,14 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
 import { submitPlatformCredentials } from "./credential-submit";
-import { onboardingStepLabels, platformStatusLabels } from "./genui-utils";
+import {
+  genuiDisclosureSummaryClassName,
+  onboardingStepLabels,
+  platformStatusLabels,
+  useGenUIMobile,
+} from "./genui-utils";
 
 // ─── Type Guards ──────────────────────────────────────────────
 
@@ -116,8 +122,52 @@ function isPlatformList(o: unknown): o is PlatformListOutput {
 // ─── Sub-Components ──────────────────────────────────────────
 
 function StepperBar({ currentStep, failed }: { currentStep: string; failed?: boolean }) {
+  const isMobile = useGenUIMobile();
   const steps = Object.entries(onboardingStepLabels);
   const currentIndex = steps.findIndex(([key]) => key === currentStep);
+
+  if (isMobile) {
+    return (
+      <details className="rounded-md border border-border/70 bg-background/70">
+        <summary className={genuiDisclosureSummaryClassName}>
+          <span>{onboardingStepLabels[currentStep] ?? "Onboardingstatus"}</span>
+          <span className="text-xs font-normal text-muted-foreground">
+            {Math.max(currentIndex + 1, 1)}/{steps.length}
+          </span>
+        </summary>
+        <ol className="space-y-2 border-t border-border/70 p-3 text-xs">
+          {steps.map(([key, label], i) => {
+            const isActive = i === currentIndex;
+            const isDone = i < currentIndex;
+            const isFailed = isActive && failed;
+            return (
+              <li key={key} className="flex items-start gap-2">
+                <span
+                  className={cn(
+                    "mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-medium",
+                    isFailed
+                      ? "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400"
+                      : isDone
+                        ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                        : isActive
+                          ? "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400"
+                          : "bg-muted text-muted-foreground",
+                  )}
+                >
+                  {isDone ? "\u2713" : i + 1}
+                </span>
+                <span
+                  className={cn(isActive ? "font-medium text-foreground" : "text-muted-foreground")}
+                >
+                  {label}
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+      </details>
+    );
+  }
 
   return (
     <div className="flex items-center gap-1 text-xs">
@@ -196,6 +246,7 @@ function CredentialForm({ platform, fields }: { platform: string; fields: Creden
           <Input
             id={field.name}
             type={field.type}
+            className="min-h-11"
             autoComplete="off"
             value={values[field.name] ?? ""}
             onChange={(e) => setValues((v) => ({ ...v, [field.name]: e.target.value }))}
@@ -203,7 +254,7 @@ function CredentialForm({ platform, fields }: { platform: string; fields: Creden
           />
         </div>
       ))}
-      <Button type="submit" size="sm" disabled={submitting}>
+      <Button type="submit" disabled={submitting} className="min-h-11 w-full sm:w-auto">
         {submitting ? "Verbinden..." : "Verbinden"}
       </Button>
       {error && <p className="text-xs text-red-600">{error}</p>}
@@ -247,7 +298,7 @@ function OnboardingRealtimeCard({ output }: { output: OnboardingTriggeredOutput 
   return (
     <Card>
       <CardHeader className="pb-2">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <CardTitle className="text-sm">{output.displayName}</CardTitle>
           <Badge variant={isDone ? "default" : isFailed ? "destructive" : "secondary"}>
             {isDone
@@ -311,7 +362,7 @@ export function PlatformCard({ output }: { output: unknown }) {
     return (
       <Card>
         <CardHeader className="pb-2">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <CardTitle className="text-sm">{output.displayName}</CardTitle>
             <Badge variant={output.isActive ? "default" : "secondary"}>
               {output.isActive ? "Actief" : "Inactief"}
@@ -335,7 +386,7 @@ export function PlatformCard({ output }: { output: unknown }) {
     return (
       <Card>
         <CardHeader className="pb-2">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <CardTitle className="text-sm">{output.displayName}</CardTitle>
             <Badge variant={output.activated ? "default" : "secondary"}>
               {output.activated ? "Actief" : "Niet geactiveerd"}
@@ -383,7 +434,7 @@ export function PlatformCard({ output }: { output: unknown }) {
     return (
       <Card>
         <CardHeader className="pb-2">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <CardTitle className="text-sm">{output.catalog.displayName}</CardTitle>
             <Badge
               variant={
@@ -438,7 +489,7 @@ export function PlatformCard({ output }: { output: unknown }) {
     }
 
     return (
-      <div className="grid grid-cols-2 gap-2">
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
         {output.slice(0, 8).map((p) => (
           <Card key={p.slug} className="p-2">
             <div className="flex items-center justify-between">

--- a/components/chat/genui/registry.ts
+++ b/components/chat/genui/registry.ts
@@ -1,22 +1,32 @@
 import { type ComponentType, lazy } from "react";
+import {
+  InterviewPlannedCard,
+  MatchApprovedCard,
+  MatchCreatedCard,
+  MatchRejectedCard,
+  MessageSentCard,
+  StageUpdateCard,
+} from "./action-card";
+import { KandidaatGenUICard } from "./kandidaat-card";
+import { KandidaatListCard } from "./kandidaat-list";
+import { OpdrachtGenUICard } from "./opdracht-card";
+import { OpdrachtListCard } from "./opdracht-list";
 
 export type GenUIEntry = {
-  component: React.LazyExoticComponent<ComponentType<{ output: unknown }>>;
+  component:
+    | ComponentType<{ output: unknown }>
+    | React.LazyExoticComponent<ComponentType<{ output: unknown }>>;
   label: string;
 };
 
 export const GENUI_REGISTRY: Record<string, GenUIEntry> = {
   // Existing detail cards
   getOpdrachtDetail: {
-    component: lazy(() =>
-      import("./opdracht-card").then((m) => ({ default: m.OpdrachtGenUICard })),
-    ),
+    component: OpdrachtGenUICard,
     label: "Opdracht",
   },
   getKandidaatDetail: {
-    component: lazy(() =>
-      import("./kandidaat-card").then((m) => ({ default: m.KandidaatGenUICard })),
-    ),
+    component: KandidaatGenUICard,
     label: "Kandidaat",
   },
   getMatchDetail: {
@@ -25,13 +35,11 @@ export const GENUI_REGISTRY: Record<string, GenUIEntry> = {
   },
   // New search result lists
   queryOpdrachten: {
-    component: lazy(() => import("./opdracht-list").then((m) => ({ default: m.OpdrachtListCard }))),
+    component: OpdrachtListCard,
     label: "Opdrachten",
   },
   zoekKandidaten: {
-    component: lazy(() =>
-      import("./kandidaat-list").then((m) => ({ default: m.KandidaatListCard })),
-    ),
+    component: KandidaatListCard,
     label: "Kandidaten",
   },
   zoekMatches: {
@@ -69,31 +77,27 @@ export const GENUI_REGISTRY: Record<string, GenUIEntry> = {
   },
   // Action cards
   maakMatchAan: {
-    component: lazy(() => import("./action-card").then((m) => ({ default: m.MatchCreatedCard }))),
+    component: MatchCreatedCard,
     label: "Match aangemaakt",
   },
   keurMatchGoed: {
-    component: lazy(() => import("./action-card").then((m) => ({ default: m.MatchApprovedCard }))),
+    component: MatchApprovedCard,
     label: "Match goedgekeurd",
   },
   wijsMatchAf: {
-    component: lazy(() => import("./action-card").then((m) => ({ default: m.MatchRejectedCard }))),
+    component: MatchRejectedCard,
     label: "Match afgewezen",
   },
   updateSollicitatieFase: {
-    component: lazy(() => import("./action-card").then((m) => ({ default: m.StageUpdateCard }))),
+    component: StageUpdateCard,
     label: "Fase bijgewerkt",
   },
   planInterview: {
-    component: lazy(() =>
-      import("./action-card").then((m) => ({
-        default: m.InterviewPlannedCard,
-      })),
-    ),
+    component: InterviewPlannedCard,
     label: "Interview gepland",
   },
   stuurBericht: {
-    component: lazy(() => import("./action-card").then((m) => ({ default: m.MessageSentCard }))),
+    component: MessageSentCard,
     label: "Bericht verstuurd",
   },
   renderCanvas: {

--- a/components/chat/genui/sollicitatie-list.tsx
+++ b/components/chat/genui/sollicitatie-list.tsx
@@ -2,7 +2,13 @@
 import { FileText, Send } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
-import { getToolErrorMessage, isToolError, stageLabels } from "./genui-utils";
+import {
+  genuiInlineActionClassName,
+  genuiMobileWrapClassName,
+  getToolErrorMessage,
+  isToolError,
+  stageLabels,
+} from "./genui-utils";
 import { ToolErrorBlock } from "./tool-error-block";
 
 type SollicitatieItem = {
@@ -74,14 +80,14 @@ export function SollicitatieListCard({ output }: { output: unknown }) {
       </div>
       <div className="space-y-1.5">
         {visible.map((item) => (
-          <Link key={item.id} href={`/sollicitaties/${item.id}`}>
+          <Link key={item.id} href={`/sollicitaties/${item.id}`} className="block">
             <div className="rounded-lg border border-border bg-card p-3 transition-colors hover:border-primary/40 hover:bg-accent cursor-pointer">
               <div className="flex items-start gap-3">
                 <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted">
                   <FileText className="h-3.5 w-3.5 text-muted-foreground" />
                 </div>
                 <div className="min-w-0 flex-1">
-                  <div className="flex items-center justify-between gap-2">
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                     <span
                       className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${stageColors[item.stage] ?? stageColors.new}`}
                     >
@@ -95,12 +101,12 @@ export function SollicitatieListCard({ output }: { output: unknown }) {
                   </div>
                   <div className="flex flex-wrap gap-x-3 gap-y-0.5 mt-1">
                     {item.candidateId && (
-                      <span className="text-xs text-muted-foreground">
+                      <span className={`text-xs text-muted-foreground ${genuiMobileWrapClassName}`}>
                         Kandidaat {item.candidateId.slice(0, 8)}...
                       </span>
                     )}
                     {item.jobId && (
-                      <span className="text-xs text-muted-foreground">
+                      <span className={`text-xs text-muted-foreground ${genuiMobileWrapClassName}`}>
                         Opdracht {item.jobId.slice(0, 8)}...
                       </span>
                     )}
@@ -118,7 +124,7 @@ export function SollicitatieListCard({ output }: { output: unknown }) {
         <button
           type="button"
           onClick={() => setShowAll(true)}
-          className="text-xs text-primary hover:underline"
+          className={genuiInlineActionClassName}
         >
           + {output.sollicitaties.length - MAX_VISIBLE} meer tonen
         </button>

--- a/components/chat/genui/stat-card-row.tsx
+++ b/components/chat/genui/stat-card-row.tsx
@@ -30,7 +30,7 @@ export const StatCardRow = memo(function StatCardRow({ output }: { output: unkno
           </span>
         </div>
       )}
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 xl:grid-cols-4">
         {output.stats.map((stat) => (
           <div key={stat.label} className="rounded-lg border border-border bg-card p-3">
             <p className="text-xs text-muted-foreground truncate">{stat.label}</p>

--- a/components/job-card.tsx
+++ b/components/job-card.tsx
@@ -34,15 +34,15 @@ export function JobCard({ job, pipelineCount }: JobCardProps) {
     new Date(job.applicationDeadline).getTime() > Date.now();
 
   return (
-    <Link href={`/vacatures/${job.id}`}>
+    <Link href={`/vacatures/${job.id}`} className="block">
       <div
         className={`bg-card border rounded-lg p-4 hover:border-primary/40 hover:bg-accent transition-colors cursor-pointer ${deadlineUrgent ? "border-orange-400/60" : "border-border"}`}
       >
-        <div className="flex items-start justify-between gap-2 mb-3">
+        <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
           <h3 className="text-sm font-semibold text-foreground line-clamp-2 leading-snug">
             {job.title}
           </h3>
-          <div className="flex items-center gap-1.5 shrink-0">
+          <div className="flex flex-wrap items-center gap-1.5 shrink-0">
             {pipelineCount != null && pipelineCount > 0 && (
               <Badge
                 variant="outline"
@@ -109,7 +109,7 @@ export function JobCard({ job, pipelineCount }: JobCardProps) {
           )}
         </div>
 
-        <div className="flex items-center gap-4 text-xs text-muted-foreground pt-1">
+        <div className="flex flex-col items-start gap-1.5 pt-1 text-xs text-muted-foreground sm:flex-row sm:items-center sm:gap-4">
           {job.applicationDeadline && (
             <span
               className={`flex items-center gap-1 ${deadlineUrgent ? "text-orange-600 font-medium" : ""}`}

--- a/scripts/harness/auto-resolve-threads.ts
+++ b/scripts/harness/auto-resolve-threads.ts
@@ -166,7 +166,9 @@ async function main(): Promise<void> {
 }
 
 // Only run when executed directly (not when imported in tests)
-const isDirectRun = process.argv[1]?.endsWith("auto-resolve-threads.ts") || process.argv[1]?.includes("auto-resolve-threads");
+const isDirectRun =
+  process.argv[1]?.endsWith("auto-resolve-threads.ts") ||
+  process.argv[1]?.includes("auto-resolve-threads");
 if (isDirectRun) {
   main().catch((err) => {
     console.error(`[auto-resolve-threads] Onverwerkte fout: ${err}`);

--- a/scripts/harness/pr-comment-writer.ts
+++ b/scripts/harness/pr-comment-writer.ts
@@ -43,12 +43,7 @@ function findMarkedComment(comments: GitHubComment[], marker: string): GitHubCom
   return comments.find((c) => c.body.includes(marker));
 }
 
-function createComment(
-  owner: string,
-  repo: string,
-  prNumber: number,
-  body: string,
-): GitHubComment {
+function createComment(owner: string, repo: string, prNumber: number, body: string): GitHubComment {
   const raw = execSync(
     `gh api -X POST repos/${owner}/${repo}/issues/${prNumber}/comments --field body='${escapeShellArg(body)}' --jq '{id: .id, body: .body}'`,
     { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },

--- a/scripts/harness/sha-discipline.ts
+++ b/scripts/harness/sha-discipline.ts
@@ -94,7 +94,12 @@ export function markStaleComments(
 // Main
 // ---------------------------------------------------------------------------
 
-export async function run(prNumber: number, newHeadSha: string, owner: string, repo: string): Promise<ShaDisciplineResult> {
+export async function run(
+  prNumber: number,
+  newHeadSha: string,
+  owner: string,
+  repo: string,
+): Promise<ShaDisciplineResult> {
   const comments = fetchComments(owner, repo, prNumber);
   const { toUpdate, skipped } = markStaleComments(comments, newHeadSha);
 
@@ -136,7 +141,8 @@ async function main(): Promise<void> {
 }
 
 // Only run when executed directly (not when imported in tests)
-const isDirectRun = process.argv[1]?.endsWith("sha-discipline.ts") || process.argv[1]?.includes("sha-discipline");
+const isDirectRun =
+  process.argv[1]?.endsWith("sha-discipline.ts") || process.argv[1]?.includes("sha-discipline");
 if (isDirectRun) {
   main().catch((err) => {
     console.error(`[sha-discipline] Onverwerkte fout: ${err}`);

--- a/tests/chat-genui-mobile-surfaces.test.ts
+++ b/tests/chat-genui-mobile-surfaces.test.ts
@@ -1,0 +1,105 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const ROOT = path.resolve(__dirname, "..");
+
+function readFile(...segments: string[]) {
+  return fs.readFileSync(path.join(ROOT, ...segments), "utf8");
+}
+
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  vi.doUnmock("@/hooks/use-mobile");
+});
+
+describe("GenUI mobile surfaces", () => {
+  it("keeps the recruiter-core modules eager while secondary modules stay lazy", () => {
+    const source = readFile("components", "chat", "genui", "registry.ts");
+
+    expect(source).toContain('from "./action-card"');
+    expect(source).toContain('from "./kandidaat-card"');
+    expect(source).toContain('from "./kandidaat-list"');
+    expect(source).toContain('from "./opdracht-card"');
+    expect(source).toContain('from "./opdracht-list"');
+
+    expect(source).toContain("component: OpdrachtGenUICard");
+    expect(source).toContain("component: KandidaatGenUICard");
+    expect(source).toContain("component: OpdrachtListCard");
+    expect(source).toContain("component: KandidaatListCard");
+    expect(source).toContain("component: MatchCreatedCard");
+
+    expect(source).toContain('import("./match-card").then');
+    expect(source).toContain('import("./match-list").then');
+    expect(source).toContain('import("./comparison-table").then');
+    expect(source).toContain('import("./platform-card").then');
+  });
+
+  it("renders comparison output as collapsible mobile cards instead of a table", async () => {
+    vi.doMock("@/hooks/use-mobile", () => ({
+      useIsMobile: () => true,
+    }));
+
+    const { ComparisonTable } = await import("../components/chat/genui/comparison-table");
+
+    const html = renderToStaticMarkup(
+      createElement(ComparisonTable, {
+        output: {
+          type: "comparison",
+          title: "Structured match vergelijking",
+          columns: ["Kandidaat A", "Kandidaat B"],
+          items: [
+            {
+              label: "Sourcingdiepgang",
+              values: { "Kandidaat A": 9, "Kandidaat B": 7 },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(html).toContain("<details");
+    expect(html).not.toContain("<table");
+    expect(html).toContain("Kandidaat A");
+    expect(html).toContain("Sourcingdiepgang");
+  });
+
+  it("uses disclosure on mobile for platform stepper output and a single-column platform list", async () => {
+    vi.doMock("@/hooks/use-mobile", () => ({
+      useIsMobile: () => true,
+    }));
+
+    const { PlatformCard } = await import("../components/chat/genui/platform-card");
+
+    const statusHtml = renderToStaticMarkup(
+      createElement(PlatformCard, {
+        output: {
+          catalog: { slug: "linkedin", displayName: "LinkedIn" },
+          config: { isActive: true, lastRunAt: "2026-04-09T09:00:00.000Z" },
+          latestRun: { status: "active", currentStep: "validate" },
+        },
+      }),
+    );
+
+    expect(statusHtml).toContain("<details");
+    expect(statusHtml).toContain("Valideren");
+
+    const source = readFile("components", "chat", "genui", "platform-card.tsx");
+    expect(source).toContain("grid grid-cols-1 gap-2 sm:grid-cols-2");
+  });
+
+  it("standardizes touch targets and routes loading through the shared GenUI skeleton", () => {
+    const utilsSource = readFile("components", "chat", "genui", "genui-utils.ts");
+    const actionSource = readFile("components", "chat", "genui", "action-primitives.tsx");
+    const canvasSource = readFile("components", "chat", "genui", "canvas-embed.tsx");
+    const skeletonSource = readFile("components", "chat", "genui", "genui-loading-skeleton.tsx");
+
+    expect(utilsSource).toContain("min-h-11");
+    expect(actionSource).toContain("genuiTouchTargetClassName");
+    expect(canvasSource).toContain("GenUILoadingSkeleton");
+    expect(skeletonSource).toContain("rows = 2");
+  });
+});

--- a/tests/harness/auto-resolve-threads.test.ts
+++ b/tests/harness/auto-resolve-threads.test.ts
@@ -9,11 +9,7 @@ import { classifyThreads, run } from "@/scripts/harness/auto-resolve-threads";
 // Fixtures
 // ---------------------------------------------------------------------------
 
-function makeThread(
-  id: string,
-  isResolved: boolean,
-  logins: string[],
-) {
+function makeThread(id: string, isResolved: boolean, logins: string[]) {
   return {
     id,
     isResolved,
@@ -29,9 +25,7 @@ function makeThread(
 
 describe("classifyThreads", () => {
   it("classifies bot-only unresolved threads as botOnly", () => {
-    const threads = [
-      makeThread("T1", false, ["review-bot[bot]", "github-actions"]),
-    ];
+    const threads = [makeThread("T1", false, ["review-bot[bot]", "github-actions"])];
 
     const { botOnly, withHumans, alreadyResolved } = classifyThreads(threads);
 
@@ -42,9 +36,7 @@ describe("classifyThreads", () => {
   });
 
   it("classifies threads with human comments as withHumans", () => {
-    const threads = [
-      makeThread("T2", false, ["review-bot[bot]", "human-dev"]),
-    ];
+    const threads = [makeThread("T2", false, ["review-bot[bot]", "human-dev"])];
 
     const { botOnly, withHumans } = classifyThreads(threads);
 
@@ -54,9 +46,7 @@ describe("classifyThreads", () => {
   });
 
   it("classifies already-resolved threads separately", () => {
-    const threads = [
-      makeThread("T3", true, ["review-bot[bot]"]),
-    ];
+    const threads = [makeThread("T3", true, ["review-bot[bot]"])];
 
     const { botOnly, withHumans, alreadyResolved } = classifyThreads(threads);
 
@@ -76,10 +66,10 @@ describe("classifyThreads", () => {
 
   it("correctly handles mixed thread types", () => {
     const threads = [
-      makeThread("T4", false, ["ci-bot[bot]"]),                  // bot-only
-      makeThread("T5", false, ["ci-bot[bot]", "developer"]),     // has human
-      makeThread("T6", true, ["ci-bot[bot]"]),                   // already resolved
-      makeThread("T7", false, ["github-actions"]),               // bot-only (known bot)
+      makeThread("T4", false, ["ci-bot[bot]"]), // bot-only
+      makeThread("T5", false, ["ci-bot[bot]", "developer"]), // has human
+      makeThread("T6", true, ["ci-bot[bot]"]), // already resolved
+      makeThread("T7", false, ["github-actions"]), // bot-only (known bot)
     ];
 
     const { botOnly, withHumans, alreadyResolved } = classifyThreads(threads);
@@ -114,8 +104,8 @@ describe("run", () => {
     });
 
     mockExecSync
-      .mockReturnValueOnce(graphqlResponse)  // fetch threads
-      .mockReturnValueOnce("{}");            // resolve T10
+      .mockReturnValueOnce(graphqlResponse) // fetch threads
+      .mockReturnValueOnce("{}"); // resolve T10
 
     const result = await run(42, "TestOwner", "test-repo");
 
@@ -137,9 +127,7 @@ describe("run", () => {
   });
 
   it("does nothing when all threads are already resolved", async () => {
-    const threads = [
-      makeThread("T20", true, ["lint-bot[bot]"]),
-    ];
+    const threads = [makeThread("T20", true, ["lint-bot[bot]"])];
 
     const graphqlResponse = JSON.stringify({
       data: {

--- a/tests/harness/pr-comment-writer.test.ts
+++ b/tests/harness/pr-comment-writer.test.ts
@@ -96,7 +96,9 @@ describe("upsertPrComment", () => {
     // Verify the PATCH call references the correct comment ID
     expect(mockExecSync).toHaveBeenNthCalledWith(
       2,
-      expect.stringContaining(`-X PATCH repos/${BASE_OPTIONS.owner}/${BASE_OPTIONS.repo}/issues/comments/77`),
+      expect.stringContaining(
+        `-X PATCH repos/${BASE_OPTIONS.owner}/${BASE_OPTIONS.repo}/issues/comments/77`,
+      ),
       expect.any(Object),
     );
   });

--- a/tests/harness/sha-discipline.test.ts
+++ b/tests/harness/sha-discipline.test.ts
@@ -25,9 +25,7 @@ describe("markStaleComments", () => {
   const NEW_SHA = "abc1234";
 
   it("marks stale bot comments when SHA changes", () => {
-    const comments = [
-      makeComment(1, "Review feedback\n<!-- sha:oldsha999 -->", "some-app[bot]"),
-    ];
+    const comments = [makeComment(1, "Review feedback\n<!-- sha:oldsha999 -->", "some-app[bot]")];
 
     const { toUpdate, skipped } = markStaleComments(comments, NEW_SHA);
 
@@ -40,9 +38,7 @@ describe("markStaleComments", () => {
   });
 
   it("skips non-bot comments", () => {
-    const comments = [
-      makeComment(2, "Human review\n<!-- sha:oldsha999 -->", "human-reviewer"),
-    ];
+    const comments = [makeComment(2, "Human review\n<!-- sha:oldsha999 -->", "human-reviewer")];
 
     const { toUpdate, skipped } = markStaleComments(comments, NEW_SHA);
 
@@ -51,9 +47,7 @@ describe("markStaleComments", () => {
   });
 
   it("skips comments without SHA tags", () => {
-    const comments = [
-      makeComment(3, "Just a regular comment with no SHA tag", "some-app[bot]"),
-    ];
+    const comments = [makeComment(3, "Just a regular comment with no SHA tag", "some-app[bot]")];
 
     const { toUpdate, skipped } = markStaleComments(comments, NEW_SHA);
 
@@ -69,9 +63,7 @@ describe("markStaleComments", () => {
   });
 
   it("skips bot comments whose SHA already matches the new HEAD", () => {
-    const comments = [
-      makeComment(4, `Up-to-date\n<!-- sha:${NEW_SHA} -->`, "github-actions"),
-    ];
+    const comments = [makeComment(4, `Up-to-date\n<!-- sha:${NEW_SHA} -->`, "github-actions")];
 
     const { toUpdate, skipped } = markStaleComments(comments, NEW_SHA);
 
@@ -91,9 +83,7 @@ describe("markStaleComments", () => {
   });
 
   it("recognizes github-actions as a known bot", () => {
-    const comments = [
-      makeComment(6, "CI feedback\n<!-- sha:oldsha999 -->", "github-actions"),
-    ];
+    const comments = [makeComment(6, "CI feedback\n<!-- sha:oldsha999 -->", "github-actions")];
 
     const { toUpdate } = markStaleComments(comments, NEW_SHA);
 
@@ -139,9 +129,7 @@ describe("run", () => {
   });
 
   it("does nothing when all comments are up-to-date", async () => {
-    const comments = [
-      makeComment(20, "Current review\n<!-- sha:currentsha -->", "ci-bot[bot]"),
-    ];
+    const comments = [makeComment(20, "Current review\n<!-- sha:currentsha -->", "ci-bot[bot]")];
 
     mockExecSync.mockReturnValueOnce(JSON.stringify(comments));
 


### PR DESCRIPTION
## Summary
- make the 16 GenUI chat surfaces mobile-first by removing mobile truncation, converting dense/table content to card/disclosure layouts, and lifting interactive controls to 44px touch targets
- eager-load the recruiter-core GenUI modules in `registry.ts` while keeping the remaining 11 modules lazy, and route loading through a shared GenUI skeleton
- add mobile regression coverage for the GenUI registry/layout contract and clear the repo-wide Biome blockers that prevented `pnpm lint` from passing

## Testing
- `pnpm test -- tests/chat-genui-mobile-surfaces.test.ts tests/chat-interview-prep-surface.test.ts tests/platform-credential-submit.test.ts tests/cv-download-button.test.ts`
- `pnpm test -- tests/harness/auto-resolve-threads.test.ts tests/harness/pr-comment-writer.test.ts tests/harness/sha-discipline.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint`

## Runtime Proof
- 375px Playwright proof attached on Linear: https://uploads.linear.app/b7688ac3-95c9-492e-9d01-20211713bf9e/f34ec97d-eb9f-4d8b-9049-7a890e2a21e0/938b71ff-5853-4081-8945-78d5a6b4217d
- final proof metrics inside the GenUI preview root: `scrollWidth=390`, `clientWidth=390`, show-more buttons `44px`, action buttons `44px`, canvas control `44px`, CV download button `44px`

## Notes
- live database-backed `/chat` session replay was not available in this workspace copy because local `DATABASE_URL` credentials were missing, so runtime verification used a reversible local GenUI proof harness that was removed before commit

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mobile-responsive layouts to chat components with collapsible sections and improved text handling on smaller screens.
  * Enhanced UI responsiveness across comparison tables, interview prep, platform cards, candidate lists, and match cards.

* **Chores**
  * Updated configuration schema version.
  * Code refactoring and formatting improvements.

* **Tests**
  * Added test coverage for mobile rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->