### PR TITLE
RJC-159 perf: cap Trigger.dev embeddings-batch queue concurrency

### DIFF
--- a/tests/embeddings-batch.test.ts
+++ b/tests/embeddings-batch.test.ts
@@ -18,6 +18,14 @@ describe("embeddings batch backfill", () => {
     expect(source).toContain("getVisibleVacancyCondition()");
   });
 
+  it("caps concurrent task instances while preserving the per-run worker pool", () => {
+    const source = readFile("trigger/embeddings-batch.ts");
+
+    expect(source).toContain("queue: {");
+    expect(source).toContain("concurrencyLimit: 2");
+    expect(source).toContain("const EMBEDDING_CONCURRENCY = 5");
+  });
+
   it("serializes job embeddings before updating the database", () => {
     const source = readFile("src/services/embedding.ts");
 

--- a/trigger/embeddings-batch.ts
+++ b/trigger/embeddings-batch.ts
@@ -15,6 +15,10 @@ export const embeddingsBatchTask = schedules.task({
     pattern: "15 6,10,14,18 * * *", // After each scrape window
     timezone: "Europe/Amsterdam",
   },
+  queue: {
+    // Bound concurrent task instances; the run body still fans out 5 workers per batch.
+    concurrencyLimit: 2,
+  },
   maxDuration: 600,
   machine: { preset: "small-1x" },
   retry: {


### PR DESCRIPTION
## Summary
- add a Trigger.dev task queue cap to `embeddings-batch` so overlapping backfill runs are bounded at the task-instance level
- keep the existing in-task `EMBEDDING_CONCURRENCY = 5` worker pool unchanged
- extend the existing `embeddings-batch` structural test to lock the queue cap in place

## Validation
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm exec vitest run tests/embeddings-batch.test.ts tests/deferred-embedding-pipeline.test.ts`

## Runtime validation status
- `trigger dev` starts successfully with the authenticated local Trigger CLI profile
- manual multi-run queue proof is still blocked because the pulled project env does not include `TRIGGER_SECRET_KEY`, so `@trigger.dev/sdk` cannot enqueue a local `embeddings-batch` run from code

## Follow-up
- `RJC-164` tracks broader shared-queue coordination for other embedding-producing Trigger paths (`defer-embedding-sync`, post-enrichment embedding work)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
