### PR TITLE
Fix inactive StatusBadge contrast in dark mode

### DIFF
--- a/components/status-badge.tsx
+++ b/components/status-badge.tsx
@@ -28,7 +28,7 @@ const statusConfig: Record<string, { label: string; className: string }> = {
   },
   inactief: {
     label: "Inactief",
-    className: "bg-muted text-muted-foreground border-border",
+    className: "bg-muted text-muted-foreground border-border dark:text-foreground/70",
   },
 };
 

--- a/tests/status-badge.test.ts
+++ b/tests/status-badge.test.ts
@@ -1,0 +1,14 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { StatusBadge } from "@/components/status-badge";
+
+describe("StatusBadge", () => {
+  it("adds a dark-mode contrast override for the inactive badge", () => {
+    const html = renderToStaticMarkup(createElement(StatusBadge, { status: "inactief" }));
+
+    expect(html).toContain("Inactief");
+    expect(html).toContain("text-muted-foreground");
+    expect(html).toContain("dark:text-foreground/70");
+  });
+});


### PR DESCRIPTION
## Summary
- raise the dark-mode `inactief` StatusBadge text contrast with a dark-only override
- keep the light-mode neutral styling intact
- add a regression test covering the inactive badge class contract

## Validation
- Playwright audit on a temporary `/ontwikkelaar` proof surface: `4.18:1 -> 6.28:1`
- `pnpm exec vitest run tests/status-badge.test.ts`
- `pnpm test`
- `pnpm lint`
- `pnpm exec tsc --noEmit`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
