### PR TITLE
perf: coordinate Trigger.dev embedding producers behind a shared queue

### DIFF
--- a/tests/deferred-embedding-pipeline.test.ts
+++ b/tests/deferred-embedding-pipeline.test.ts
@@ -28,6 +28,7 @@ const {
 vi.mock("@trigger.dev/sdk", () => ({
   tasks: { trigger: mockTrigger },
   task: <T extends Record<string, unknown>>(config: T) => config,
+  queue: <T extends Record<string, unknown>>(config: T) => config,
   logger: {
     info: mockLoggerInfo,
     error: mockLoggerError,
@@ -65,6 +66,13 @@ describe("deferred embedding pipeline", () => {
       entityType: "candidate",
       entityId: "cand-123",
       source: "candidate:create",
+    });
+  });
+
+  it("uses the shared embedding producer queue", () => {
+    expect(deferEmbeddingSyncTask.queue).toMatchObject({
+      name: "embedding-producers",
+      concurrencyLimit: 2,
     });
   });
 

--- a/tests/embedding-queue-coordination.test.ts
+++ b/tests/embedding-queue-coordination.test.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const ROOT = path.resolve(__dirname, "..");
+
+function readFile(...segments: string[]): string {
+  return fs.readFileSync(path.join(ROOT, ...segments), "utf-8");
+}
+
+describe("embedding producer queue coordination", () => {
+  it("defines a shared queue with the existing concurrency budget", () => {
+    const source = readFile("trigger", "queues.ts");
+
+    expect(source).toContain('EMBEDDING_PRODUCER_QUEUE_NAME = "embedding-producers"');
+    expect(source).toContain("EMBEDDING_PRODUCER_CONCURRENCY_LIMIT = 2");
+    expect(source).toContain("queue({");
+  });
+
+  it("routes ai enrichment through the shared queue", () => {
+    const source = readFile("trigger", "ai-enrichment-batch.ts");
+
+    expect(source).toContain('import { embeddingProducerQueue } from "./queues"');
+    expect(source).toContain("queue: embeddingProducerQueue");
+  });
+
+  it("routes deferred sync through the shared queue", () => {
+    const source = readFile("trigger", "defer-embedding-sync.ts");
+
+    expect(source).toContain('import { embeddingProducerQueue } from "./queues"');
+    expect(source).toContain("queue: embeddingProducerQueue");
+  });
+});

--- a/tests/embeddings-batch.test.ts
+++ b/tests/embeddings-batch.test.ts
@@ -21,8 +21,7 @@ describe("embeddings batch backfill", () => {
   it("caps concurrent task instances while preserving the per-run worker pool", () => {
     const source = readFile("trigger/embeddings-batch.ts");
 
-    expect(source).toContain("queue: {");
-    expect(source).toContain("concurrencyLimit: 2");
+    expect(source).toContain("queue: embeddingProducerQueue");
     expect(source).toContain("const EMBEDDING_CONCURRENCY = 5");
   });
 

--- a/trigger/ai-enrichment-batch.ts
+++ b/trigger/ai-enrichment-batch.ts
@@ -1,5 +1,6 @@
 import { logger, schedules } from "@trigger.dev/sdk";
 import { enrichJobsBatch } from "@/src/services/ai-enrichment";
+import { embeddingProducerQueue } from "./queues";
 
 /**
  * Post-scrape AI enrichment — runs after scrape-pipeline completes.
@@ -19,6 +20,8 @@ export const aiEnrichmentBatchTask = schedules.task({
     pattern: "30 6,10,14,18 * * *", // 30 min after each scrape run
     timezone: "Europe/Amsterdam",
   },
+  // Coordinate post-enrichment embeddings with backfill and deferred sync work.
+  queue: embeddingProducerQueue,
   maxDuration: 300, // 5 minutes — platforms run in parallel now
   machine: { preset: "small-2x" },
   retry: {

--- a/trigger/defer-embedding-sync.ts
+++ b/trigger/defer-embedding-sync.ts
@@ -5,6 +5,7 @@ import {
   type DeferredEmbeddingSyncPayload,
   runDeferredEmbeddingSync,
 } from "@/src/services/embedding";
+import { embeddingProducerQueue } from "./queues";
 
 function revalidateEntity(payload: DeferredEmbeddingSyncPayload) {
   switch (payload.entityType) {
@@ -30,6 +31,7 @@ function toErrorMessage(error: unknown): string {
 
 export const deferEmbeddingSyncTask = task({
   id: "defer-embedding-sync",
+  queue: embeddingProducerQueue,
   retry: {
     maxAttempts: 3,
     factor: 2,

--- a/trigger/embeddings-batch.ts
+++ b/trigger/embeddings-batch.ts
@@ -2,6 +2,7 @@ import { logger, schedules } from "@trigger.dev/sdk";
 import { and, db, isNull, jobs } from "@/src/db";
 import { embedCandidatesBatch, embedJob } from "@/src/services/embedding";
 import { getVisibleVacancyCondition } from "@/src/services/jobs/filters";
+import { embeddingProducerQueue } from "./queues";
 
 /**
  * Hourly task to backfill missing embeddings for jobs and candidates.
@@ -15,10 +16,8 @@ export const embeddingsBatchTask = schedules.task({
     pattern: "15 6,10,14,18 * * *", // After each scrape window
     timezone: "Europe/Amsterdam",
   },
-  queue: {
-    // Bound concurrent task instances; the run body still fans out 5 workers per batch.
-    concurrencyLimit: 2,
-  },
+  // Share the same concurrency budget as other embedding-producing tasks.
+  queue: embeddingProducerQueue,
   maxDuration: 600,
   machine: { preset: "small-1x" },
   retry: {

--- a/trigger/queues.ts
+++ b/trigger/queues.ts
@@ -1,0 +1,9 @@
+import { queue } from "@trigger.dev/sdk";
+
+export const EMBEDDING_PRODUCER_QUEUE_NAME = "embedding-producers";
+export const EMBEDDING_PRODUCER_CONCURRENCY_LIMIT = 2;
+
+export const embeddingProducerQueue = queue({
+  name: EMBEDDING_PRODUCER_QUEUE_NAME,
+  concurrencyLimit: EMBEDDING_PRODUCER_CONCURRENCY_LIMIT,
+});


### PR DESCRIPTION
## Summary
- add a shared Trigger.dev `embedding-producers` queue with the existing concurrency budget of `2`
- route `embeddings-batch`, `defer-embedding-sync`, and `ai-enrichment-batch` through that queue so embedding-producing tasks share one cap
- add regression coverage for the shared queue helper and the deferred embedding pipeline config

## Validation
- `pnpm test -- --run tests/embeddings-batch.test.ts tests/deferred-embedding-pipeline.test.ts tests/embedding-queue-coordination.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint`

## Notes
- deferred job/candidate mutations still only enqueue background embedding work; they do not wait for OpenAI embeddings inline
- post-enrichment embedding fan-out inside `src/services/ai-enrichment.ts` is unchanged; this PR scopes the cap to cross-task coordination

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/204" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
