### PR TITLE
fix(tests): stabilize candidate auto-match db mock

### DIFF
--- a/tests/candidate-auto-match-event.test.ts
+++ b/tests/candidate-auto-match-event.test.ts
@@ -30,23 +30,20 @@ const { mockDb, mockEmitAgentEvent, mockQueueDeferredEmbeddingSync } = vi.hoiste
   };
 });
 
-vi.mock("../src/db", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../src/db")>();
-  return {
-    db: {
-      insert: mockDb.insert,
-      update: mockDb.update,
-      select: mockDb.select,
-    },
-    eq: vi.fn((...args: unknown[]) => ({ type: "eq", args })),
-    and: vi.fn((...args: unknown[]) => ({ type: "and", args })),
-    desc: vi.fn((col: unknown) => ({ type: "desc", col })),
-    isNull: vi.fn((col: unknown) => ({ type: "isNull", col })),
-    inArray: vi.fn((...args: unknown[]) => ({ type: "inArray", args })),
-    sql: vi.fn(),
-    getTableColumns: actual.getTableColumns,
-  };
-});
+vi.mock("../src/db", () => ({
+  db: {
+    insert: mockDb.insert,
+    update: mockDb.update,
+    select: mockDb.select,
+  },
+  eq: vi.fn((...args: unknown[]) => ({ type: "eq", args })),
+  and: vi.fn((...args: unknown[]) => ({ type: "and", args })),
+  desc: vi.fn((col: unknown) => ({ type: "desc", col })),
+  isNull: vi.fn((col: unknown) => ({ type: "isNull", col })),
+  inArray: vi.fn((...args: unknown[]) => ({ type: "inArray", args })),
+  sql: vi.fn(() => "sql"),
+  getTableColumns: vi.fn((table: Record<string, unknown>) => table),
+}));
 
 vi.mock("../src/db/schema", () => ({
   candidates: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- inspected the latest failed `CI` runs and extracted failing `Test` job logs
- identified deterministic regressions (`tests/vaardigheden-page.test.ts`) versus a likely flaky failure pattern in `tests/candidate-auto-match-event.test.ts`
- replaced the async partial `../src/db` mock in `tests/candidate-auto-match-event.test.ts` with deterministic synchronous stubs for `sql` and `getTableColumns`

## Why this change
Recent failed runs showed occasional `No "getTableColumns" export is defined on the "../src/db" mock` errors in `tests/candidate-auto-match-event.test.ts`, indicating brittle mock evaluation/order behavior. This patch keeps the mock shape stable and removes the async import path that can intermittently produce missing exports.

## Validation
- `pnpm vitest run tests/candidate-auto-match-event.test.ts`
- repeated the same test file 20 times in a loop (all green)
- `pnpm lint tests/candidate-auto-match-event.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e70d62b1-1c19-4740-802a-68e08aa476a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e70d62b1-1c19-4740-802a-68e08aa476a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test mock implementation to use inline stubs instead of async factory pattern for improved test isolation and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->