### PR TITLE
feat(mcp): add cookbook memory packs and retrieval tool

### DIFF
--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1,4 +1,6 @@
 import type { ParsedArgs } from "./parse-args";
+import { generateCookbooksFromTools } from "../services/cookbooks";
+import { allTools } from "../mcp/tools";
 
 // ========== Kandidaten ==========
 
@@ -129,6 +131,18 @@ export type Command = {
 };
 
 export const commands: Record<string, Command> = {
+  "orbit:cookbook:generate": {
+    description: "Genereer cookbook-memory packs voor alle MCP tools",
+    usage: "",
+    handler: async () => {
+      const cookbooks = generateCookbooksFromTools(allTools);
+      return {
+        generated: cookbooks.length,
+        tools: cookbooks.map((entry) => entry.toolName),
+      };
+    },
+  },
+
   // ── Kandidaten ─────────────────────────────────────────────────────────
 
   "kandidaten:zoek": {

--- a/src/mcp/create-server.ts
+++ b/src/mcp/create-server.ts
@@ -1,6 +1,7 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import * as Sentry from "@sentry/node";
+import { generateCookbooksFromTools, suggestCookbookForError } from "../services/cookbooks";
 import { allHandlers, allTools } from "./tools/index";
 
 const SENTRY_DSN = process.env.SENTRY_DSN;
@@ -10,6 +11,7 @@ const SENTRY_DSN = process.env.SENTRY_DSN;
  * Shared between the stdio entrypoint and the Vercel HTTP adapter.
  */
 function registerToolHandlers(server: Server): void {
+  generateCookbooksFromTools(allTools);
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: allTools,
   }));
@@ -31,8 +33,12 @@ function registerToolHandlers(server: Server): void {
     } catch (err) {
       if (SENTRY_DSN) Sentry.captureException(err);
       const message = err instanceof Error ? err.message : String(err);
+      const cookbookHint = suggestCookbookForError(name);
+      const hintText = cookbookHint ? `
+
+${cookbookHint}` : "";
       return {
-        content: [{ type: "text" as const, text: `Fout: ${message}` }],
+        content: [{ type: "text" as const, text: `Fout: ${message}${hintText}` }],
         isError: true,
       };
     }

--- a/src/mcp/tools/cookbook.ts
+++ b/src/mcp/tools/cookbook.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { getCookbookByToolName } from "../../services/cookbooks";
+
+const cookbookGetSchema = z.object({
+  toolName: z.string().min(1).describe("Naam van de MCP tool"),
+});
+
+export const tools = [
+  {
+    name: "cookbook_get",
+    description:
+      "Haal de procedural cookbook op voor een MCP toolnaam (frontmatter + stapsgewijze procedure).",
+    inputSchema: zodToJsonSchema(cookbookGetSchema, { $refStrategy: "none" }),
+  },
+];
+
+export const handlers: Record<string, (args: unknown) => Promise<unknown>> = {
+  cookbook_get: async (raw) => {
+    const { toolName } = cookbookGetSchema.parse(raw);
+    const cookbook = getCookbookByToolName(toolName);
+    if (!cookbook) {
+      return {
+        found: false,
+        toolName,
+        message: `Geen cookbook gevonden voor tool ${toolName}`,
+      };
+    }
+
+    return {
+      found: true,
+      cookbook,
+    };
+  },
+};

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -8,6 +8,7 @@ import {
   tools as batchOperationsTools,
 } from "./batch-operations";
 import { handlers as channelOfferHandlers, tools as channelOfferTools } from "./channel-offer";
+import { handlers as cookbookHandlers, tools as cookbookTools } from "./cookbook";
 import { handlers as chatSessionsHandlers, tools as chatSessionsTools } from "./chat-sessions";
 import { handlers as cvOpsHandlers, tools as cvOpsTools } from "./cv-operations";
 import { handlers as escoSkillsHandlers, tools as escoSkillsTools } from "./esco-skills";
@@ -46,6 +47,7 @@ export const allTools = [
   ...batchOperationsTools,
   ...cvOpsTools,
   ...channelOfferTools,
+  ...cookbookTools,
 ];
 
 export const allHandlers: Record<string, (args: unknown) => Promise<unknown>> = {
@@ -66,4 +68,5 @@ export const allHandlers: Record<string, (args: unknown) => Promise<unknown>> = 
   ...batchOperationsHandlers,
   ...cvOpsHandlers,
   ...channelOfferHandlers,
+  ...cookbookHandlers,
 };

