### PR TITLE
feat(repo-learning): add incremental repo-to-facts extractor (repo_learn)

### DIFF
--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -62,6 +62,7 @@ import {
   reviewGdprRetention,
   runCandidateScoringBatch,
 } from "../services/operations-console";
+import { runRepoLearning } from "../services/repo-learning";
 import { getHistory } from "../services/scrape-results";
 import {
   activatePlatform,
@@ -767,6 +768,20 @@ export const commands: Record<string, Command> = {
         count: records.length,
         xml: buildSalesforceFeedXml(records),
       };
+    },
+  },
+
+  // ── Repo Learning ─────────────────────────────────────────────────────
+
+  "repo:learn": {
+    description: "Extraheer repository-kennis naar gestructureerde facts",
+    usage: "[--repo-root <pad>] [--state-path <pad>] [--facts-path <pad>]",
+    handler: async (args) => {
+      return runRepoLearning({
+        repoRoot: optionalString(args, "repo-root"),
+        statePath: optionalString(args, "state-path"),
+        factsPath: optionalString(args, "facts-path"),
+      });
     },
   },
 

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -17,6 +17,7 @@ import { handlers as kandidatenHandlers, tools as kandidatenTools } from "./kand
 import { handlers as matchHandlers, tools as matchTools } from "./matches";
 import { handlers as pipelineHandlers, tools as pipelineTools } from "./pipeline";
 import { handlers as platformsHandlers, tools as platformsTools } from "./platforms";
