### PR TITLE
ui: add loading.tsx for kandidaten and vacatures detail routes (RJC-162)

### DIFF
--- a/app/kandidaten/[id]/loading.tsx
+++ b/app/kandidaten/[id]/loading.tsx
@@ -1,0 +1,166 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function KandidaatDetailLoading() {
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-6xl space-y-6 px-4 py-6 sm:px-6 lg:px-8">
+        <section className="rounded-[28px] border border-border/80 bg-card/95 p-5 shadow-sm sm:p-6">
+          <div className="mb-5 flex flex-wrap items-start justify-between gap-3">
+            <Skeleton className="h-5 w-40 bg-muted" />
+            <Skeleton className="h-9 w-28 rounded-md bg-muted" />
+          </div>
+
+          <div className="grid gap-5 xl:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.8fr)]">
+            <div className="min-w-0 space-y-5">
+              <div className="flex items-start gap-4">
+                <Skeleton className="h-20 w-20 shrink-0 rounded-3xl bg-muted" />
+                <div className="min-w-0 flex-1 space-y-3">
+                  <Skeleton className="h-8 w-full max-w-sm bg-muted" />
+                  <Skeleton className="h-5 w-full max-w-56 bg-muted" />
+                  <Skeleton className="h-4 w-full max-w-xl bg-muted" />
+                  <Skeleton className="h-4 w-full max-w-lg bg-muted" />
+                </div>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+                  <Skeleton key={`badge-${i}`} className="h-6 w-24 rounded-full bg-muted" />
+                ))}
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+                  <Skeleton key={`action-${i}`} className="h-9 w-32 rounded-md bg-muted" />
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <div className="rounded-2xl border border-border/70 bg-background/55 p-4">
+                <div className="flex items-center gap-4">
+                  <Skeleton className="h-16 w-16 rounded-full bg-muted" />
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-4 w-28 bg-muted" />
+                    <Skeleton className="h-6 w-36 bg-muted" />
+                    <Skeleton className="h-4 w-full max-w-xs bg-muted" />
+                  </div>
+                </div>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+                {["hero-primary", "hero-secondary"].map((key) => (
+                  <div
+                    key={key}
+                    className="rounded-2xl border border-border/70 bg-background/55 p-4"
+                  >
+                    <Skeleton className="h-3 w-28 bg-muted" />
+                    <Skeleton className="mt-3 h-5 w-36 bg-muted" />
+                    <Skeleton className="mt-2 h-4 w-full max-w-xs bg-muted" />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-border bg-card p-5">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-2">
+              <Skeleton className="h-5 w-44 bg-muted" />
+              <Skeleton className="h-4 w-full max-w-md bg-muted" />
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Skeleton className="h-9 w-32 rounded-md bg-muted" />
+              <Skeleton className="h-9 w-28 rounded-md bg-muted" />
+            </div>
+          </div>
+
+          <div className="mt-4 grid gap-3 lg:grid-cols-2">
+            {["workflow-primary", "workflow-secondary"].map((key) => (
+              <div key={key} className="rounded-xl border border-border bg-background/60 p-4">
+                <Skeleton className="h-5 w-full max-w-56 bg-muted" />
+                <Skeleton className="mt-2 h-4 w-full max-w-40 bg-muted" />
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <Skeleton className="h-5 w-20 rounded-full bg-muted" />
+                  <Skeleton className="h-5 w-24 rounded-full bg-muted" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <div className="rounded-2xl border border-border bg-card p-5">
+          <div className="grid gap-4 lg:grid-cols-3">
+            <Skeleton className="h-32 rounded-xl bg-muted lg:col-span-2" />
+            <Skeleton className="h-32 rounded-xl bg-muted" />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+          <div className="space-y-6 lg:col-span-2">
+            <section className="rounded-xl border border-border bg-card p-4">
+              <Skeleton className="h-5 w-28 bg-muted" />
+              <Skeleton className="mt-4 h-4 w-full bg-muted" />
+              <Skeleton className="mt-2 h-4 w-full max-w-3xl bg-muted" />
+              <Skeleton className="mt-2 h-4 w-full max-w-2xl bg-muted" />
+            </section>
+
+            <section>
+              <Skeleton className="mb-3 h-5 w-36 bg-muted" />
+              <div className="space-y-3">
+                {["employment-primary", "employment-secondary", "employment-tertiary"].map(
+                  (key) => (
+                    <div key={key} className="rounded-xl border border-border bg-card p-4">
+                      <Skeleton className="h-5 w-full max-w-52 bg-muted" />
+                      <Skeleton className="mt-2 h-4 w-32 bg-muted" />
+                      <Skeleton className="mt-4 h-4 w-full bg-muted" />
+                      <Skeleton className="mt-2 h-4 w-full max-w-2xl bg-muted" />
+                    </div>
+                  ),
+                )}
+              </div>
+            </section>
+
+            <section className="rounded-xl border border-border bg-card p-4">
+              <Skeleton className="h-5 w-32 bg-muted" />
+              <Skeleton className="mt-4 h-24 rounded-xl bg-muted" />
+            </section>
+          </div>
+
+          <div className="space-y-6">
+            <section className="rounded-xl border border-border bg-card p-4">
+              <div className="flex items-center gap-2">
+                <Skeleton className="h-5 w-36 bg-muted" />
+              </div>
+              <Skeleton className="mt-4 h-32 rounded-xl bg-muted" />
+              <div className="mt-4 space-y-3">
+                {["match-primary", "match-secondary"].map((key) => (
+                  <div key={key} className="rounded-xl border border-border bg-background/60 p-4">
+                    <Skeleton className="h-5 w-full max-w-40 bg-muted" />
+                    <Skeleton className="mt-2 h-4 w-full max-w-28 bg-muted" />
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      <Skeleton className="h-5 w-16 rounded-full bg-muted" />
+                      <Skeleton className="h-5 w-20 rounded-full bg-muted" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            <section className="rounded-xl border border-border bg-card p-4">
+              <Skeleton className="h-5 w-32 bg-muted" />
+              <div className="mt-4 grid gap-3">
+                {Array.from({ length: 2 }).map((_, i) => (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+                  <Skeleton key={`score-${i}`} className="h-24 rounded-xl bg-muted" />
+                ))}
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/kandidaten/[id]/page.tsx
+++ b/app/kandidaten/[id]/page.tsx
@@ -67,6 +67,7 @@ import {
   buildCandidateOfferReadiness,
   buildMatchBrief,
 } from "@/src/services/recruiter-insights";
+import KandidaatDetailLoading from "./loading";
 
 export const dynamic = "force-dynamic";
 
@@ -228,28 +229,6 @@ function getLanguageSkills(languageSkills: unknown): Array<{ language: string; l
       };
     })
     .filter((l) => l.language);
-}
-
-function KandidaatDetailSkeleton() {
-  return (
-    <div className="min-h-0 flex-1 overflow-y-auto">
-      <div className="max-w-[1400px] mx-auto px-4 md:px-6 lg:px-8 py-6 space-y-6">
-        <Skeleton className="h-5 w-64" />
-        <div className="flex items-start gap-4">
-          <Skeleton className="h-16 w-16 rounded-full" />
-          <div className="space-y-2 flex-1">
-            <Skeleton className="h-7 w-48" />
-            <Skeleton className="h-4 w-32" />
-          </div>
-        </div>
-        <div className="grid gap-4 lg:grid-cols-3">
-          <Skeleton className="h-64 rounded-xl lg:col-span-2" />
-          <Skeleton className="h-64 rounded-xl" />
-        </div>
-        <Skeleton className="h-48 rounded-xl" />
-      </div>
-    </div>
-  );
 }
 
 async function KandidaatDetailContent({ params }: Props) {
@@ -1189,7 +1168,7 @@ async function KandidaatDetailContent({ params }: Props) {
 
 export default function KandidaatDetailPage(props: Props) {
   return (
-    <Suspense fallback={<KandidaatDetailSkeleton />}>
+    <Suspense fallback={<KandidaatDetailLoading />}>
       <KandidaatDetailContent {...props} />
     </Suspense>
   );

--- a/app/vacatures/[id]/loading.tsx
+++ b/app/vacatures/[id]/loading.tsx
@@ -1,0 +1,119 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function VacatureDetailLoading() {
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+      <div className="border-b border-border bg-background/95 px-4 py-4 sm:px-6">
+        <Skeleton className="mb-4 h-5 w-36 bg-muted" />
+
+        <div className="mb-3 flex flex-wrap items-center gap-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+            <Skeleton key={`tag-${i}`} className="h-6 w-20 rounded-full bg-muted" />
+          ))}
+          <div className="ml-auto flex items-center gap-2">
+            <Skeleton className="h-8 w-8 rounded-md bg-muted" />
+            <Skeleton className="h-8 w-8 rounded-md bg-muted" />
+          </div>
+        </div>
+
+        <div className="flex items-start gap-3">
+          <Skeleton className="h-14 w-14 rounded-xl bg-muted" />
+          <div className="min-w-0 flex-1 space-y-2">
+            <Skeleton className="h-8 w-full max-w-xl bg-muted" />
+            <Skeleton className="h-5 w-full max-w-xs bg-muted" />
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap gap-x-5 gap-y-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+            <Skeleton key={`meta-${i}`} className="h-4 w-28 bg-muted" />
+          ))}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto flex w-full max-w-4xl flex-col gap-5 px-4 py-4 sm:px-6 sm:py-5">
+          <div className="rounded-lg border border-border bg-card p-3">
+            <Skeleton className="h-10 w-full bg-muted" />
+          </div>
+
+          <section className="rounded-lg border border-border bg-card p-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="space-y-2">
+                <Skeleton className="h-5 w-40 bg-muted" />
+                <Skeleton className="h-4 w-full max-w-lg bg-muted" />
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Skeleton className="h-9 w-36 rounded-md bg-muted" />
+                <Skeleton className="h-9 w-28 rounded-md bg-muted" />
+              </div>
+            </div>
+
+            <div className="mt-4 grid gap-2 sm:grid-cols-3">
+              {["cockpit-deadline", "cockpit-shortlist", "cockpit-next-step"].map((key) => (
+                <div key={key} className="rounded-lg border border-border bg-background/60 p-3">
+                  <Skeleton className="h-3 w-20 bg-muted" />
+                  <Skeleton className="mt-3 h-5 w-28 bg-muted" />
+                  <Skeleton className="mt-2 h-4 w-full bg-muted" />
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-border bg-card p-4">
+            <Skeleton className="h-5 w-36 bg-muted" />
+            <div className="mt-4 grid gap-3 lg:grid-cols-3">
+              <Skeleton className="h-24 rounded-xl bg-muted lg:col-span-2" />
+              <Skeleton className="h-24 rounded-xl bg-muted" />
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-border bg-card p-4">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <div className="space-y-2">
+                <Skeleton className="h-5 w-28 bg-muted" />
+                <Skeleton className="h-4 w-full max-w-md bg-muted" />
+              </div>
+              <Skeleton className="h-4 w-24 bg-muted" />
+            </div>
+
+            <div className="mt-4 grid gap-3 xl:grid-cols-2">
+              {["candidate-primary", "candidate-secondary"].map((key) => (
+                <div key={key} className="rounded-lg border border-border bg-background/60 p-3">
+                  <Skeleton className="h-5 w-full max-w-44 bg-muted" />
+                  <Skeleton className="mt-2 h-4 w-full max-w-32 bg-muted" />
+                  <div className="mt-4 flex flex-wrap gap-2">
+                    <Skeleton className="h-5 w-16 rounded-full bg-muted" />
+                    <Skeleton className="h-5 w-20 rounded-full bg-muted" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-border bg-card p-4">
+            <Skeleton className="h-5 w-44 bg-muted" />
+            <Skeleton className="mt-4 h-10 w-full max-w-xs bg-muted" />
+          </section>
+
+          <section className="rounded-lg border border-border bg-card p-4">
+            <Skeleton className="h-5 w-32 bg-muted" />
+            <Skeleton className="mt-4 h-20 rounded-xl bg-muted" />
+          </section>
+
+          <section className="rounded-lg border border-border bg-card p-4">
+            <Skeleton className="h-5 w-40 bg-muted" />
+            <div className="mt-4 space-y-2">
+              {Array.from({ length: 6 }).map((_, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+                <Skeleton key={`description-${i}`} className="h-4 w-full bg-muted" />
+              ))}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/vacatures/[id]/page.tsx
+++ b/app/vacatures/[id]/page.tsx
@@ -32,7 +32,6 @@ import {
 } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import { Skeleton } from "@/components/ui/skeleton";
 import { VacatureShareButton } from "@/components/vacature-share-button";
 import { VacatureTriageScorecard } from "@/components/vacatures/vacature-triage-scorecard";
 import { stripHtml } from "@/src/lib/html";
@@ -41,6 +40,7 @@ import { getJobDetailPageData } from "@/src/services/jobs/detail-page";
 import { buildVacatureTriageScorecard } from "@/src/services/recruiter-insights";
 import { JobDetailFields } from "./job-detail-fields";
 import { JsonViewer } from "./json-viewer";
+import VacatureDetailLoading from "./loading";
 
 const AIGrading = dynamic(
   () => import("@/components/ai-grading").then((mod) => ({ default: mod.AIGrading })),
@@ -186,30 +186,6 @@ function SectionBlock({ title, items }: { title: string; items: string[] }) {
           </li>
         ))}
       </ul>
-    </div>
-  );
-}
-
-function OpdrachtDetailSkeleton() {
-  return (
-    <div className="min-h-0 flex-1 overflow-y-auto">
-      <div className="max-w-[1400px] mx-auto px-4 md:px-6 lg:px-8 py-6 space-y-6">
-        <Skeleton className="h-5 w-64" />
-        <div className="space-y-2">
-          <Skeleton className="h-8 w-72" />
-          <Skeleton className="h-4 w-48" />
-        </div>
-        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-          {Array.from({ length: 4 }).map((_, i) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
-            <Skeleton key={`kpi-${i}`} className="h-20 rounded-xl" />
-          ))}
-        </div>
-        <div className="grid gap-4 lg:grid-cols-3">
-          <Skeleton className="h-64 rounded-xl lg:col-span-2" />
-          <Skeleton className="h-64 rounded-xl" />
-        </div>
-      </div>
     </div>
   );
 }
@@ -1104,7 +1080,7 @@ async function OpdrachtDetailContent({ params, searchParams }: Props) {
 
 export default function OpdrachtDetailPage(props: Props) {
   return (
-    <Suspense fallback={<OpdrachtDetailSkeleton />}>
+    <Suspense fallback={<VacatureDetailLoading />}>
       <OpdrachtDetailContent {...props} />
     </Suspense>
   );


### PR DESCRIPTION
## Summary

- add route-level `loading.tsx` shells for `app/kandidaten/[id]` and `app/vacatures/[id]`
- mirror each route's top-level layout and reuse the same loading component as the page-level `Suspense` fallback
- keep container sizing aligned with the live pages so the shells stay overflow-safe on mobile

## Validation

- `pnpm lint`
- `pnpm exec tsc --noEmit`
- Playwright client-navigation probes from `/ontwikkelaar` into `/kandidaten/test` and `/vacatures/test` with delayed target-route responses
- 375px overflow checks for both loading shells

## Notes

- Real-data runtime validation against existing IDs is blocked in this checkout because `DATABASE_URL` is unavailable locally.
- Local screenshots were captured under `.omx/` during validation; GraphQL file upload URLs expired before the shell PUT completed in this environment.
