### PR TITLE
ui: add loading.tsx for kandidaten and vacatures detail routes (RJC-162)

### DIFF
--- a/app/kandidaten/[id]/loading.tsx
+++ b/app/kandidaten/[id]/loading.tsx
@@ -1,0 +1,85 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function KandidaatDetailLoading() {
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
+        <section className="mb-8 rounded-[28px] border border-border/80 bg-card/95 p-5 shadow-sm sm:p-6">
+          <div className="mb-5 flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-28 bg-muted" />
+              <Skeleton className="h-4 w-40 bg-muted" />
+            </div>
+            <Skeleton className="h-9 w-32 rounded-md bg-muted" />
+          </div>
+
+          <div className="grid gap-5 xl:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.8fr)]">
+            <div className="min-w-0 space-y-5">
+              <div className="flex items-start gap-4">
+                <Skeleton className="h-20 w-20 shrink-0 rounded-3xl bg-muted" />
+                <div className="min-w-0 flex-1 space-y-3">
+                  <Skeleton className="h-8 w-56 max-w-full bg-muted" />
+                  <Skeleton className="h-5 w-40 max-w-full bg-muted" />
+                  <Skeleton className="h-4 w-full bg-muted" />
+                  <Skeleton className="h-4 w-5/6 bg-muted" />
+                </div>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                {["location", "availability", "applications", "rate", "contact"].map((key) => (
+                  <Skeleton key={key} className="h-7 w-28 rounded-full bg-muted" />
+                ))}
+              </div>
+
+              <Skeleton className="h-4 w-44 bg-muted" />
+
+              <div className="flex flex-wrap gap-2">
+                {["workflow", "offer", "save", "call"].map((key) => (
+                  <Skeleton key={key} className="h-9 w-36 rounded-md bg-muted" />
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <Skeleton className="h-44 rounded-3xl bg-card" />
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
+                {["readiness", "status"].map((key) => (
+                  <Skeleton key={key} className="h-28 rounded-2xl bg-card" />
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mb-8 space-y-4 rounded-2xl border border-border bg-card p-5">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="space-y-2">
+              <Skeleton className="h-6 w-48 bg-muted" />
+              <Skeleton className="h-4 w-80 max-w-full bg-muted" />
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Skeleton className="h-9 w-36 rounded-md bg-muted" />
+              <Skeleton className="h-9 w-32 rounded-md bg-muted" />
+            </div>
+          </div>
+          <div className="grid gap-3 lg:grid-cols-2">
+            <Skeleton className="h-40 rounded-xl bg-card" />
+            <Skeleton className="h-40 rounded-xl bg-card" />
+          </div>
+        </section>
+
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+          <div className="space-y-6 lg:col-span-2">
+            <Skeleton className="h-48 rounded-xl bg-card" />
+            <Skeleton className="h-80 rounded-xl bg-card" />
+            <Skeleton className="h-72 rounded-xl bg-card" />
+          </div>
+          <div className="space-y-6">
+            <Skeleton className="h-56 rounded-xl bg-card" />
+            <Skeleton className="h-72 rounded-xl bg-card" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/kandidaten/[id]/page.tsx
+++ b/app/kandidaten/[id]/page.tsx
@@ -67,6 +67,7 @@ import {
   buildCandidateOfferReadiness,
   buildMatchBrief,
 } from "@/src/services/recruiter-insights";
+import KandidaatDetailLoading from "./loading";
 
 export const dynamic = "force-dynamic";
 
@@ -231,25 +232,7 @@ function getLanguageSkills(languageSkills: unknown): Array<{ language: string; l
 }
 
 function KandidaatDetailSkeleton() {
-  return (
-    <div className="min-h-0 flex-1 overflow-y-auto">
-      <div className="max-w-[1400px] mx-auto px-4 md:px-6 lg:px-8 py-6 space-y-6">
-        <Skeleton className="h-5 w-64" />
-        <div className="flex items-start gap-4">
-          <Skeleton className="h-16 w-16 rounded-full" />
-          <div className="space-y-2 flex-1">
-            <Skeleton className="h-7 w-48" />
-            <Skeleton className="h-4 w-32" />
-          </div>
-        </div>
-        <div className="grid gap-4 lg:grid-cols-3">
-          <Skeleton className="h-64 rounded-xl lg:col-span-2" />
-          <Skeleton className="h-64 rounded-xl" />
-        </div>
-        <Skeleton className="h-48 rounded-xl" />
-      </div>
-    </div>
-  );
+  return <KandidaatDetailLoading />;
 }
 
 async function KandidaatDetailContent({ params }: Props) {

--- a/app/kandidaten/[id]/page.tsx
+++ b/app/kandidaten/[id]/page.tsx
@@ -231,10 +231,6 @@ function getLanguageSkills(languageSkills: unknown): Array<{ language: string; l
     .filter((l) => l.language);
 }
 
-function KandidaatDetailSkeleton() {
-  return <KandidaatDetailLoading />;
-}
-
 async function KandidaatDetailContent({ params }: Props) {
   const { id } = await params;
 
@@ -1172,7 +1168,7 @@ async function KandidaatDetailContent({ params }: Props) {
 
 export default function KandidaatDetailPage(props: Props) {
   return (
-    <Suspense fallback={<KandidaatDetailSkeleton />}>
+    <Suspense fallback={<KandidaatDetailLoading />}>
       <KandidaatDetailContent {...props} />
     </Suspense>
   );

--- a/app/vacatures/[id]/loading.tsx
+++ b/app/vacatures/[id]/loading.tsx
@@ -1,0 +1,81 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function VacatureDetailLoading() {
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-[1400px] px-4 py-6 md:px-6 lg:px-8">
+        <section className="rounded-[28px] border border-border bg-card p-5 shadow-sm sm:p-6">
+          <div className="space-y-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <Skeleton className="h-6 w-24 rounded-full bg-muted" />
+              <Skeleton className="h-6 w-36 rounded-full bg-muted" />
+              <Skeleton className="ml-auto h-9 w-24 rounded-md bg-muted" />
+            </div>
+
+            <div className="flex items-start gap-3">
+              <Skeleton className="h-14 w-14 shrink-0 rounded-2xl bg-muted" />
+              <div className="min-w-0 flex-1 space-y-3">
+                <Skeleton className="h-8 w-80 max-w-full bg-muted" />
+                <Skeleton className="h-5 w-40 max-w-full bg-muted" />
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-x-5 gap-y-2">
+              {["location", "arrangement", "rate", "start"].map((key) => (
+                <Skeleton key={key} className="h-5 w-36 rounded-full bg-muted" />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <div className="mx-auto mt-5 flex w-full max-w-4xl flex-col gap-5">
+          <section className="rounded-lg border border-border bg-card p-4">
+            <div className="space-y-4">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="space-y-2">
+                  <Skeleton className="h-6 w-44 bg-muted" />
+                  <Skeleton className="h-4 w-96 max-w-full bg-muted" />
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Skeleton className="h-9 w-40 rounded-md bg-muted" />
+                  <Skeleton className="h-9 w-28 rounded-md bg-muted" />
+                </div>
+              </div>
+
+              <div className="grid gap-2 sm:grid-cols-3">
+                {["deadline", "shortlist", "action"].map((key) => (
+                  <Skeleton key={key} className="h-28 rounded-lg bg-card" />
+                ))}
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-border bg-card p-4">
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Skeleton className="h-6 w-40 bg-muted" />
+                <Skeleton className="h-4 w-72 max-w-full bg-muted" />
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                {["top-1", "top-2", "top-3"].map((key) => (
+                  <Skeleton key={key} className="h-44 rounded-lg bg-card" />
+                ))}
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-lg border border-border bg-card p-4">
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Skeleton className="h-6 w-32 bg-muted" />
+                <Skeleton className="h-4 w-full bg-muted" />
+                <Skeleton className="h-4 w-5/6 bg-muted" />
+              </div>
+              <Skeleton className="h-64 rounded-lg bg-card" />
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/vacatures/[id]/page.tsx
+++ b/app/vacatures/[id]/page.tsx
@@ -32,7 +32,6 @@ import {
 } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import { Skeleton } from "@/components/ui/skeleton";
 import { VacatureShareButton } from "@/components/vacature-share-button";
 import { VacatureTriageScorecard } from "@/components/vacatures/vacature-triage-scorecard";
 import { stripHtml } from "@/src/lib/html";
@@ -41,6 +40,7 @@ import { getJobDetailPageData } from "@/src/services/jobs/detail-page";
 import { buildVacatureTriageScorecard } from "@/src/services/recruiter-insights";
 import { JobDetailFields } from "./job-detail-fields";
 import { JsonViewer } from "./json-viewer";
+import VacatureDetailLoading from "./loading";
 
 const AIGrading = dynamic(
   () => import("@/components/ai-grading").then((mod) => ({ default: mod.AIGrading })),
@@ -191,27 +191,7 @@ function SectionBlock({ title, items }: { title: string; items: string[] }) {
 }
 
 function OpdrachtDetailSkeleton() {
-  return (
-    <div className="min-h-0 flex-1 overflow-y-auto">
-      <div className="max-w-[1400px] mx-auto px-4 md:px-6 lg:px-8 py-6 space-y-6">
-        <Skeleton className="h-5 w-64" />
-        <div className="space-y-2">
-          <Skeleton className="h-8 w-72" />
-          <Skeleton className="h-4 w-48" />
-        </div>
-        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-          {Array.from({ length: 4 }).map((_, i) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
-            <Skeleton key={`kpi-${i}`} className="h-20 rounded-xl" />
-          ))}
-        </div>
-        <div className="grid gap-4 lg:grid-cols-3">
-          <Skeleton className="h-64 rounded-xl lg:col-span-2" />
-          <Skeleton className="h-64 rounded-xl" />
-        </div>
-      </div>
-    </div>
-  );
+  return <VacatureDetailLoading />;
 }
 
 async function OpdrachtDetailContent({ params, searchParams }: Props) {

--- a/app/vacatures/[id]/page.tsx
+++ b/app/vacatures/[id]/page.tsx
@@ -190,10 +190,6 @@ function SectionBlock({ title, items }: { title: string; items: string[] }) {
   );
 }
 
-function OpdrachtDetailSkeleton() {
-  return <VacatureDetailLoading />;
-}
-
 async function OpdrachtDetailContent({ params, searchParams }: Props) {
   const { id } = await params;
   const resolvedSearchParams = await searchParams;
@@ -1084,7 +1080,7 @@ async function OpdrachtDetailContent({ params, searchParams }: Props) {
 
 export default function OpdrachtDetailPage(props: Props) {
   return (
-    <Suspense fallback={<OpdrachtDetailSkeleton />}>
+    <Suspense fallback={<VacatureDetailLoading />}>
       <OpdrachtDetailContent {...props} />
     </Suspense>
   );


### PR DESCRIPTION
## Summary

- add route-level `loading.tsx` shells for `app/kandidaten/[id]` and `app/vacatures/[id]`
- mirror the live candidate/vacancy detail containers and reuse those same components as the page-level `Suspense` fallback shells
- validate the loading state on desktop and 375px mobile with delayed client navigations plus uploaded screenshot evidence in Linear

## Validation

- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `HOSTNAME=0.0.0.0 pnpm dev`
- Playwright-delayed navigations from `/kandidaten` and `/vacatures` into live detail routes at 1440px and 375px, with no horizontal overflow (`scrollWidth === clientWidth` on mobile)
- `pnpm tsx scripts/harness/entropy-check.ts`

## Notes

- The checkout was missing `.env.local`; `vercel link --yes --project motian --scope tsg-group-17fc4f3f` pulled development envs so local runtime validation could run.
- `pnpm test` still times out in existing harness suites (`tests/harness/integration.test.ts` and `tests/harness/orchestrator.test.ts`), which appears unrelated to this low-risk UI diff.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Extracted loading skeleton UI components from candidate and vacancy detail page routes into dedicated route-level loading files, with each module containing layout-specific placeholder sections, cards, and grid elements styled with Tailwind CSS.
  * Consolidated inline skeleton patterns into organized, reusable loading components that provide consistent visual placeholders and loading states while content is loading on detail pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->