### PR TITLE
fix(mobile): resolve UI alignment issues on chat and vacatures pages

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -2,7 +2,7 @@ import { ChatPageContent } from "@/components/chat/chat-page-content";
 
 export default function ChatPage() {
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+    <div className="flex h-[var(--mobile-content-height)] min-h-0 flex-col overflow-hidden md:h-auto md:flex-1">
       <ChatPageContent />
     </div>
   );

--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -508,10 +508,7 @@ export function ChatMessages({
           isWidget
             ? "max-w-3xl px-3 py-4 pb-28 sm:px-4 sm:pb-32"
             : "max-w-4xl px-3 py-4 pb-32 sm:px-4 sm:py-6 sm:pb-40",
-          !hasUserMessage &&
-            (isWidget
-              ? "flex min-h-full flex-col justify-center"
-              : "flex min-h-[calc(100vh-160px)] flex-col justify-center"),
+          !hasUserMessage && "flex min-h-full flex-col justify-center",
         )}
       >
         {hasOlderMessages || loadingOlder ? (
@@ -631,7 +628,7 @@ export function ChatMessages({
               <div
                 className={cn(
                   "grid gap-3",
-                  isWidget ? "grid-cols-2" : "sm:grid-cols-2 xl:grid-cols-4",
+                  isWidget ? "grid-cols-2" : "grid-cols-2 xl:grid-cols-4",
                 )}
               >
                 {emptyStatePrompts.map((suggestion) => (

--- a/components/opdrachten-sidebar.tsx
+++ b/components/opdrachten-sidebar.tsx
@@ -174,7 +174,7 @@ export function OpdrachtenSidebar({
 
   return (
     <aside className="h-full min-w-0 w-full bg-sidebar/25">
-      <div className="grid h-full min-h-0 overflow-hidden lg:grid-cols-[300px_minmax(0,1fr)]">
+      <div className="flex h-full min-h-0 flex-col overflow-hidden lg:grid lg:grid-cols-[300px_minmax(0,1fr)]">
         <OverviewFilterPanel
           inputValue={inputValue}
           onInputChange={setInputValue}
@@ -217,7 +217,7 @@ export function OpdrachtenSidebar({
           onOnlyShortlistChange={handleOnlyShortlistChange}
         />
 
-        <div className="flex h-full min-h-0 min-w-0 flex-col px-3 py-2 sm:px-4 sm:py-4 md:px-5 md:py-5 lg:px-6 overflow-hidden">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col px-3 py-2 sm:px-4 sm:py-4 md:px-5 md:py-5 lg:px-6 overflow-hidden">
           <div className="mb-2 flex flex-col gap-2 border-b border-border/70 pb-2 sm:mb-4 sm:gap-3 sm:pb-4">
             <SidebarResultsHeader
               displayTotal={displayTotal}

--- a/components/sidebar/overview-filter-panel.tsx
+++ b/components/sidebar/overview-filter-panel.tsx
@@ -127,7 +127,7 @@ export function OverviewFilterPanel({
         </button>
       </div>
 
-      <div className="flex min-h-0 flex-1 flex-col gap-2 sm:gap-4">
+      <div className="flex min-h-0 flex-col gap-2 sm:gap-4 lg:flex-1">
         <SidebarSearchBar
           value={inputValue}
           onChange={onInputChange}
@@ -169,8 +169,8 @@ export function OverviewFilterPanel({
         <div
           id="opdrachten-mobile-filters"
           className={cn(
-            "min-h-0 flex-1 space-y-2 overflow-y-auto rounded-xl border border-border/70 bg-background/60 p-2.5 sm:space-y-3 sm:p-3 lg:rounded-none lg:border-0 lg:bg-transparent lg:p-0 lg:space-y-4",
-            !mobileFiltersOpen && "hidden lg:block",
+            "min-h-0 space-y-2 overflow-y-auto rounded-xl border border-border/70 bg-background/60 p-2.5 sm:space-y-3 sm:p-3 lg:flex-1 lg:rounded-none lg:border-0 lg:bg-transparent lg:p-0 lg:space-y-4",
+            mobileFiltersOpen ? "max-h-[40vh] lg:max-h-none" : "hidden lg:block",
           )}
         >
           <VacatureFilterExtras

--- a/src/components/ai-elements/chat-prompt-composer.tsx
+++ b/src/components/ai-elements/chat-prompt-composer.tsx
@@ -89,7 +89,7 @@ export function ChatPromptComposer({
   );
 
   return (
-    <div className="shrink-0 border-t border-border/70 bg-background/95 pb-[env(safe-area-inset-bottom)] backdrop-blur">
+    <div className="shrink-0 border-t border-border/70 bg-background/95 backdrop-blur">
       <div className="mx-auto flex w-full max-w-4xl flex-col gap-3 px-3 py-3 sm:px-4 sm:py-4">
         {composerContextHint ? (
           <div

--- a/tests/mobile-shell-scroll-contract.test.ts
+++ b/tests/mobile-shell-scroll-contract.test.ts
@@ -51,4 +51,16 @@ describe("mobile shell scroll contract", () => {
     expect(layoutShell).toContain("var(--mobile-content-height)");
     expect(layoutShell).toContain("md:h-full");
   });
+
+  it("gives the chat page a definite mobile height via the content-height token so StickToBottom resolves", () => {
+    const chatPage = readFile("app", "chat", "page.tsx");
+    const chatMessages = readFile("components", "chat", "chat-messages.tsx");
+
+    // Chat page must use the mobile content-height token
+    expect(chatPage).toContain("var(--mobile-content-height)");
+    expect(chatPage).toContain("md:h-auto");
+
+    // Chat messages must not use raw 100vh (breaks on mobile with chrome)
+    expect(chatMessages).not.toContain("100vh");
+  });
 });


### PR DESCRIPTION
## Summary

- **Chat page**: Give the chat container a definite height on mobile (`--mobile-content-height`) so StickToBottom can resolve its scroll bounds — content was overflowing past the bottom nav
- **Chat empty state**: Replace `100vh`-based min-height with `min-h-full`, use 2-column grid for suggestion cards on mobile (8 cards in 1 column was ~1000px tall)
- **Chat composer**: Remove redundant `pb-[env(safe-area-inset-bottom)]` already handled by SidebarLayout
- **Vacatures page**: Switch the overview sidebar from CSS Grid to flex-col on mobile so the filter panel and job list properly share the fixed viewport height instead of overlapping
- **Vacatures filters**: Cap expanded mobile filters at `max-h-[40vh]` so the job list always gets adequate space; remove `flex-1` from filter panel on mobile so it takes natural height

## Test plan

- [x] All existing `mobile-shell-scroll-contract` tests pass (5/5)
- [x] New test assertion added: chat page uses `--mobile-content-height` and no raw `100vh` in chat messages
- [x] Biome lint passes with no new errors
- [x] TypeScript type check passes
- [ ] Manual: verify chat page on mobile viewport (375px) — empty state centered, suggestion cards in 2 columns, composer visible above bottom nav
- [ ] Manual: verify vacatures page on mobile — filters collapsible, job list visible with multiple cards, no overlap between filter panel and results header

https://claude.ai/code/session_01Kvex4PB3oN8Ztumca1CMKW
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile chat height and scroll behavior
  * Fixed chat empty-state and message grid responsiveness
  * Improved sidebar layout expansion across breakpoints
  * Adjusted filter panel visibility and responsive behavior

* **Style**
  * Refined layout and spacing for better mobile/desktop consistency

* **Tests**
  * Added a contract test to verify mobile chat height/scroll behavior and prevent viewport-height regressions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->