### PR TITLE
Debounce data refresh and smooth mobile recruiter updates

### DIFF
--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,0 +1,73 @@
+import type { NextRequest } from "next/server";
+import { type DataRefreshEvent, deriveRefreshTags } from "@/src/lib/data-refresh";
+import { type SSEEvent, subscribe } from "@/src/lib/event-bus";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+const encoder = new TextEncoder();
+
+function formatSse(event: DataRefreshEvent) {
+  return encoder.encode(`data: ${JSON.stringify(event)}\n\n`);
+}
+
+function mapEvent(event: SSEEvent): DataRefreshEvent {
+  return {
+    ...event,
+    tags: deriveRefreshTags(event.type),
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let closed = false;
+
+      const close = () => {
+        if (closed) return;
+        closed = true;
+        clearInterval(keepAlive);
+        unsubscribe();
+        try {
+          controller.close();
+        } catch {
+          // Connection already closed by the runtime.
+        }
+      };
+
+      const pushEvent = (event: DataRefreshEvent) => {
+        if (closed) return;
+        controller.enqueue(formatSse(event));
+      };
+
+      const unsubscribe = subscribe((event) => {
+        pushEvent(mapEvent(event));
+      });
+
+      const keepAlive = setInterval(() => {
+        if (closed) return;
+        controller.enqueue(encoder.encode(": keep-alive\n\n"));
+      }, 15_000);
+
+      pushEvent({
+        type: "system:connected",
+        data: {},
+        timestamp: new Date().toISOString(),
+        tags: [],
+      });
+
+      request.signal.addEventListener("abort", close);
+    },
+    cancel() {
+      // Consumers disconnecting will trigger request.signal.abort in production.
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-store",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/app/api/kandidaten/[id]/notities/route.ts
+++ b/app/api/kandidaten/[id]/notities/route.ts
@@ -2,6 +2,7 @@ import { revalidatePath } from "next/cache";
 import type { NextRequest } from "next/server";
 import { z } from "zod";
 import { withApiHandler } from "@/src/lib/api-handler";
+import { publish } from "@/src/lib/event-bus";
 import { addNoteToCandidate } from "@/src/services/candidates";
 
 export const dynamic = "force-dynamic";
@@ -26,6 +27,8 @@ export const POST = withApiHandler(
       return Response.json({ error: "Kandidaat niet gevonden" }, { status: 404 });
     }
     revalidatePath("/kandidaten");
+    revalidatePath(`/kandidaten/${id}`);
+    publish("candidate:updated", { id, action: "note_added" });
     return Response.json(
       { data: { notes: candidate.notes } },
       {

--- a/app/api/kandidaten/[id]/route.ts
+++ b/app/api/kandidaten/[id]/route.ts
@@ -2,6 +2,7 @@ import { revalidatePath } from "next/cache";
 import type { NextRequest } from "next/server";
 import { z } from "zod";
 import { withApiHandler } from "@/src/lib/api-handler";
+import { publish } from "@/src/lib/event-bus";
 import { deleteCandidate, getCandidateById, updateCandidate } from "@/src/services/candidates";
 import { withCandidateCanonicalSkills } from "@/src/services/esco";
 
@@ -55,6 +56,8 @@ export const PATCH = withApiHandler(
       return Response.json({ error: "Kandidaat niet gevonden" }, { status: 404 });
     }
     revalidatePath("/kandidaten");
+    revalidatePath(`/kandidaten/${id}`);
+    publish("candidate:updated", { id, action: "profile_updated" });
     return Response.json(
       { data: await withCandidateCanonicalSkills(candidate) },
       {
@@ -73,6 +76,7 @@ export const DELETE = withApiHandler(
       return Response.json({ error: "Kandidaat niet gevonden" }, { status: 404 });
     }
     revalidatePath("/kandidaten");
+    publish("candidate:deleted", { id });
     return Response.json(
       { data: { id, deleted: true } },
       {

--- a/app/api/sollicitaties/[id]/route.ts
+++ b/app/api/sollicitaties/[id]/route.ts
@@ -60,7 +60,11 @@ export const PATCH = withApiHandler(
       return Response.json({ error: "Sollicitatie niet gevonden" }, { status: 404 });
     }
     revalidatePath("/pipeline");
-    publish("application:updated", { applicationId: id, stage: parsed.data.stage });
+    publish("application:updated", {
+      applicationId: id,
+      stage: parsed.data.stage,
+      notesUpdated: parsed.data.notes !== undefined,
+    });
     return Response.json(
       { data: application },
       {
@@ -79,6 +83,7 @@ export const DELETE = withApiHandler(
       return Response.json({ error: "Sollicitatie niet gevonden" }, { status: 404 });
     }
     revalidatePath("/pipeline");
+    publish("application:deleted", { applicationId: id });
     return Response.json(
       { data: { id, deleted: true } },
       {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { Inter, JetBrains_Mono, Playfair_Display } from "next/font/google";
 import Script from "next/script";
 import "./globals.css";
+import { DataRefreshListener } from "@/components/data-refresh-listener";
 import { RouteShellOverlays } from "@/components/route-shell-overlays";
 import { SidebarLayout } from "@/components/sidebar-layout";
 import { Providers } from "./providers";
@@ -42,6 +43,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       >
         <Providers>
           <SidebarLayout>{children}</SidebarLayout>
+          <DataRefreshListener />
           <RouteShellOverlays />
         </Providers>
         <SpeedInsights />

--- a/components/candidate-notes.tsx
+++ b/components/candidate-notes.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { useState, useTransition } from "react";
+import { useEffect, useState } from "react";
+import { useDataMutationNotifier } from "@/components/data-refresh-listener";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { appendOptimisticNote } from "@/src/lib/mobile-optimistic";
 
 export function CandidateNotes({
   candidateId,
@@ -12,28 +13,48 @@ export function CandidateNotes({
   candidateId: string;
   initialNotes: string | null;
 }) {
-  const router = useRouter();
+  const notifyDataMutation = useDataMutationNotifier();
   const [notes, setNotes] = useState(initialNotes);
   const [draft, setDraft] = useState("");
   const [saving, setSaving] = useState(false);
-  const [, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setNotes(initialNotes);
+  }, [initialNotes]);
 
   async function handleAddNote() {
-    if (!draft.trim()) return;
+    const trimmedDraft = draft.trim();
+    if (!trimmedDraft) return;
 
+    const previousNotes = notes;
+    setError(null);
     setSaving(true);
+    setNotes(appendOptimisticNote(notes, trimmedDraft));
+    setDraft("");
+
     try {
       const res = await fetch(`/api/kandidaten/${candidateId}/notities`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ note: draft.trim() }),
+        body: JSON.stringify({ note: trimmedDraft }),
       });
-      if (res.ok) {
-        const { data } = await res.json();
-        setNotes(data.notes);
-        setDraft("");
-        startTransition(() => router.refresh());
+
+      const body = (await res.json().catch(() => null)) as {
+        data?: { notes?: string | null };
+        error?: string;
+      } | null;
+
+      if (!res.ok) {
+        throw new Error(body?.error ?? "Notitie opslaan mislukt");
       }
+
+      setNotes(body?.data?.notes ?? appendOptimisticNote(previousNotes, trimmedDraft));
+      notifyDataMutation(["candidates"]);
+    } catch (saveError) {
+      setNotes(previousNotes);
+      setDraft(trimmedDraft);
+      setError(saveError instanceof Error ? saveError.message : "Notitie opslaan mislukt");
     } finally {
       setSaving(false);
     }
@@ -67,6 +88,7 @@ export function CandidateNotes({
               }
             }}
           />
+          {error ? <p className="text-sm text-destructive">{error}</p> : null}
           <div className="flex justify-end">
             <Button size="sm" onClick={handleAddNote} disabled={saving || !draft.trim()}>
               {saving ? "Opslaan…" : "Notitie toevoegen"}

--- a/components/candidate-recommendation-panel.tsx
+++ b/components/candidate-recommendation-panel.tsx
@@ -3,9 +3,10 @@
 import { ArrowRight, Loader2, RefreshCw, Sparkles } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { MatchSuggestionCard } from "@/components/candidate-wizard/match-suggestion-card";
 import type { MatchSuggestionItem } from "@/components/candidate-wizard/types";
+import { useDataMutationNotifier } from "@/components/data-refresh-listener";
 import { Button } from "@/components/ui/button";
 
 interface CandidateRecommendationPanelProps {
@@ -81,9 +82,14 @@ export function CandidateRecommendationPanel({
   initialMatches,
 }: CandidateRecommendationPanelProps) {
   const router = useRouter();
+  const notifyDataMutation = useDataMutationNotifier();
   const [matches, setMatches] = useState(initialMatches);
   const [pendingAction, setPendingAction] = useState<"refresh" | "link" | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setMatches(initialMatches);
+  }, [initialMatches]);
 
   const recommendedMatch = useMemo(() => pickRecommendedMatch(matches), [matches]);
   const highlightedRecommendationSource: MatchSuggestionItem["recommendationSource"] =
@@ -128,8 +134,14 @@ export function CandidateRecommendationPanel({
   const autoLinkRecommendation = async () => {
     if (!recommendedMatch) return;
 
+    const previousMatches = matches;
     setPendingAction("link");
     setError(null);
+    setMatches((currentMatches) =>
+      currentMatches.map((match) =>
+        match.matchId === recommendedMatch.matchId ? { ...match, isLinked: true } : match,
+      ),
+    );
 
     try {
       const response = await fetch(`/api/kandidaten/${candidateId}/koppel`, {
@@ -144,8 +156,9 @@ export function CandidateRecommendationPanel({
         throw new Error(message ?? "Aanbevolen match koppelen mislukt");
       }
 
-      router.refresh();
+      notifyDataMutation(["pipeline", "matches", "candidates", "jobs"]);
     } catch (err) {
+      setMatches(previousMatches);
       setError(err instanceof Error ? err.message : "Aanbevolen match koppelen mislukt");
     } finally {
       setPendingAction(null);

--- a/components/data-refresh-listener.tsx
+++ b/components/data-refresh-listener.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+import { createContext, useCallback, useContext, useEffect } from "react";
+import { useEventSource } from "@/src/hooks/use-event-source";
+import {
+  type DataRefreshEvent,
+  LOCAL_DATA_CHANGE_EVENT,
+  mergeRefreshTags,
+  normalizeRefreshTags,
+  REFRESH_DEBOUNCE_MS,
+  type RefreshTag,
+  shouldRefreshPath,
+} from "@/src/lib/data-refresh";
+
+const DataMutationContext = createContext<(tags: readonly RefreshTag[]) => void>(() => undefined);
+
+export function DataMutationProvider({ children }: { children: React.ReactNode }) {
+  const notify = useCallback((tags: readonly RefreshTag[]) => {
+    if (typeof window === "undefined") return;
+
+    window.dispatchEvent(
+      new CustomEvent(LOCAL_DATA_CHANGE_EVENT, {
+        detail: {
+          tags: tags.length > 0 ? Array.from(tags) : ["all"],
+        },
+      }),
+    );
+  }, []);
+
+  return <DataMutationContext.Provider value={notify}>{children}</DataMutationContext.Provider>;
+}
+
+export function useDataMutationNotifier() {
+  return useContext(DataMutationContext);
+}
+
+export function DataRefreshListener() {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const handleBatch = useCallback(
+    (events: DataRefreshEvent[]) => {
+      const tags = mergeRefreshTags(events);
+      if (!shouldRefreshPath(pathname, tags)) return;
+      router.refresh();
+    },
+    [pathname, router],
+  );
+
+  const { enqueueEvent } = useEventSource({
+    url: "/api/events",
+    debounceMs: REFRESH_DEBOUNCE_MS,
+    onBatch: handleBatch,
+  });
+
+  useEffect(() => {
+    const handleLocalChange = (event: Event) => {
+      const detail =
+        event instanceof CustomEvent && event.detail && typeof event.detail === "object"
+          ? (event.detail as { tags?: unknown[] })
+          : undefined;
+
+      enqueueEvent({
+        type: "local:mutation",
+        data: {},
+        timestamp: new Date().toISOString(),
+        tags: detail && Array.isArray(detail.tags) ? normalizeRefreshTags(detail.tags) : ["all"],
+      });
+    };
+
+    window.addEventListener(LOCAL_DATA_CHANGE_EVENT, handleLocalChange as EventListener);
+
+    return () => {
+      window.removeEventListener(LOCAL_DATA_CHANGE_EVENT, handleLocalChange as EventListener);
+    };
+  }, [enqueueEvent]);
+
+  return null;
+}

--- a/components/pipeline/application-feedback-editor.tsx
+++ b/components/pipeline/application-feedback-editor.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Loader2, MessageSquarePlus } from "lucide-react";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useDataMutationNotifier } from "@/components/data-refresh-listener";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -18,27 +18,37 @@ import { Textarea } from "@/components/ui/textarea";
 export function ApplicationFeedbackEditor({
   applicationId,
   initialNotes,
+  onNotesChange,
 }: {
   applicationId: string;
   initialNotes?: string | null;
+  onNotesChange?: (notes: string | null) => void;
 }) {
-  const router = useRouter();
+  const notifyDataMutation = useDataMutationNotifier();
   const [open, setOpen] = useState(false);
   const [notes, setNotes] = useState(initialNotes ?? "");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  useEffect(() => {
+    setNotes(initialNotes ?? "");
+  }, [initialNotes]);
+
   const hasNotes = (initialNotes ?? "").trim().length > 0;
 
   const handleSave = async () => {
+    const previousNotes = initialNotes ?? "";
+    const nextNotes = notes.trim();
+
     setSaving(true);
     setError(null);
+    onNotesChange?.(nextNotes || null);
 
     try {
       const response = await fetch(`/api/sollicitaties/${applicationId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ notes }),
+        body: JSON.stringify({ notes: nextNotes }),
       });
 
       const body = (await response.json().catch(() => null)) as { error?: string } | null;
@@ -46,9 +56,10 @@ export function ApplicationFeedbackEditor({
         throw new Error(body?.error ?? "Recruiterfeedback opslaan mislukt");
       }
 
+      notifyDataMutation(["pipeline"]);
       setOpen(false);
-      router.refresh();
     } catch (saveError) {
+      onNotesChange?.(previousNotes || null);
       setError(
         saveError instanceof Error ? saveError.message : "Recruiterfeedback opslaan mislukt",
       );

--- a/components/pipeline/kanban-board.tsx
+++ b/components/pipeline/kanban-board.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { useCallback, useOptimistic, useTransition } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { useDataMutationNotifier } from "@/components/data-refresh-listener";
+import { moveStageCard } from "@/src/lib/mobile-optimistic";
 import type { KanbanCardData } from "./kanban-card";
 import { KanbanColumn } from "./kanban-column";
 
@@ -20,30 +21,20 @@ interface KanbanBoardProps {
 type OptimisticAction = { applicationId: string; fromStage: string; toStage: string };
 
 export function KanbanBoard({ byStage }: KanbanBoardProps) {
-  const router = useRouter();
-  const [isPending, startTransition] = useTransition();
+  const notifyDataMutation = useDataMutationNotifier();
+  const [boardState, setBoardState] = useState(byStage);
+  const [savingMove, setSavingMove] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const [optimisticByStage, addOptimisticMove] = useOptimistic(
-    byStage,
-    (state, action: OptimisticAction) => {
-      const next = { ...state };
-      // Remove card from old stage
-      const fromCards = [...(next[action.fromStage] ?? [])];
-      const cardIndex = fromCards.findIndex((c) => c.id === action.applicationId);
-      if (cardIndex === -1) return state;
-      const [card] = fromCards.splice(cardIndex, 1);
-      next[action.fromStage] = fromCards;
-      // Add card to new stage
-      next[action.toStage] = [card, ...(next[action.toStage] ?? [])];
-      return next;
-    },
-  );
+  useEffect(() => {
+    setBoardState(byStage);
+  }, [byStage]);
 
   const handleDrop = useCallback(
-    (applicationId: string, targetStage: string) => {
+    async (applicationId: string, targetStage: string) => {
       // Find the card's current stage
       let fromStage = "";
-      for (const [stage, cards] of Object.entries(optimisticByStage)) {
+      for (const [stage, cards] of Object.entries(boardState)) {
         if (cards.some((c) => c.id === applicationId)) {
           fromStage = stage;
           break;
@@ -51,36 +42,53 @@ export function KanbanBoard({ byStage }: KanbanBoardProps) {
       }
       if (!fromStage || fromStage === targetStage) return;
 
-      startTransition(async () => {
-        addOptimisticMove({ applicationId, fromStage, toStage: targetStage });
+      const previousState = boardState;
+      const action: OptimisticAction = { applicationId, fromStage, toStage: targetStage };
+      setError(null);
+      setSavingMove(true);
+      setBoardState((currentState) =>
+        moveStageCard(currentState, {
+          cardId: action.applicationId,
+          fromStage: action.fromStage,
+          toStage: action.toStage,
+        }),
+      );
 
-        try {
-          const res = await fetch(`/api/sollicitaties/${applicationId}`, {
-            method: "PATCH",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ stage: targetStage }),
-          });
+      try {
+        const res = await fetch(`/api/sollicitaties/${applicationId}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ stage: targetStage }),
+        });
 
-          if (!res.ok) {
-            console.error("Failed to update stage:", await res.text());
-          }
-        } catch (err) {
-          console.error("Network error updating stage:", err);
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        if (!res.ok) {
+          throw new Error(body?.error ?? "Pipeline-fase opslaan mislukt");
         }
 
-        router.refresh();
-      });
+        notifyDataMutation(["pipeline"]);
+      } catch (err) {
+        setBoardState(previousState);
+        setError(err instanceof Error ? err.message : "Pipeline-fase opslaan mislukt");
+      } finally {
+        setSavingMove(false);
+      }
     },
-    [optimisticByStage, addOptimisticMove, router],
+    [boardState, notifyDataMutation],
   );
 
   return (
     <div className="relative">
-      {isPending && (
+      {savingMove && (
         <div className="absolute top-0 right-0 z-10">
           <span className="text-xs text-muted-foreground animate-pulse">Opslaan...</span>
         </div>
       )}
+      {error ? (
+        <div className="mb-3 rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      ) : null}
       <div className="flex gap-3 overflow-x-auto pb-4">
         {STAGES.map((stage) => (
           <KanbanColumn
@@ -88,7 +96,7 @@ export function KanbanBoard({ byStage }: KanbanBoardProps) {
             stage={stage.key}
             label={stage.label}
             color={stage.color}
-            cards={optimisticByStage[stage.key] ?? []}
+            cards={boardState[stage.key] ?? []}
             onDrop={handleDrop}
           />
         ))}

--- a/components/pipeline/kanban-card.tsx
+++ b/components/pipeline/kanban-card.tsx
@@ -2,7 +2,7 @@
 
 import { GripVertical } from "lucide-react";
 import Link from "next/link";
-import { type DragEvent, useCallback, useRef, useState } from "react";
+import { type DragEvent, useCallback, useEffect, useRef, useState } from "react";
 import { ScreeningCallButton } from "@/components/screening-call/screening-call-button";
 import { Badge } from "@/components/ui/badge";
 import { ApplicationFeedbackEditor } from "./application-feedback-editor";
@@ -27,7 +27,12 @@ interface KanbanCardProps {
 
 export function KanbanCard({ card }: KanbanCardProps) {
   const [isDragging, setIsDragging] = useState(false);
+  const [notes, setNotes] = useState(card.notes ?? null);
   const didDrag = useRef(false);
+
+  useEffect(() => {
+    setNotes(card.notes ?? null);
+  }, [card.notes]);
 
   const handleDragStart = useCallback(
     (e: DragEvent<HTMLDivElement>) => {
@@ -139,12 +144,16 @@ export function KanbanCard({ card }: KanbanCardProps) {
             )}
           </div>
 
-          {card.notes ? (
-            <p className="mt-2 line-clamp-2 text-xs text-muted-foreground">{card.notes}</p>
+          {notes ? (
+            <p className="mt-2 line-clamp-2 text-xs text-muted-foreground">{notes}</p>
           ) : null}
 
           <div className="mt-2">
-            <ApplicationFeedbackEditor applicationId={card.id} initialNotes={card.notes} />
+            <ApplicationFeedbackEditor
+              applicationId={card.id}
+              initialNotes={notes}
+              onNotesChange={setNotes}
+            />
           </div>
         </div>
       </div>

--- a/components/sidebar-layout.tsx
+++ b/components/sidebar-layout.tsx
@@ -2,6 +2,7 @@
 
 import { Search } from "lucide-react";
 import { AppSidebar } from "@/components/app-sidebar";
+import { DataMutationProvider } from "@/components/data-refresh-listener";
 import { MobileBottomNav } from "@/components/mobile-bottom-nav";
 import { SidebarInset, SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -10,28 +11,32 @@ export function SidebarLayout({ children }: { children: React.ReactNode }) {
   return (
     <TooltipProvider>
       <SidebarProvider>
-        <AppSidebar />
-        <SidebarInset className="min-w-0 overflow-x-hidden">
-          <div className="sticky top-0 z-30 flex h-12 items-center gap-2 border-b border-border/80 bg-background/95 px-3 pt-[max(env(safe-area-inset-top),0px)] backdrop-blur supports-backdrop-filter:bg-background/80 md:hidden">
-            <SidebarTrigger
-              className="size-10 rounded-xl border border-border bg-background/95 shadow-sm"
-              title="Navigatie openen of sluiten (⌘/Ctrl+B)"
-            />
-            <div className="flex-1" />
-            <button
-              type="button"
-              onClick={() => document.dispatchEvent(new CustomEvent("motian-command-palette-open"))}
-              className="flex size-10 items-center justify-center rounded-xl border border-border bg-background/95 shadow-sm text-muted-foreground transition-colors hover:text-foreground"
-              title="Zoeken (⌘K)"
-            >
-              <Search className="h-4 w-4" />
-            </button>
-          </div>
-          <div className="flex min-h-0 flex-1 flex-col pb-[calc(3.75rem+env(safe-area-inset-bottom))] md:pb-0">
-            {children}
-          </div>
-          <MobileBottomNav />
-        </SidebarInset>
+        <DataMutationProvider>
+          <AppSidebar />
+          <SidebarInset className="min-w-0 overflow-x-hidden">
+            <div className="sticky top-0 z-30 flex h-12 items-center gap-2 border-b border-border/80 bg-background/95 px-3 pt-[max(env(safe-area-inset-top),0px)] backdrop-blur supports-backdrop-filter:bg-background/80 md:hidden">
+              <SidebarTrigger
+                className="size-10 rounded-xl border border-border bg-background/95 shadow-sm"
+                title="Navigatie openen of sluiten (⌘/Ctrl+B)"
+              />
+              <div className="flex-1" />
+              <button
+                type="button"
+                onClick={() =>
+                  document.dispatchEvent(new CustomEvent("motian-command-palette-open"))
+                }
+                className="flex size-10 items-center justify-center rounded-xl border border-border bg-background/95 shadow-sm text-muted-foreground transition-colors hover:text-foreground"
+                title="Zoeken (⌘K)"
+              >
+                <Search className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="flex min-h-0 flex-1 flex-col pb-[calc(3.75rem+env(safe-area-inset-bottom))] md:pb-0">
+              {children}
+            </div>
+            <MobileBottomNav />
+          </SidebarInset>
+        </DataMutationProvider>
       </SidebarProvider>
     </TooltipProvider>
   );

--- a/proxy.ts
+++ b/proxy.ts
@@ -80,6 +80,7 @@ const FIRST_PARTY_PATHS = [
   "/api/interviews",
   "/api/sollicitaties",
   "/api/berichten",
+  "/api/events",
   "/api/instellingen",
   "/api/platforms",
   "/api/salesforce-feed",

--- a/src/hooks/use-event-source.ts
+++ b/src/hooks/use-event-source.ts
@@ -1,0 +1,107 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { type DataRefreshEvent, normalizeDataRefreshEvent } from "@/src/lib/data-refresh";
+import { createRefreshCoalescer } from "@/src/lib/refresh-coalescer";
+
+export type EventSourceStatus = "idle" | "connecting" | "open" | "error" | "unsupported";
+
+export function createEventBatcher(
+  flush: (events: DataRefreshEvent[]) => void,
+  { delayMs }: { delayMs: number },
+) {
+  let pending: DataRefreshEvent[] = [];
+
+  const coalescer = createRefreshCoalescer(
+    () => {
+      if (pending.length === 0) return;
+      const batch = pending;
+      pending = [];
+      flush(batch);
+    },
+    { delayMs },
+  );
+
+  return {
+    push(event: DataRefreshEvent) {
+      pending.push(event);
+      coalescer.trigger();
+    },
+    cancel() {
+      pending = [];
+      coalescer.cancel();
+    },
+  };
+}
+
+export function useEventSource({
+  url,
+  onBatch,
+  enabled = true,
+  debounceMs,
+}: {
+  url: string;
+  onBatch: (events: DataRefreshEvent[]) => void;
+  enabled?: boolean;
+  debounceMs: number;
+}) {
+  const [status, setStatus] = useState<EventSourceStatus>("idle");
+  const onBatchRef = useRef(onBatch);
+  const batcherRef = useRef(
+    createEventBatcher((events) => onBatchRef.current(events), { delayMs: debounceMs }),
+  );
+
+  onBatchRef.current = onBatch;
+
+  useEffect(() => {
+    batcherRef.current.cancel();
+    batcherRef.current = createEventBatcher((events) => onBatchRef.current(events), {
+      delayMs: debounceMs,
+    });
+
+    return () => {
+      batcherRef.current.cancel();
+    };
+  }, [debounceMs]);
+
+  const enqueueEvent = useCallback((event: DataRefreshEvent) => {
+    batcherRef.current.push(event);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      setStatus("idle");
+      return;
+    }
+
+    if (typeof window === "undefined" || typeof EventSource === "undefined") {
+      setStatus("unsupported");
+      return;
+    }
+
+    setStatus("connecting");
+
+    const eventSource = new EventSource(url);
+
+    eventSource.onopen = () => {
+      setStatus("open");
+    };
+
+    eventSource.onmessage = (message) => {
+      const nextEvent = normalizeDataRefreshEvent(message.data);
+      if (!nextEvent) return;
+      enqueueEvent(nextEvent);
+    };
+
+    eventSource.onerror = () => {
+      setStatus("error");
+    };
+
+    return () => {
+      eventSource.close();
+      setStatus("idle");
+    };
+  }, [enabled, enqueueEvent, url]);
+
+  return { enqueueEvent, status };
+}

--- a/src/lib/data-refresh.ts
+++ b/src/lib/data-refresh.ts
@@ -1,0 +1,112 @@
+export const LOCAL_DATA_CHANGE_EVENT = "motian-data-changed";
+export const REFRESH_DEBOUNCE_MS = 500;
+
+export const REFRESH_TAG_VALUES = [
+  "all",
+  "candidates",
+  "matches",
+  "pipeline",
+  "jobs",
+  "interviews",
+  "messages",
+  "scrapers",
+] as const;
+
+export type RefreshTag = (typeof REFRESH_TAG_VALUES)[number];
+
+export type DataRefreshEvent = {
+  type: string;
+  data: Record<string, unknown>;
+  timestamp: string;
+  tags: RefreshTag[];
+};
+
+const REFRESH_TAG_SET = new Set<RefreshTag>(REFRESH_TAG_VALUES);
+
+const EVENT_TAGS: Array<[prefix: string, tags: RefreshTag[]]> = [
+  ["candidate:", ["candidates"]],
+  ["match:", ["matches", "candidates", "jobs", "pipeline"]],
+  ["matches:", ["matches", "candidates", "jobs", "pipeline"]],
+  ["application:", ["pipeline", "candidates", "jobs"]],
+  ["interview:", ["interviews", "pipeline", "candidates"]],
+  ["message:", ["messages", "pipeline", "candidates"]],
+  ["job:", ["jobs", "matches", "pipeline"]],
+  ["scrape:", ["scrapers", "jobs"]],
+  ["platform:", ["scrapers", "jobs"]],
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function normalizeRefreshTags(tags: readonly unknown[] | null | undefined): RefreshTag[] {
+  if (!tags || tags.length === 0) return [];
+
+  const normalized = new Set<RefreshTag>();
+
+  for (const value of tags) {
+    if (typeof value !== "string") continue;
+    if (!REFRESH_TAG_SET.has(value as RefreshTag)) continue;
+    normalized.add(value as RefreshTag);
+  }
+
+  return Array.from(normalized);
+}
+
+export function deriveRefreshTags(type: string): RefreshTag[] {
+  for (const [prefix, tags] of EVENT_TAGS) {
+    if (type.startsWith(prefix)) return tags;
+  }
+
+  return [];
+}
+
+export function normalizeDataRefreshEvent(value: unknown): DataRefreshEvent | null {
+  if (typeof value === "string") {
+    try {
+      return normalizeDataRefreshEvent(JSON.parse(value));
+    } catch {
+      return null;
+    }
+  }
+
+  if (!isRecord(value) || typeof value.type !== "string") return null;
+
+  const tags = normalizeRefreshTags(Array.isArray(value.tags) ? value.tags : undefined);
+
+  return {
+    type: value.type,
+    data: isRecord(value.data) ? value.data : {},
+    timestamp: typeof value.timestamp === "string" ? value.timestamp : new Date().toISOString(),
+    tags: tags.length > 0 ? tags : deriveRefreshTags(value.type),
+  };
+}
+
+export function mergeRefreshTags(
+  events: ReadonlyArray<Pick<DataRefreshEvent, "tags">>,
+): RefreshTag[] {
+  return normalizeRefreshTags(events.flatMap((event) => event.tags));
+}
+
+export function shouldRefreshPath(pathname: string, tags: readonly RefreshTag[]): boolean {
+  if (tags.length === 0) return false;
+  if (tags.includes("all")) return true;
+
+  const routeTags = pathname.startsWith("/kandidaten")
+    ? (["candidates", "matches", "pipeline"] as const)
+    : pathname.startsWith("/vacatures") || pathname.startsWith("/opdrachten")
+      ? (["jobs", "matches", "pipeline"] as const)
+      : pathname.startsWith("/pipeline")
+        ? (["pipeline", "matches", "candidates", "jobs"] as const)
+        : pathname.startsWith("/interviews")
+          ? (["interviews", "pipeline", "candidates"] as const)
+          : pathname.startsWith("/messages")
+            ? (["messages", "pipeline", "candidates"] as const)
+            : pathname.startsWith("/overzicht")
+              ? (["candidates", "matches", "pipeline", "jobs", "interviews", "messages"] as const)
+              : pathname.startsWith("/automatisering") || pathname.startsWith("/scraper")
+                ? (["scrapers", "jobs"] as const)
+                : ([] as const);
+
+  return routeTags.some((tag) => tags.includes(tag));
+}

--- a/src/lib/mobile-optimistic.ts
+++ b/src/lib/mobile-optimistic.ts
@@ -1,0 +1,40 @@
+export type StageCard = {
+  id: string;
+};
+
+export function moveStageCard<T extends StageCard>(
+  state: Record<string, T[]>,
+  {
+    cardId,
+    fromStage,
+    toStage,
+  }: {
+    cardId: string;
+    fromStage: string;
+    toStage: string;
+  },
+) {
+  if (fromStage === toStage) return state;
+
+  const next = { ...state };
+  const fromCards = [...(next[fromStage] ?? [])];
+  const cardIndex = fromCards.findIndex((card) => card.id === cardId);
+
+  if (cardIndex === -1) return state;
+
+  const [card] = fromCards.splice(cardIndex, 1);
+  next[fromStage] = fromCards;
+  next[toStage] = [card, ...(next[toStage] ?? [])];
+
+  return next;
+}
+
+export function appendOptimisticNote(existingNotes: string | null, nextNote: string) {
+  const trimmedNextNote = nextNote.trim();
+  if (!trimmedNextNote) return existingNotes ?? "";
+
+  const trimmedExisting = existingNotes?.trim();
+  if (!trimmedExisting) return trimmedNextNote;
+
+  return `${trimmedExisting}\n\n${trimmedNextNote}`;
+}

--- a/tests/cost-reduction-runtime-cleanup.test.ts
+++ b/tests/cost-reduction-runtime-cleanup.test.ts
@@ -9,12 +9,12 @@ function readFile(...segments: string[]) {
 }
 
 describe("runtime cost reduction cleanup", () => {
-  it("removes the unused Trigger tasks and generic SSE route", () => {
+  it("keeps unused Trigger tasks removed while restoring targeted refresh plumbing", () => {
     expect(fs.existsSync(path.join(ROOT, "trigger", "whatsapp-gateway.ts"))).toBe(false);
     expect(fs.existsSync(path.join(ROOT, "trigger", "autopilot-nightly.ts"))).toBe(false);
-    expect(fs.existsSync(path.join(ROOT, "app", "api", "events", "route.ts"))).toBe(false);
-    expect(fs.existsSync(path.join(ROOT, "components", "data-refresh-listener.tsx"))).toBe(false);
-    expect(fs.existsSync(path.join(ROOT, "src", "hooks", "use-event-source.ts"))).toBe(false);
+    expect(fs.existsSync(path.join(ROOT, "app", "api", "events", "route.ts"))).toBe(true);
+    expect(fs.existsSync(path.join(ROOT, "components", "data-refresh-listener.tsx"))).toBe(true);
+    expect(fs.existsSync(path.join(ROOT, "src", "hooks", "use-event-source.ts"))).toBe(true);
   });
 
   it("returns a static disabled WhatsApp status payload", async () => {
@@ -62,7 +62,8 @@ describe("runtime cost reduction cleanup", () => {
     expect(scraperActions).not.toContain("EventSource");
   });
 
-  it("removes SSE refresh listeners from recruiter pages and proxy allowlists", () => {
+  it("keeps refresh listeners centralized in the app shell instead of route files", () => {
+    const layoutSource = readFile("app", "layout.tsx");
     const kandidatenPage = readFile("app", "kandidaten", "page.tsx");
     const pipelinePage = readFile("app", "pipeline", "page.tsx");
     const interviewsPage = readFile("app", "interviews", "page.tsx");
@@ -70,11 +71,12 @@ describe("runtime cost reduction cleanup", () => {
     const vacaturesPage = readFile("app", "vacatures", "page.tsx");
     const proxySource = readFile("proxy.ts");
 
+    expect(layoutSource).toContain("DataRefreshListener");
     expect(kandidatenPage).not.toContain("DataRefreshListener");
     expect(pipelinePage).not.toContain("DataRefreshListener");
     expect(interviewsPage).not.toContain("DataRefreshListener");
     expect(messagesPage).not.toContain("DataRefreshListener");
     expect(vacaturesPage).not.toContain("DataRefreshListener");
-    expect(proxySource).not.toContain('"/api/events"');
+    expect(proxySource).toContain('"/api/events"');
   });
 });

--- a/tests/data-refresh-routing.test.ts
+++ b/tests/data-refresh-routing.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveRefreshTags,
+  mergeRefreshTags,
+  normalizeDataRefreshEvent,
+  shouldRefreshPath,
+} from "../src/lib/data-refresh";
+
+describe("data refresh routing", () => {
+  it("maps application updates onto pipeline-related tags", () => {
+    expect(deriveRefreshTags("application:updated")).toEqual(["pipeline", "candidates", "jobs"]);
+  });
+
+  it("normalizes streamed events and backfills missing tags from the event type", () => {
+    const event = normalizeDataRefreshEvent({
+      type: "match:updated",
+      data: { matchId: "match-1" },
+      timestamp: "2026-04-10T00:00:00.000Z",
+    });
+
+    expect(event).toEqual({
+      type: "match:updated",
+      data: { matchId: "match-1" },
+      timestamp: "2026-04-10T00:00:00.000Z",
+      tags: ["matches", "candidates", "jobs", "pipeline"],
+    });
+  });
+
+  it("refreshes only routes that intersect the event tags", () => {
+    const tags = mergeRefreshTags([
+      { tags: ["pipeline", "jobs"] },
+      { tags: ["pipeline", "candidates"] },
+    ]);
+
+    expect(shouldRefreshPath("/pipeline", tags)).toBe(true);
+    expect(shouldRefreshPath("/kandidaten/abc", tags)).toBe(true);
+    expect(shouldRefreshPath("/ontwikkelaar", tags)).toBe(false);
+  });
+});

--- a/tests/mobile-optimistic.test.ts
+++ b/tests/mobile-optimistic.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { appendOptimisticNote, moveStageCard } from "../src/lib/mobile-optimistic";
+
+describe("mobile optimistic helpers", () => {
+  it("appends a new note with paragraph spacing", () => {
+    expect(appendOptimisticNote("Eerste notitie", "Tweede notitie")).toBe(
+      "Eerste notitie\n\nTweede notitie",
+    );
+  });
+
+  it("moves a card between pipeline stages without mutating unrelated stages", () => {
+    const state = {
+      new: [{ id: "app-1" }, { id: "app-2" }],
+      screening: [{ id: "app-3" }],
+    };
+
+    const next = moveStageCard(state, {
+      cardId: "app-2",
+      fromStage: "new",
+      toStage: "screening",
+    });
+
+    expect(next.new).toEqual([{ id: "app-1" }]);
+    expect(next.screening).toEqual([{ id: "app-2" }, { id: "app-3" }]);
+    expect(state.new).toEqual([{ id: "app-1" }, { id: "app-2" }]);
+  });
+});

--- a/tests/refresh-coalescer.test.ts
+++ b/tests/refresh-coalescer.test.ts
@@ -21,6 +21,21 @@ describe("createRefreshCoalescer", () => {
     expect(refresh).toHaveBeenCalledTimes(1);
   });
 
+  it("coalesces a burst of ten triggers inside the debounce window", () => {
+    const refresh = vi.fn();
+    const coalescer = createRefreshCoalescer(refresh, { delayMs: 500 });
+
+    for (let index = 0; index < 10; index += 1) {
+      coalescer.trigger();
+      vi.advanceTimersByTime(40);
+    }
+
+    expect(refresh).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(500);
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
   it("cancels a pending refresh", () => {
     const refresh = vi.fn();
     const coalescer = createRefreshCoalescer(refresh, { delayMs: 150 });

--- a/tests/use-event-source.test.ts
+++ b/tests/use-event-source.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createEventBatcher } from "../src/hooks/use-event-source";
+
+describe("createEventBatcher", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("batches ten realtime events into a single flush inside the debounce window", () => {
+    const flush = vi.fn();
+    const batcher = createEventBatcher(flush, { delayMs: 500 });
+
+    for (let index = 0; index < 10; index += 1) {
+      batcher.push({
+        type: "application:updated",
+        data: { index },
+        timestamp: new Date(index).toISOString(),
+        tags: ["pipeline"],
+      });
+      vi.advanceTimersByTime(40);
+    }
+
+    expect(flush).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(500);
+
+    expect(flush).toHaveBeenCalledTimes(1);
+    expect(flush.mock.calls[0]?.[0]).toHaveLength(10);
+  });
+
+  it("drops pending events when cancelled", () => {
+    const flush = vi.fn();
+    const batcher = createEventBatcher(flush, { delayMs: 500 });
+
+    batcher.push({
+      type: "candidate:updated",
+      data: {},
+      timestamp: new Date().toISOString(),
+      tags: ["candidates"],
+    });
+    batcher.cancel();
+
+    vi.advanceTimersByTime(500);
+
+    expect(flush).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add a centralized `/api/events` SSE route, `useEventSource` batching, and a shell-mounted `DataRefreshListener` with 500ms coalescing and tag-based route matching
- switch mobile recruiter mutations away from immediate `router.refresh()` by keeping optimistic local state for candidate notes, recruiter recommendation linking, pipeline stage moves, and pipeline feedback edits
- add focused regression coverage for refresh batching, route-tag filtering, optimistic helpers, and the updated centralized refresh contract

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm test tests/refresh-coalescer.test.ts tests/use-event-source.test.ts tests/data-refresh-routing.test.ts tests/mobile-optimistic.test.ts tests/cost-reduction-runtime-cleanup.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint` (still fails on pre-existing Biome config/schema drift, `app/api/feed/vacatures/route.ts`, and existing `scripts/harness` formatting issues)

## Notes
- the ticket wording references a star/favorite candidate action, but the current product surface has no persisted favorite field; this PR maps that requirement onto the existing candidate-to-screening recommendation/link flow and keeps the mismatch documented in the Linear workpad
- mobile rendering evidence was captured through a temporary local proof route and screenshots, but uploading the screenshot into Linear via the signed `fileUpload` URL repeatedly failed because the returned upload URL had already expired by the time the shell command executed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time data refresh across candidates, applications, and pipeline sections
  * Optimistic UI updates for immediate visual feedback when adding notes or moving pipeline cards
  * Improved error recovery with automatic rollback on failed operations

* **Tests**
  * Added new test coverage for real-time refresh routing, optimistic UI helpers, and event batching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->