+import { handlers as repoLearningHandlers, tools as repoLearningTools } from "./repo-learning";
 import {
   handlers as salesforceFeedHandlers,
   tools as salesforceFeedTools,
@@ -46,6 +47,7 @@ export const allTools = [
   ...batchOperationsTools,
   ...cvOpsTools,
   ...channelOfferTools,
+  ...repoLearningTools,
 ];
 
 export const allHandlers: Record<string, (args: unknown) => Promise<unknown>> = {
@@ -66,4 +68,5 @@ export const allHandlers: Record<string, (args: unknown) => Promise<unknown>> = 
   ...batchOperationsHandlers,
   ...cvOpsHandlers,
   ...channelOfferHandlers,
+  ...repoLearningHandlers,
 };

--- a/src/mcp/tools/repo-learning.ts
+++ b/src/mcp/tools/repo-learning.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+import { runRepoLearning } from "../../services/repo-learning";
+
+const repoLearnSchema = z.object({
+  repoRoot: z.string().optional(),
+  statePath: z.string().optional(),
+  factsPath: z.string().optional(),
+});
+
+export const tools = [
+  {
+    name: "repo_learn",
+    description:
+      "Extraheert kennis uit de repository (tests, AGENTS/CLAUDE, Cargo.toml, hooks) en slaat facts op.",
+    inputSchema: zodToJsonSchema(repoLearnSchema, { $refStrategy: "none" }),
+  },
+];
+
+export const handlers: Record<string, (args: unknown) => Promise<unknown>> = {
+  repo_learn: async (args) => {
+    const input = repoLearnSchema.parse(args ?? {});
+    return runRepoLearning(input);
+  },
+};

--- a/src/services/repo-learning.ts
+++ b/src/services/repo-learning.ts
@@ -1,0 +1,294 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+export type RepoLearningTaxonomy =
+  | "test-recipe"
+  | "convention"
+  | "dependency-constraint"
+  | "procedure";
+
+export type RepoLearningFact = {
+  id: string;
+  taxonomy: RepoLearningTaxonomy;
+  source: "repo-extractor";
+  module: string;
+  title: string;
+  fact: string;
+  sourcePath: string;
+  extractedAt: string;
+};
+
+type RepoLearningState = {
+  lastExtractedSha: string;
+  extractedAt: string;
+};
+
+export type RepoLearningResult = {
+  baseSha: string | null;
+  headSha: string;
+  processedFiles: string[];
+  factCount: number;
+  outputPath: string;
+  statePath: string;
+};
+
+const DEFAULT_STATE_PATH = ".cache/repo-learning/state.json";
+const DEFAULT_FACTS_PATH = ".cache/repo-learning/facts.json";
+
+export function extractFactsFromContent(
+  path: string,
+  content: string,
+  extractedAt: string,
+): RepoLearningFact[] {
+  if (path.endsWith(".test.ts") || path.includes("/tests/") || path.startsWith("tests/")) {
+    return extractTestFacts(path, content, extractedAt);
+  }
+
+  if (path.endsWith("AGENTS.md") || path.endsWith("CLAUDE.md")) {
+    return extractConventionFacts(path, content, extractedAt);
+  }
+
+  if (path.endsWith("Cargo.toml")) {
+    return extractDependencyFacts(path, content, extractedAt);
+  }
+
+  if (isHookScript(path)) {
+    return extractProcedureFacts(path, content, extractedAt);
+  }
+
+  return [];
+}
+
+export function runRepoLearning(options?: {
+  repoRoot?: string;
+  statePath?: string;
+  factsPath?: string;
+}): RepoLearningResult {
+  const repoRoot = resolve(options?.repoRoot ?? process.cwd());
+  const statePath = resolve(repoRoot, options?.statePath ?? DEFAULT_STATE_PATH);
+  const factsPath = resolve(repoRoot, options?.factsPath ?? DEFAULT_FACTS_PATH);
+
+  const headSha = runGit(repoRoot, ["rev-parse", "HEAD"]);
+  const previousState = readState(statePath);
+  const baseSha = previousState?.lastExtractedSha ?? null;
+
+  const candidateFiles = listCandidateFiles(repoRoot, baseSha, headSha);
+  const extractedAt = new Date().toISOString();
+
+  const facts = candidateFiles.flatMap((relativePath) => {
+    const absolutePath = resolve(repoRoot, relativePath);
+    let content = "";
+    try {
+      content = readFileSync(absolutePath, "utf-8");
+    } catch {
+      return [];
+    }
+    return extractFactsFromContent(relativePath, content, extractedAt);
+  });
+
+  writeJsonFile(factsPath, facts);
+  writeJsonFile(statePath, { lastExtractedSha: headSha, extractedAt } satisfies RepoLearningState);
+
+  return {
+    baseSha,
+    headSha,
+    processedFiles: candidateFiles,
+    factCount: facts.length,
+    outputPath: factsPath,
+    statePath,
+  };
+}
+
+function extractTestFacts(path: string, content: string, extractedAt: string): RepoLearningFact[] {
+  const describes = Array.from(content.matchAll(/describe\(\s*["'`](.+?)["'`]/g), (m) =>
+    m[1]?.trim(),
+  );
+  const tests = Array.from(content.matchAll(/(?:it|test)\(\s*["'`](.+?)["'`]/g), (m) =>
+    m[1]?.trim(),
+  );
+  const module = inferModuleFromTestPath(path);
+
+  const facts: RepoLearningFact[] = [];
+
+  if (describes.length > 0 || tests.length > 0) {
+    const scenario = [
+      describes.length ? `describe: ${describes.slice(0, 4).join("; ")}` : "",
+      tests.length ? `cases: ${tests.slice(0, 6).join("; ")}` : "",
+    ]
+      .filter(Boolean)
+      .join(" | ");
+
+    facts.push(
+      createFact(
+        path,
+        module,
+        "test-recipe",
+        `How to test ${module}`,
+        scenario || "Structural test patterns",
+        extractedAt,
+      ),
+    );
+  }
+
+  return facts;
+}
+
+function extractConventionFacts(
+  path: string,
+  content: string,
+  extractedAt: string,
+): RepoLearningFact[] {
+  const module = path.replace(/\/AGENTS\.md$|\/CLAUDE\.md$/, "") || "repo";
+  const lines = content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("- ") || /^\d+\./.test(line))
+    .slice(0, 20);
+
+  if (lines.length === 0) return [];
+
+  return [
+    createFact(
+      path,
+      module,
+      "convention",
+      `Project conventions for ${module}`,
+      lines.join(" | "),
+      extractedAt,
+    ),
+  ];
+}
+
+function extractDependencyFacts(
+  path: string,
+  content: string,
+  extractedAt: string,
+): RepoLearningFact[] {
+  const lines = content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#") && line.includes("="));
+
+  const dependencies = lines.filter((line) => /^\w[\w-]*\s*=/.test(line)).slice(0, 30);
+  if (dependencies.length === 0) return [];
+
+  return [
+    createFact(
+      path,
+      "cargo",
+      "dependency-constraint",
+      "Cargo dependency constraints",
+      dependencies.join(" | "),
+      extractedAt,
+    ),
+  ];
+}
+
+function extractProcedureFacts(
+  path: string,
+  content: string,
+  extractedAt: string,
+): RepoLearningFact[] {
+  const topLines = content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .slice(0, 12);
+
+  if (topLines.length === 0) return [];
+
+  return [
+    createFact(
+      path,
+      "hooks",
+      "procedure",
+      `How hook ${path} works`,
+      topLines.join(" | "),
+      extractedAt,
+    ),
+  ];
+}
+
+function createFact(
+  sourcePath: string,
+  module: string,
+  taxonomy: RepoLearningTaxonomy,
+  title: string,
+  fact: string,
+  extractedAt: string,
+): RepoLearningFact {
+  const id = `${taxonomy}:${sourcePath}`;
+  return {
+    id,
+    taxonomy,
+    source: "repo-extractor",
+    module,
+    title,
+    fact,
+    sourcePath,
+    extractedAt,
+  };
+}
+
+function isHookScript(path: string): boolean {
+  const normalized = path.toLowerCase();
+  return (
+    normalized.includes(".husky/") ||
+    normalized.includes("/hooks/") ||
+    normalized.endsWith("pre-commit") ||
+    normalized.endsWith("pre-push")
+  );
+}
+
+function inferModuleFromTestPath(path: string): string {
+  if (path.startsWith("tests/")) {
+    return path.replace(/^tests\//, "").replace(/\.test\.[^.]+$/, "");
+  }
+
+  return path
+    .replace(/^src\//, "")
+    .replace(/^app\//, "")
+    .replace(/\.test\.[^.]+$/, "")
+    .replace(/\.[^.]+$/, "");
+}
+
+function listCandidateFiles(repoRoot: string, baseSha: string | null, headSha: string): string[] {
+  const relevantPattern =
+    /(^|\/)(tests\/.*\.test\.ts|AGENTS\.md|CLAUDE\.md|Cargo\.toml|\.husky\/|hooks\/)/;
+
+  if (baseSha) {
+    const changed = runGit(repoRoot, ["diff", "--name-only", `${baseSha}..${headSha}`])
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .filter((path) => relevantPattern.test(path));
+    return Array.from(new Set(changed));
+  }
+
+  const allTracked = runGit(repoRoot, ["ls-files"])
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((path) => relevantPattern.test(path));
+
+  return Array.from(new Set(allTracked));
+}
+
+function readState(statePath: string): RepoLearningState | null {
+  try {
+    const raw = readFileSync(statePath, "utf-8");
+    return JSON.parse(raw) as RepoLearningState;
+  } catch {
+    return null;
+  }
+}
+
+function writeJsonFile(path: string, data: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+}
+
+function runGit(repoRoot: string, args: string[]): string {
+  return execFileSync("git", args, { cwd: repoRoot, encoding: "utf-8" }).trim();
+}

--- a/tests/repo-learning.test.ts
+++ b/tests/repo-learning.test.ts
@@ -1,0 +1,69 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { extractFactsFromContent, runRepoLearning } from "../src/services/repo-learning";
+
+describe("repo learning extractor", () => {
+  it("extracts test-recipe facts from test source", () => {
+    const facts = extractFactsFromContent(
+      "tests/jobs-search.test.ts",
+      `describe("jobs search", () => { it("filters by platform", () => {}) })`,
+      "2026-04-10T00:00:00.000Z",
+    );
+
+    expect(facts).toHaveLength(1);
+    expect(facts[0]).toMatchObject({
+      taxonomy: "test-recipe",
+      source: "repo-extractor",
+      module: "jobs-search",
+    });
+    expect(facts[0]?.fact).toContain("filters by platform");
+  });
+
+  it("extracts convention facts from AGENTS markdown", () => {
+    const facts = extractFactsFromContent(
+      "src/AGENTS.md",
+      `- Keep service boundaries clean\n- Run pnpm lint`,
+      "2026-04-10T00:00:00.000Z",
+    );
+
+    expect(facts).toHaveLength(1);
+    expect(facts[0]).toMatchObject({ taxonomy: "convention", sourcePath: "src/AGENTS.md" });
+  });
+});
+
+describe("runRepoLearning", () => {
+  let repoRoot = "";
+
+  beforeEach(() => {
+    repoRoot = mkdtempSync(join(tmpdir(), "repo-learning-"));
+    execFileSync("git", ["init"], { cwd: repoRoot });
+    execFileSync("git", ["config", "user.email", "repo-learning@example.com"], { cwd: repoRoot });
+    execFileSync("git", ["config", "user.name", "Repo Learning"], { cwd: repoRoot });
+
+    mkdirSync(join(repoRoot, "tests"), { recursive: true });
+    writeFileSync(
+      join(repoRoot, "tests", "sample.test.ts"),
+      `describe("sample", () => { it("works", () => {}) });\n`,
+      "utf-8",
+    );
+
+    writeFileSync(join(repoRoot, "AGENTS.md"), "- Keep changes minimal\n", "utf-8");
+    execFileSync("git", ["add", "."], { cwd: repoRoot });
+    execFileSync("git", ["commit", "-m", "chore: seed repo"], { cwd: repoRoot });
+  });
+
+  it("writes extracted facts and state for the current SHA", () => {
+    const result = runRepoLearning({ repoRoot });
+
+    expect(result.headSha).toMatch(/[a-f0-9]{40}/);
+    expect(result.factCount).toBeGreaterThan(0);
+
+    const facts = JSON.parse(readFileSync(result.outputPath, "utf-8")) as Array<{ source: string }>;
+    expect(facts.length).toBeGreaterThan(0);
+    expect(facts.every((fact) => fact.source === "repo-extractor")).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide an on-demand, incremental "repo-to-memory" extractor to mine repository knowledge into structured facts for downstream learning and automation. 
- Avoid full rescans by tracking the last-processed git SHA and only processing changed candidate files. 
- Surface the extractor across operator surfaces (CLI and MCP) so automation and agents can trigger extraction reliably. 

### Description
- Add a new service `runRepoLearning` in `src/services/repo-learning.ts` that extracts facts from tests, `AGENTS.md`/`CLAUDE.md`, `Cargo.toml`, and hook scripts and emits typed `RepoLearningFact` objects with taxonomy values `test-recipe`, `convention`, `dependency-constraint`, and `procedure` and `source: "repo-extractor"`.
- Persist artifacts to repo-local cache files by default at `.cache/repo-learning/facts.json` and store incremental state at `.cache/repo-learning/state.json` (last processed git SHA).
- Expose the extractor via CLI as `repo:learn` (`src/cli/commands.ts`) and as an MCP tool `repo_learn` (`src/mcp/tools/repo-learning.ts`) and register the tool in `src/mcp/tools/index.ts`.
- Add regression tests in `tests/repo-learning.test.ts` covering fact extraction utilities and an end-to-end run against a temporary git repo.

### Testing
- Ran `pnpm test -- tests/repo-learning.test.ts` and the test suite passed (3 tests across the file). 
- Ran `pnpm lint` (Biome) and the workspace passed after formatting fixes were applied. 
- The new tests verify extraction of `test-recipe` and `convention` facts and that `runRepoLearning` writes facts/state and returns a valid `headSha`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d985677d2483308d3505a9895dfce2)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `repo:learn` CLI command to extract and catalog repository facts, including test recipes, conventions, dependency constraints, and procedures
  * Facts are cached and tracked across runs to monitor repository structure and patterns
  * Supports optional configuration for custom repository root, state, and output paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->