### PR TITLE
perf: parallelize extractRequirements across deep-match pairs in auto-matching

### DIFF
--- a/src/services/auto-matching.ts
+++ b/src/services/auto-matching.ts
@@ -57,20 +57,31 @@ export type AutoMatchResult = {
   matchSaveError: boolean;
 };
 
+type ExtractedRequirements = Awaited<ReturnType<typeof extractRequirements>>;
+
 // ========== Helpers ==========
 
-/** Run deep structured match for a candidate against a job. Returns null on failure. */
-async function deepMatch(job: Job, candidate: Candidate): Promise<StructuredMatchOutput | null> {
-  if (!job.description || job.description.length < 50) return null;
-  if (!candidate.resumeRaw) return null;
-
-  const requirements = await extractRequirements({
+function buildRequirementExtractionInput(job: Job) {
+  return {
     title: job.title,
     description: job.description,
     requirements: job.requirements as unknown[],
     wishes: job.wishes as unknown[],
     competences: job.competences as unknown[],
-  });
+  };
+}
+
+/** Run deep structured match for a candidate against a job. Returns null on failure. */
+async function deepMatch(
+  job: Job,
+  candidate: Candidate,
+  requirementsPromise?: Promise<ExtractedRequirements>,
+): Promise<StructuredMatchOutput | null> {
+  if (!job.description || job.description.length < 50) return null;
+  if (!candidate.resumeRaw) return null;
+
+  const requirements = await (requirementsPromise ??
+    extractRequirements(buildRequirementExtractionInput(job)));
 
   if (requirements.length === 0) return null;
 
@@ -134,11 +145,19 @@ async function runAutoMatchPipeline(
 
   if (top.length === 0) return [];
 
+  const requirementsByJobId = new Map<string, Promise<ExtractedRequirements>>();
+  for (const { job, candidate } of top) {
+    if (requirementsByJobId.has(job.id)) continue;
+    if (!job.description || job.description.length < 50) continue;
+    if (!candidate.resumeRaw) continue;
+    requirementsByJobId.set(job.id, extractRequirements(buildRequirementExtractionInput(job)));
+  }
+
   return Promise.all(
     top.map(async ({ job: j, candidate: c, score, reasoning, model }): Promise<AutoMatchResult> => {
       let structuredResult: StructuredMatchOutput | null = null;
       try {
-        structuredResult = await deepMatch(j, c);
+        structuredResult = await deepMatch(j, c, requirementsByJobId.get(j.id));
       } catch (err) {
         console.error(`[Auto-Match] Deep match failed for job ${j.id} / candidate ${c.id}:`, err);
       }

--- a/tests/auto-matching.test.ts
+++ b/tests/auto-matching.test.ts
@@ -3,23 +3,29 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const {
   mockEmbedCandidate,
   mockCreateMatch,
+  mockExtractRequirements,
   mockFindSimilarCandidatesByEmbedding,
   mockGetCandidateById,
   mockGetCandidatesByIds,
   mockGetMatchByJobAndCandidate,
   mockGetJobById,
+  mockJudgeMatch,
   mockListActiveCandidates,
   mockListActiveJobs,
+  mockRunStructuredMatch,
 } = vi.hoisted(() => ({
   mockEmbedCandidate: vi.fn(),
   mockCreateMatch: vi.fn(),
+  mockExtractRequirements: vi.fn(),
   mockFindSimilarCandidatesByEmbedding: vi.fn(),
   mockGetCandidateById: vi.fn(),
   mockGetCandidatesByIds: vi.fn(),
   mockGetMatchByJobAndCandidate: vi.fn(),
   mockGetJobById: vi.fn(),
+  mockJudgeMatch: vi.fn(),
   mockListActiveCandidates: vi.fn(),
   mockListActiveJobs: vi.fn(),
+  mockRunStructuredMatch: vi.fn(),
 }));
 
 vi.mock("../src/lib/notify-slack", () => ({ notifySlack: vi.fn() }));
@@ -47,19 +53,15 @@ vi.mock("../src/services/jobs", () => ({
   getJobById: mockGetJobById,
   listActiveJobs: mockListActiveJobs,
 }));
-vi.mock("../src/services/match-judge", () => ({ judgeMatch: vi.fn() }));
+vi.mock("../src/services/match-judge", () => ({ judgeMatch: mockJudgeMatch }));
 vi.mock("../src/services/matches", () => ({
   createMatch: mockCreateMatch,
   getMatchByJobAndCandidate: mockGetMatchByJobAndCandidate,
 }));
 vi.mock("../src/services/requirement-extraction", () => ({
-  extractRequirements: vi.fn(),
+  extractRequirements: mockExtractRequirements,
 }));
 vi.mock("../src/services/scoring", () => ({ computeMatchScore: vi.fn() }));
-vi.mock("../src/services/settings", () => ({
-  getAllSettings: vi.fn().mockResolvedValue({}),
-}));
-vi.mock("../src/services/structured-matching", () => ({ runStructuredMatch: vi.fn() }));
 vi.mock("../src/services/settings", () => ({
   getAllSettings: vi.fn().mockResolvedValue({
     autoMatchTopN: 3,
@@ -67,11 +69,70 @@ vi.mock("../src/services/settings", () => ({
     searchVectorMinScore: 0.3,
   }),
 }));
+vi.mock("../src/services/structured-matching", () => ({
+  runStructuredMatch: mockRunStructuredMatch,
+}));
 
 import {
   autoMatchCandidateToJobs,
   autoMatchJobToCandidates,
 } from "../src/services/auto-matching.js";
+
+const mockRequirements = [
+  {
+    criterion: "5 jaar Java ervaring",
+    tier: "knockout" as const,
+    weight: null,
+    source: "vacaturetekst",
+  },
+  {
+    criterion: "Ervaring met microservices",
+    tier: "gunning" as const,
+    weight: 30,
+    source: "functieprofiel",
+  },
+];
+
+const mockStructuredMatchOutput = {
+  criteriaBreakdown: [
+    {
+      criterion: "5 jaar Java ervaring",
+      tier: "knockout",
+      passed: true,
+      stars: null,
+      evidence: "ruime ervaring met Java",
+      confidence: "high",
+    },
+  ],
+  overallScore: 78,
+  knockoutsPassed: true,
+  riskProfile: [],
+  enrichmentSuggestions: ["AWS certificering behalen"],
+  recommendation: "go" as const,
+  recommendationReasoning:
+    "Kandidaat voldoet aan alle knock-out criteria en scoort goed op gunningscriteria.",
+  recommendationConfidence: 85,
+};
+
+function createLongResume(label: string) {
+  return `${label} heeft ruime ervaring met Java, microservices en enterprise delivery. `.repeat(2);
+}
+
+function createStructuredMatchJob() {
+  return {
+    id: "job-1",
+    title: "Senior Java Developer",
+    descriptionSummary: null,
+    description:
+      "Wij zoeken een senior Java developer met ruime ervaring in microservices, cloud-native architectuur en samenwerken in enterprise omgevingen. ".repeat(
+        2,
+      ),
+    categories: [],
+    requirements: [],
+    wishes: [],
+    competences: [],
+  };
+}
 
 describe("auto-matching prefilter limits", () => {
   beforeEach(() => {
@@ -85,6 +146,9 @@ describe("auto-matching prefilter limits", () => {
     mockListActiveJobs.mockResolvedValue([]);
     mockGetJobById.mockResolvedValue({ id: "job-1", title: "Test Opdracht" });
     mockListActiveCandidates.mockResolvedValue([]);
+    mockExtractRequirements.mockResolvedValue(mockRequirements);
+    mockRunStructuredMatch.mockResolvedValue(mockStructuredMatchOutput);
+    mockJudgeMatch.mockResolvedValue(null);
   });
 
   it("requests a bounded number of active jobs when candidate auto-match falls back", async () => {
@@ -126,5 +190,100 @@ describe("auto-matching prefilter limits", () => {
 
     expect(mockFindSimilarCandidatesByEmbedding).toHaveBeenCalled();
     expect(mockListActiveCandidates).not.toHaveBeenCalled();
+  });
+
+  it("reuses extracted requirements across semantic top candidates for the same job", async () => {
+    mockGetJobById.mockResolvedValue(createStructuredMatchJob());
+    mockFindSimilarCandidatesByEmbedding.mockResolvedValue([
+      { id: "cand-1", similarity: 0.91 },
+      { id: "cand-2", similarity: 0.87 },
+      { id: "cand-3", similarity: 0.83 },
+    ]);
+    mockGetCandidatesByIds.mockResolvedValue([
+      { id: "cand-1", name: "Alice", resumeRaw: createLongResume("Alice") },
+      { id: "cand-2", name: "Bob", resumeRaw: createLongResume("Bob") },
+      { id: "cand-3", name: "Charlie", resumeRaw: createLongResume("Charlie") },
+    ]);
+
+    const results = await autoMatchJobToCandidates("job-1");
+
+    expect(results).toHaveLength(3);
+    expect(mockExtractRequirements).toHaveBeenCalledTimes(1);
+    expect(mockRunStructuredMatch).toHaveBeenCalledTimes(3);
+    expect(mockRunStructuredMatch).toHaveBeenNthCalledWith(1, {
+      requirements: mockRequirements,
+      candidateName: "Alice",
+      cvText: createLongResume("Alice"),
+    });
+    expect(mockRunStructuredMatch).toHaveBeenNthCalledWith(2, {
+      requirements: mockRequirements,
+      candidateName: "Bob",
+      cvText: createLongResume("Bob"),
+    });
+    expect(mockRunStructuredMatch).toHaveBeenNthCalledWith(3, {
+      requirements: mockRequirements,
+      candidateName: "Charlie",
+      cvText: createLongResume("Charlie"),
+    });
+  });
+
+  it("falls back to quick-score persistence for all pairs when shared requirement extraction fails", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      mockGetJobById.mockResolvedValue(createStructuredMatchJob());
+      mockFindSimilarCandidatesByEmbedding.mockResolvedValue([
+        { id: "cand-1", similarity: 0.91 },
+        { id: "cand-2", similarity: 0.87 },
+        { id: "cand-3", similarity: 0.83 },
+      ]);
+      mockGetCandidatesByIds.mockResolvedValue([
+        { id: "cand-1", name: "Alice", resumeRaw: createLongResume("Alice") },
+        { id: "cand-2", name: "Bob", resumeRaw: createLongResume("Bob") },
+        { id: "cand-3", name: "Charlie", resumeRaw: createLongResume("Charlie") },
+      ]);
+      mockExtractRequirements.mockRejectedValueOnce(new Error("requirement extraction timeout"));
+
+      const results = await autoMatchJobToCandidates("job-1");
+
+      expect(mockExtractRequirements).toHaveBeenCalledTimes(1);
+      expect(mockRunStructuredMatch).not.toHaveBeenCalled();
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            candidateId: "cand-1",
+            quickScore: 91,
+            structuredResult: null,
+            matchSaveError: false,
+          }),
+          expect.objectContaining({
+            candidateId: "cand-2",
+            quickScore: 87,
+            structuredResult: null,
+            matchSaveError: false,
+          }),
+          expect.objectContaining({
+            candidateId: "cand-3",
+            quickScore: 83,
+            structuredResult: null,
+            matchSaveError: false,
+          }),
+        ]),
+      );
+      expect(mockCreateMatch).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ candidateId: "cand-1", matchScore: 91 }),
+      );
+      expect(mockCreateMatch).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ candidateId: "cand-2", matchScore: 87 }),
+      );
+      expect(mockCreateMatch).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({ candidateId: "cand-3", matchScore: 83 }),
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(3);
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- cache one requirement-extraction promise per unique job across the top-N auto-match pairs
- pass shared requirements into structured matching so repeated candidate comparisons do not trigger duplicate LLM extraction calls
- add regressions for shared-job extraction reuse and shared extraction failure fallback behavior

## Validation
- [x] `pnpm exec vitest run tests/auto-matching.test.ts`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm lint`
- [ ] DB-backed spot-run via `vacatures:auto-match` for a job with >=3 candidates
  - Blocked in this workspace: `.env.local` is absent and `DATABASE_URL` is not set, so the real auto-match path cannot connect to Neon for the requested dev validation.

## Risk notes
- Shares extraction work per shortlisted job while keeping the existing per-pair `deepMatch()` catch path intact.
- A rejected extraction promise is still observed by every affected pair, which preserves quick-score fallback instead of aborting the whole shortlist.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/201" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