--- a/src/services/cookbooks.ts
+++ b/src/services/cookbooks.ts
@@ -1,0 +1,100 @@
+import type { allTools } from "../mcp/tools";
+
+type McpToolDefinition = (typeof allTools)[number];
+
+export type CookbookBlock = {
+  type: "cookbook";
+  tags: string[];
+  toolName: string;
+  markdown: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const cookbookStore = new Map<string, CookbookBlock>();
+
+function normalizeToolName(toolName: string): string {
+  return toolName.trim().toLowerCase();
+}
+
+function deriveFailureModes(tool: McpToolDefinition): string[] {
+  return [
+    `Schema-validatie mislukt voor tool ${tool.name}`,
+    `Upstream service-fout in handler van ${tool.name}`,
+    `Ontbrekende of ongeldige argumenten voor ${tool.name}`,
+  ];
+}
+
+export function createCookbookMarkdown(tool: McpToolDefinition): string {
+  const failureModes = deriveFailureModes(tool)
+    .map((mode) => `  - "${mode}"`)
+    .join("\n");
+
+  return `---
+tool_name: "${tool.name}"
+prerequisites:
+  - "Bevestig vereiste velden tegen inputSchema"
+  - "Controleer authenticatie en omgevingsvariabelen"
+failure_modes:
+${failureModes}
+---
+
+# Cookbook: ${tool.name}
+
+## Doel
+${tool.description}
+
+## Procedure
+1. Controleer de verwachte input tegen de schema-eisen.
+2. Voer de tool uit met minimale geldige argumenten.
+3. Verifieer outputvorm en domeinvalidatie.
+4. Schaal op met volledige payload en controleer randgevallen.
+
+## Troubleshooting
+- Bekijk de exacte foutmelding en map die naar een failure mode.
+- Valideer argumentnamen en types opnieuw.
+- Probeer de tool opnieuw met een minimale payload om de fout te isoleren.
+`;
+}
+
+export function createCookbookBlock(tool: McpToolDefinition): CookbookBlock {
+  const timestamp = new Date().toISOString();
+  return {
+    type: "cookbook",
+    tags: [tool.name],
+    toolName: tool.name,
+    markdown: createCookbookMarkdown(tool),
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+}
+
+export function upsertCookbook(block: CookbookBlock): CookbookBlock {
+  const key = normalizeToolName(block.toolName);
+  const existing = cookbookStore.get(key);
+  const next: CookbookBlock = {
+    ...block,
+    createdAt: existing?.createdAt ?? block.createdAt,
+    updatedAt: new Date().toISOString(),
+  };
+  cookbookStore.set(key, next);
+  return next;
+}
+
+export function getCookbookByToolName(toolName: string): CookbookBlock | null {
+  return cookbookStore.get(normalizeToolName(toolName)) ?? null;
+}
+
+export function suggestCookbookForError(toolName: string): string | null {
+  const cookbook = getCookbookByToolName(toolName);
+  if (!cookbook) return null;
+  return `Tip: gebruik cookbook_get met toolName=\"${cookbook.toolName}\" voor stapsgewijze troubleshooting.`;
+}
+
+export function generateCookbooksFromTools(tools: McpToolDefinition[]): CookbookBlock[] {
+  return tools.map((tool) => upsertCookbook(createCookbookBlock(tool)));
+}
+
+export function resetCookbookStore(): void {
+  cookbookStore.clear();
+}

--- a/tests/cookbooks.test.ts
+++ b/tests/cookbooks.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  createCookbookBlock,
+  createCookbookMarkdown,
+  generateCookbooksFromTools,
+  getCookbookByToolName,
+  resetCookbookStore,
+  suggestCookbookForError,
+} from "@/src/services/cookbooks";
+import { allTools } from "@/src/mcp/tools";
+
+describe("cookbooks service", () => {
+  beforeEach(() => {
+    resetCookbookStore();
+  });
+
+  it("generates markdown skeleton with required frontmatter fields", () => {
+    const tool = allTools[0];
+    const markdown = createCookbookMarkdown(tool);
+
+    expect(markdown).toContain("tool_name:");
+    expect(markdown).toContain("prerequisites:");
+    expect(markdown).toContain("failure_modes:");
+    expect(markdown).toContain(`# Cookbook: ${tool.name}`);
+  });
+
+  it("creates cookbook blocks tagged by tool name", () => {
+    const tool = allTools[0];
+    const block = createCookbookBlock(tool);
+
+    expect(block.type).toBe("cookbook");
+    expect(block.tags).toContain(tool.name);
+    expect(block.toolName).toBe(tool.name);
+  });
+
+  it("stores and retrieves cookbook blocks by tool name", () => {
+    const generated = generateCookbooksFromTools(allTools.slice(0, 3));
+    expect(generated).toHaveLength(3);
+
+    const result = getCookbookByToolName(generated[1].toolName);
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("cookbook");
+  });
+
+  it("returns a cookbook suggestion for known tools", () => {
+    generateCookbooksFromTools(allTools.slice(0, 1));
+    const known = allTools[0].name;
+
+    expect(suggestCookbookForError(known)).toContain('cookbook_get met toolName');
+    expect(suggestCookbookForError("unknown_tool")).toBeNull();
+  });
+});

--- a/tests/mcp-server-setup.test.ts
+++ b/tests/mcp-server-setup.test.ts
@@ -49,6 +49,30 @@ describe("createMotianMCPServer", () => {
     expect(registeredNames.length).toBeGreaterThan(0);
   });
 
+
+  it("includes cookbook_get in tool list", async () => {
+    const server = createMotianMCPServer();
+
+    const listResult = await invokeHandler(server, "tools/list", {
+      method: "tools/list",
+    });
+
+    const registeredNames = listResult.tools.map((t: { name: string }) => t.name);
+    expect(registeredNames).toContain("cookbook_get");
+  });
+
+  it("appends cookbook hint when a tool call fails", async () => {
+    const server = createMotianMCPServer();
+
+    const result = await invokeHandler(server, "tools/call", {
+      method: "tools/call",
+      params: { name: "kandidaat_detail", arguments: { id: "not-a-uuid" } },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Tip: gebruik cookbook_get");
+  });
+
   it("returns error for unknown tool name", async () => {
     const server = createMotianMCPServer();
 


### PR DESCRIPTION
### Motivation
- Provide first-class procedural documentation for MCP tools so operators and agents can access troubleshooting steps when tool calls fail.
- Make cookbooks discoverable by tool name and surface actionable hints from the MCP server when handlers error.

### Description
- Add a cookbook service (`src/services/cookbooks.ts`) that defines a `cookbook` block shape, generates a markdown skeleton with frontmatter (`tool_name`, `prerequisites`, `failure_modes`), stores/upserts blocks in memory, and exposes retrieval/suggestion helpers (`getCookbookByToolName`, `suggestCookbookForError`, `generateCookbooksFromTools`).
- Add an MCP tool `cookbook_get` (`src/mcp/tools/cookbook.ts`) that returns the cookbook block for a provided `toolName` and wire it into the MCP tool registry (`src/mcp/tools/index.ts`).
- Auto-generate cookbooks from `allTools` when the MCP server registers handlers and append a cookbook hint to MCP error responses when a matching cookbook exists (`src/mcp/create-server.ts`).
- Add a CLI command `orbit:cookbook:generate` to emit cookbook packs from `allTools` (`src/cli/commands.ts`).
- Add unit/regression tests: `tests/cookbooks.test.ts` for cookbook generation, tagging, storage and suggestion text, and extend `tests/mcp-server-setup.test.ts` to assert `cookbook_get` is listed and that failing tool calls include the cookbook hint.

### Testing
- Ran `pnpm lint` which failed in this environment because the `biome` binary is not available, so lint checks were not completed.
- Attempted `pnpm install --frozen-lockfile` but the install failed in this environment due to a network error during an `onnxruntime-node` postinstall (`ENETUNREACH`), preventing dev dependencies from being available.
- Attempted `pnpm exec biome check ...` and `pnpm test -- tests/cookbooks.test.ts tests/mcp-server-setup.test.ts`, but these failed because `biome` and `vitest` are not present in the execution environment; the new tests were added but could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da0a6a98bc8330be96574aab40a19c)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `orbit:cookbook:generate` CLI command to generate tool documentation
* Added `cookbook_get` tool to retrieve guidance information for specific tools
* Enhanced error messages to include contextual troubleshooting hints

## Tests
* Added test coverage for cookbook generation, retrieval, and error hint functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->