### PR TITLE
Fix canonical skill bootstrap on empty catalogs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,6 +80,31 @@ Unified job search lives in `src/services/jobs/` (modules: `repository`, `filter
 
 RRF formula: `score = sum(1 / (k + rank))` with k=60. Benchmark: `just benchmark-hybrid-search` (writes `docs/metrics/hybrid-search-benchmark-latest.json`).
 
+## Canonical Skills Runtime
+
+The runtime source of truth for canonical skills is the LinkedIn-style v2
+catalog:
+
+- `skills`
+- `candidate_skills_v2`
+- `job_skills_v2`
+
+Writes bootstrap through `src/services/skills.ts`: `findOrCreateSkill()`
+creates missing `skills` rows, while `syncCandidateSkills()` and
+`syncJobSkills()` populate the link tables from candidate/job ingest.
+
+Runtime readers include:
+
+- search filters in `src/services/candidates.ts` and `src/services/jobs/query-filters.ts`
+- matching/scoring in `src/services/auto-matching.ts`, `src/services/scoring.ts`, and `src/services/esco-scoring.ts`
+- metadata/detail/tool facades in `src/services/esco.ts`, `src/services/sidebar-metadata.ts`, AI tools, MCP tools, and detail pages
+
+Legacy ESCO tables (`esco_skills`, `skill_aliases`, `candidate_skills`,
+`job_skills`, `skill_mappings`) are now import/backfill/reference data, not the
+runtime source of truth. `scripts/import-esco-skills.ts` seeds that legacy
+layer, and `scripts/backfill-skills-v2.ts` bridges legacy ESCO rows into the
+runtime catalog when explicit seeding is needed.
+
 ## Salesforce XML Feed
 
 `/api/salesforce-feed` is a live **read-only XML export** for **pull-based Salesforce integrations**. It reads from Motian records and returns a custom `<sObjects>` XML document, so it should be treated as a bespoke feed rather than an OData surface.

--- a/docs/runbooks/linkedin-skills-migration-runbook.md
+++ b/docs/runbooks/linkedin-skills-migration-runbook.md
@@ -1,19 +1,61 @@
 # LinkedIn-style skills migratie & backfill runbook
 
-Runbook voor de overstap van ESCO-first skills naar een eenvoudiger
+Runbook voor de overstap van ESCO-first skills naar het huidige
 LinkedIn-style skillsmodel met canonical labels/slugs.
 
 ## Doel
 
-Deze rollout vervangt ESCO niet in één stap, maar introduceert een nieuwe
-canonical skill-laag naast de bestaande tabellen:
+De runtime source of truth voor canonieke skills is:
 
 - `skills`
 - `candidate_skills_v2`
 - `job_skills_v2`
 
-De applicatie leest daarna skills via recruiter-vriendelijke labels en slugs,
-met exact-match scoring en consistente tags/badges in de UI.
+De applicatie leest, filtert en scoort daarna via recruiter-vriendelijke labels
+en slugs uit deze tabellen.
+
+Legacy ESCO-tabellen blijven alleen bestaan voor import/backfill/reference:
+
+- `esco_skills`
+- `skill_aliases`
+- `candidate_skills`
+- `job_skills`
+- `skill_mappings`
+
+Die legacy laag is **niet** meer de runtime source of truth voor matching,
+filters of skill-weergave in de app.
+
+## Runtime source of truth
+
+### Schrijven / bootstrap
+
+- `src/services/normalize.ts` roept `syncJobSkills()` aan na job-upserts.
+- `src/services/candidates.ts` roept `syncCandidateSkills()` aan op writes.
+- `src/services/skills.ts` maakt ontbrekende `skills` rows zelf aan via
+  `findOrCreateSkill()`.
+
+Dat betekent dat een lege `skills`-catalogus zichzelf weer kan opbouwen vanuit
+nieuwe vacature- of kandidaat-ingestie. Een expliciete seed blijft mogelijk via
+`scripts/backfill-skills-v2.ts` wanneer je bestaande legacy ESCO-data wilt
+omzetten.
+
+### Lezen / runtime consumers
+
+De volgende runtime-paden lezen al uit de v2-catalogus:
+
+- detail/enrichment facades in `src/services/esco.ts`
+- search filters in `src/services/candidates.ts` en `src/services/jobs/query-filters.ts`
+- matching/scoring in `src/services/auto-matching.ts`, `src/services/scoring.ts`, en `src/services/esco-scoring.ts`
+- filter/sidebar metadata in `src/services/sidebar-metadata.ts`
+- AI/MCP/detail surfaces zoals `src/mcp/tools/esco-skills.ts`, `src/ai/tools/get-opdracht-detail.ts`, `app/kandidaten/[id]/page.tsx`, en `app/vacatures/[id]/page.tsx`
+
+### Legacy relatie
+
+- `scripts/import-esco-skills.ts` vult alleen de legacy ESCO-tabellen.
+- `scripts/backfill-skills-v2.ts` is de brug van legacy ESCO-data naar de
+  runtime catalogus.
+- `packages/esco` bevat nog legacy ESCO-logica, maar wordt niet gebruikt door
+  de live app-runtime.
 
 ---
 
@@ -68,7 +110,7 @@ Nieuwe tabellen bestaan, maar oude ESCO-tabellen blijven nog intact.
 
 ## 3. Backfill uitvoeren
 
-### Stap 2 — vul canonical skills vanuit bestaande ESCO-data
+### Stap 2 — optioneel: vul canonical skills vanuit bestaande ESCO-data
 
 Voer het backfill script uit:
 
@@ -96,6 +138,9 @@ Het script logt JSON met ongeveer deze shape:
 - vult `candidate_skills_v2`
 - vult `job_skills_v2`
 - laat bestaande ESCO-tabellen ongemoeid
+
+> Niet verplicht voor bootstrap van nieuwe data: nieuwe kandidaat/job writes
+> vullen de runtime catalogus ook zonder voorafgaande seed.
 
 ---
 
@@ -160,7 +205,7 @@ LIMIT 20;
 Controleer een paar matches handmatig:
 
 - [ ] reasoning gebruikt recruiter-taal zoals `3 van 5 vereiste skills matchen`
-- [ ] `model` blijft `esco-rule-v1` op canonical skill path
+- [ ] `model` blijft `skills-rule-v1` op canonical skill path
 - [ ] er zijn geen ESCO guardrail fallback logs meer nodig voor deze flow
 
 ---
@@ -230,8 +275,8 @@ TRUNCATE TABLE skills RESTART IDENTITY CASCADE;
 
 Na een stabiele periode kun je fase 2 van cleanup plannen:
 
-- ESCO reads verwijderen uit app/services
-- MCP/AI surfaces hernoemen van `esco` naar `skills`
+- legacy `esco` naming verwijderen uit app/services en tool surfaces
+- MCP/AI/API filter-interfaces hernoemen van `esco` naar `skills` / `skillSlug`
 - oude tabellen pas daarna droppen:
   - `esco_skills`
   - `skill_aliases`

--- a/src/services/normalize.ts
+++ b/src/services/normalize.ts
@@ -2,7 +2,7 @@ import type { z } from "zod";
 import { stripHtml } from "../../packages/scrapers/src/strip-html";
 import { db, jobs, sql } from "../db";
 import { unifiedJobSchema } from "../schemas/job";
-import { isSkillsCatalogAvailable, syncJobSkills } from "./esco";
+import { syncJobSkills } from "./esco";
 
 /** Permissive type for scraped data — Zod validates at runtime via safeParse */
 export type RawScrapedListing = Record<string, unknown>;
@@ -295,11 +295,6 @@ export async function normalizeAndSaveJobs(
         jobsNew += inserted;
         duplicates += updated;
 
-        const skillsCatalogAvailable = await isSkillsCatalogAvailable();
-        if (!skillsCatalogAvailable) {
-          continue;
-        }
-
         // Parallel skill sync with concurrency cap to avoid exhausting Neon connection pool
         const SKILL_SYNC_CONCURRENCY = 5;
         for (let j = 0; j < result.length; j += SKILL_SYNC_CONCURRENCY) {
@@ -321,7 +316,9 @@ export async function normalizeAndSaveJobs(
           );
           const failed = settled.filter((s) => s.status === "rejected").length;
           if (failed > 0) {
-            console.warn(`[normalize] ${failed}/${chunk.length} ESCO syncs failed in chunk`);
+            console.warn(
+              `[normalize] ${failed}/${chunk.length} canonical skill syncs failed in chunk`,
+            );
           }
         }
       } catch (err) {

--- a/tests/normalization.test.ts
+++ b/tests/normalization.test.ts
@@ -1,9 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { normalizeAndSaveJobs } from "../src/services/normalize";
 
-const { mockSyncJobSkills, mockIsSkillsCatalogAvailable } = vi.hoisted(() => ({
+const { mockSyncJobSkills } = vi.hoisted(() => ({
   mockSyncJobSkills: vi.fn().mockResolvedValue(undefined),
-  mockIsSkillsCatalogAvailable: vi.fn().mockResolvedValue(true),
 }));
 
 const mockValues = vi.fn().mockImplementation(() => ({
@@ -21,7 +20,6 @@ vi.mock("../src/db", async (importOriginal) => ({
 }));
 
 vi.mock("../src/services/esco", () => ({
-  isSkillsCatalogAvailable: mockIsSkillsCatalogAvailable,
   syncJobSkills: mockSyncJobSkills,
   getSkillsCatalogStatusCached: vi.fn().mockResolvedValue({
     available: true,
@@ -36,7 +34,6 @@ vi.mock("../src/services/esco", () => ({
 describe("normalizeAndSaveJobs regression", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockIsSkillsCatalogAvailable.mockResolvedValue(true);
   });
 
   it("should verify HTML stripping and range clamping", async () => {
@@ -81,9 +78,7 @@ describe("normalizeAndSaveJobs regression", () => {
     expect(valuesCall[1].minHoursPerWeek).toBe(1);
   });
 
-  it("skips skill sync entirely when the canonical skills catalog is unavailable", async () => {
-    mockIsSkillsCatalogAvailable.mockResolvedValue(false);
-
+  it("keeps syncing canonical job skills even when the catalog starts empty", async () => {
     await normalizeAndSaveJobs("test-platform", [
       {
         externalId: "ext-1",
@@ -96,7 +91,12 @@ describe("normalizeAndSaveJobs regression", () => {
       },
     ]);
 
-    expect(mockIsSkillsCatalogAvailable).toHaveBeenCalledTimes(1);
-    expect(mockSyncJobSkills).not.toHaveBeenCalled();
+    expect(mockSyncJobSkills).toHaveBeenCalledTimes(1);
+    expect(mockSyncJobSkills).toHaveBeenCalledWith({
+      jobId: "uuid-1",
+      requirements: [{ description: "React", isKnockout: true }],
+      wishes: [],
+      competences: ["TypeScript"],
+    });
   });
 });


### PR DESCRIPTION
## Summary
- remove the normalization gate that skipped canonical job-skill sync when the v2 catalog was empty
- update the normalization regression to prove bootstrap still syncs when the runtime catalog starts empty
- document that runtime canonical skills live in `skills`, `candidate_skills_v2`, and `job_skills_v2`, while legacy ESCO tables remain import/backfill/reference data

## Why
`src/services/esco.ts` already reads from the v2 skills catalog, but `normalizeAndSaveJobs()` still blocked `syncJobSkills()` behind `isSkillsCatalogAvailable()`. On an empty catalog that created a bootstrap deadlock: the sync path that can self-seed the catalog was never allowed to run.

## Validation
- `pnpm test tests/normalization.test.ts tests/esco-ingestion-wiring.test.ts tests/integration-scoring.test.ts tests/sidebar-metadata.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm harness:entropy`

## Follow-up
- `RJC-172` tracks the remaining out-of-scope cleanup to rename legacy `esco` runtime surfaces to `skills` / `skillSlug`.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
