### PR TITLE
fix: label mobile search button in SidebarLayout (RJC-163)

### DIFF
--- a/components/sidebar-layout.tsx
+++ b/components/sidebar-layout.tsx
@@ -24,6 +24,7 @@ export function SidebarLayout({ children }: { children: React.ReactNode }) {
               type="button"
               onClick={() => document.dispatchEvent(new CustomEvent("motian-command-palette-open"))}
               className="flex size-11 items-center justify-center rounded-2xl border border-border bg-background/95 shadow-sm text-muted-foreground transition-colors hover:text-foreground"
+              aria-label="Zoeken (⌘K)"
               title="Zoeken (⌘K)"
             >
               <Search className="h-4 w-4" />

--- a/tests/sidebar-shell-top-bar.test.ts
+++ b/tests/sidebar-shell-top-bar.test.ts
@@ -24,8 +24,9 @@ describe("sidebar shell top-bar refactor", () => {
   it("gives the mobile search icon button an explicit accessible name", () => {
     const source = readFile("components", "sidebar-layout.tsx");
 
-    expect(source).toContain('aria-label="Zoeken (⌘K)"');
-    expect(source).toContain('title="Zoeken (⌘K)"');
+    expect(source).toMatch(
+      /<button[\s\S]*aria-label="Zoeken \(⌘K\)"[\s\S]*title="Zoeken \(⌘K\)"[\s\S]*>/,
+    );
   });
 
   it("moves theme controls into the user menu", () => {

--- a/tests/sidebar-shell-top-bar.test.ts
+++ b/tests/sidebar-shell-top-bar.test.ts
@@ -21,6 +21,13 @@ describe("sidebar shell top-bar refactor", () => {
     expect(source).toContain("var(--mobile-top-bar-height)");
   });
 
+  it("gives the mobile search icon button an explicit accessible name", () => {
+    const source = readFile("components", "sidebar-layout.tsx");
+
+    expect(source).toContain('aria-label="Zoeken (⌘K)"');
+    expect(source).toContain('title="Zoeken (⌘K)"');
+  });
+
   it("moves theme controls into the user menu", () => {
     const source = readFile("components", "nav-user.tsx");
 


### PR DESCRIPTION
## Summary
- add `aria-label="Zoeken (⌘K)"` to the icon-only mobile search button in `SidebarLayout`
- keep the existing `title` text unchanged for tooltip parity
- add a structural regression assertion covering the mobile search accessible-name contract

## Validation
- `pnpm exec vitest run tests/sidebar-shell-top-bar.test.ts`
- `pnpm lint`
- Playwright mobile aria snapshot + focus check against local dev server after a clean `.next` rebuild

## Risk
- low; single attribute addition plus a source-level regression check

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced search button with improved accessibility labels for screen reader users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->