### PR TITLE
feat: scaffold Microsoft365Provider for ADR-005 stage 2

### DIFF
--- a/docs/M365-setup.md
+++ b/docs/M365-setup.md
@@ -1,0 +1,51 @@
+# Microsoft 365 setup (ADR-005 Stage 2)
+
+Dit document beschrijft wat STAR IT moet opleveren om `MAIL_PROVIDER=m365` veilig te activeren.
+
+## Vereiste Azure AD app-registratie
+
+1. Maak een app-registratie in de STAR tenant.
+2. Voeg **Application permissions** toe:
+   - `Mail.Read`
+   - `Mail.Send`
+   - `Sites.Selected`
+   - `offline_access`
+3. Geef admin consent voor alle bovenstaande scopes.
+4. Maak een client secret met rotatiebeleid (max 90 dagen aanbevolen).
+
+## Vereiste configuratie (environment)
+
+```
+MAIL_PROVIDER=m365
+M365_TENANT_ID=<tenant-id>
+M365_CLIENT_ID=<app-client-id>
+M365_CLIENT_SECRET=<client-secret>
+M365_WEBHOOK_CLIENT_STATE=<shared-random-secret>
+```
+
+## Webhooks en subscriptions
+
+- Configureer een publiek HTTPS endpoint voor Graph notifications.
+- Configureer ook een `lifecycleNotificationUrl` endpoint.
+- Subscriptions op `/users/{mailbox}/messages` moeten elke 3 dagen vernieuwd worden.
+- `clientState` moet exact matchen met `M365_WEBHOOK_CLIENT_STATE`.
+
+## Burn-in plan (switch-over)
+
+1. **Dag 0-2 (shadow mode):**
+   - Houd huidige provider actief.
+   - Laat `Microsoft365Provider` mee-draaien met mocked/gespiegelde events in testtenant.
+2. **Dag 3-5 (canary mailboxes):**
+   - Zet `MAIL_PROVIDER=m365` voor 1-2 mailboxen.
+   - Controleer subscription renewal, attachment fetches, en sendMail latency.
+3. **Dag 6-7 (volledige overgang):**
+   - Verhoog naar alle mailboxen.
+   - Monitor webhook volume, 4xx/5xx responsen en delivery delay.
+4. **Rollback:**
+   - Zet `MAIL_PROVIDER=agentmail` terug.
+   - Recreate subscriptions nadat incident is opgelost.
+
+## Teststrategie
+
+- Unit tests gebruiken een mocked Graph client.
+- Integratietests draaien alleen wanneer `M365_TENANT_ID` is gezet.

--- a/src/env.ts
+++ b/src/env.ts
@@ -82,6 +82,11 @@ export const env = createEnv({
     ESCO_SCORING_ENABLED: z.string().optional(),
 
     // App config
+    MAIL_PROVIDER: z.enum(["agentmail", "m365"]).optional(),
+    M365_TENANT_ID: z.string().optional(),
+    M365_CLIENT_ID: z.string().optional(),
+    M365_CLIENT_SECRET: z.string().optional(),
+    M365_WEBHOOK_CLIENT_STATE: z.string().optional(),
     MOTIA_API_URL: z.string().url().optional(),
     NEXT_URL: z.string().url().optional(),
     PUBLIC_API_BASE_URL: z.string().url().optional(),
@@ -185,6 +190,11 @@ export const env = createEnv({
     ESCO_VERSION: process.env.ESCO_VERSION,
     ESCO_CRITICAL_REVIEW_THRESHOLD: process.env.ESCO_CRITICAL_REVIEW_THRESHOLD,
     ESCO_SCORING_ENABLED: process.env.ESCO_SCORING_ENABLED,
+    MAIL_PROVIDER: process.env.MAIL_PROVIDER,
+    M365_TENANT_ID: process.env.M365_TENANT_ID,
+    M365_CLIENT_ID: process.env.M365_CLIENT_ID,
+    M365_CLIENT_SECRET: process.env.M365_CLIENT_SECRET,
+    M365_WEBHOOK_CLIENT_STATE: process.env.M365_WEBHOOK_CLIENT_STATE,
     MOTIA_API_URL: process.env.MOTIA_API_URL,
     NEXT_URL: process.env.NEXT_URL,
     PUBLIC_API_BASE_URL: process.env.PUBLIC_API_BASE_URL,

--- a/src/services/Microsoft365Provider.ts
+++ b/src/services/Microsoft365Provider.ts
@@ -1,0 +1,232 @@
+import type {
+  AttachmentRequest,
+  InboxSubscription,
+  InboxSubscriptionRequest,
+  MailProvider,
+  MailSendRequest,
+  VerifyWebhookSignatureInput,
+} from "./mail-provider";
+
+const GRAPH_SCOPE = "https://graph.microsoft.com/.default";
+const SUBSCRIPTION_WINDOW_MS = 1000 * 60 * 60 * 24 * 3;
+
+interface GraphClientLike {
+  api(path: string): {
+    get: () => Promise<any>;
+    post: (body: unknown) => Promise<any>;
+  };
+}
+
+export interface Microsoft365ProviderOptions {
+  tenantId: string;
+  clientId: string;
+  clientSecret: string;
+  expectedClientState: string;
+  graphClient?: GraphClientLike;
+  requireTlsCertificate?: boolean;
+}
+
+function getHeader(
+  headers: Headers | Record<string, string | undefined>,
+  key: string,
+): string | undefined {
+  if (headers instanceof Headers) {
+    return headers.get(key) ?? undefined;
+  }
+
+  return headers[key] ?? headers[key.toLowerCase()];
+}
+
+function parseBase64(content: string): Buffer {
+  return Buffer.from(content, "base64");
+}
+
+export function createMicrosoftGraphClient(options: {
+  tenantId: string;
+  clientId: string;
+  clientSecret: string;
+}): GraphClientLike {
+  const tokenUrl = `https://login.microsoftonline.com/${options.tenantId}/oauth2/v2.0/token`;
+  let cachedToken = "";
+  let tokenExpiry = 0;
+
+  async function getToken(): Promise<string> {
+    if (cachedToken && tokenExpiry > Date.now() + 30_000) {
+      return cachedToken;
+    }
+
+    const response = await fetch(tokenUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "client_credentials",
+        client_id: options.clientId,
+        client_secret: options.clientSecret,
+        scope: GRAPH_SCOPE,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Token ophalen mislukt (${response.status}).`);
+    }
+
+    const payload = (await response.json()) as { access_token: string; expires_in: number };
+    cachedToken = payload.access_token;
+    tokenExpiry = Date.now() + payload.expires_in * 1000;
+    return cachedToken;
+  }
+
+  return {
+    api(path: string) {
+      return {
+        get: async () => {
+          const token = await getToken();
+          const response = await fetch(`https://graph.microsoft.com/v1.0${path}`, {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          if (!response.ok) {
+            throw new Error(`Graph GET mislukt (${response.status}) op ${path}.`);
+          }
+          const contentType = response.headers.get("content-type") ?? "";
+          if (contentType.includes("application/json")) {
+            return response.json();
+          }
+          return response.arrayBuffer();
+        },
+        post: async (body: unknown) => {
+          const token = await getToken();
+          const response = await fetch(`https://graph.microsoft.com/v1.0${path}`, {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${token}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(body),
+          });
+          if (!response.ok) {
+            throw new Error(`Graph POST mislukt (${response.status}) op ${path}.`);
+          }
+          if (response.status === 204) {
+            return {};
+          }
+          return response.json();
+        },
+      };
+    },
+  };
+}
+
+export class Microsoft365Provider implements MailProvider {
+  private readonly graphClient: GraphClientLike;
+
+  constructor(private readonly options: Microsoft365ProviderOptions) {
+    this.graphClient =
+      options.graphClient ??
+      createMicrosoftGraphClient({
+        tenantId: options.tenantId,
+        clientId: options.clientId,
+        clientSecret: options.clientSecret,
+      });
+  }
+
+  async subscribeInbox(input: InboxSubscriptionRequest): Promise<InboxSubscription> {
+    const payload = {
+      changeType: "created,updated",
+      notificationUrl: input.notificationUrl,
+      lifecycleNotificationUrl: input.lifecycleNotificationUrl,
+      resource: `/users/${input.mailbox}/messages`,
+      clientState: input.clientState,
+      expirationDateTime: new Date(Date.now() + SUBSCRIPTION_WINDOW_MS).toISOString(),
+    };
+
+    const response = await this.graphClient.api("/subscriptions").post(payload);
+
+    return {
+      id: response.id,
+      expirationDateTime: response.expirationDateTime,
+      resource: response.resource,
+    };
+  }
+
+  async fetchAttachment(input: AttachmentRequest): Promise<Buffer> {
+    if (input.messageId && input.attachmentId) {
+      const attachment = await this.graphClient
+        .api(`/users/${input.mailbox}/messages/${input.messageId}/attachments/${input.attachmentId}`)
+        .get();
+
+      if (!attachment.contentBytes) {
+        throw new Error("Microsoft Graph attachment bevat geen inhoud.");
+      }
+
+      return parseBase64(attachment.contentBytes);
+    }
+
+    if (input.sharePointSiteId && input.driveId && input.itemId) {
+      const file = await this.graphClient
+        .api(`/sites/${input.sharePointSiteId}/drives/${input.driveId}/items/${input.itemId}/content`)
+        .get();
+
+      if (file instanceof ArrayBuffer) {
+        return Buffer.from(file);
+      }
+
+      if (typeof file === "string") {
+        return Buffer.from(file);
+      }
+
+      return Buffer.from(JSON.stringify(file));
+    }
+
+    throw new Error("Attachment-verzoek mist message/attachment IDs of SharePoint IDs.");
+  }
+
+  async sendReply(input: MailSendRequest): Promise<void> {
+    await this.sendMail(input);
+  }
+
+  async sendReport(input: MailSendRequest): Promise<void> {
+    await this.sendMail(input);
+  }
+
+  verifyWebhookSignature(input: VerifyWebhookSignatureInput): boolean {
+    if (input.clientState !== this.options.expectedClientState) {
+      return false;
+    }
+
+    if (this.options.requireTlsCertificate !== false) {
+      const forwardedClientCert = getHeader(input.headers, "x-arr-clientcert");
+      const tlsClientCertificate = input.tlsClientCertificate ?? forwardedClientCert;
+      if (!tlsClientCertificate) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private async sendMail(input: MailSendRequest): Promise<void> {
+    const internetMessageHeaders = input.conversationId
+      ? [
+          {
+            name: "x-ms-conversation-id",
+            value: input.conversationId,
+          },
+        ]
+      : undefined;
+
+    await this.graphClient.api(`/users/${input.mailbox}/sendMail`).post({
+      message: {
+        subject: input.subject,
+        body: {
+          contentType: "HTML",
+          content: input.htmlBody,
+        },
+        toRecipients: input.to.map((address) => ({
+          emailAddress: { address },
+        })),
+        internetMessageHeaders,
+      },
+      saveToSentItems: true,
+    });
+  }
+}

--- a/src/services/mail-provider-config.ts
+++ b/src/services/mail-provider-config.ts
@@ -1,0 +1,11 @@
+export const MAIL_PROVIDER_VALUES = ["agentmail", "m365"] as const;
+
+export type MailProviderValue = (typeof MAIL_PROVIDER_VALUES)[number];
+
+export function resolveMailProvider(value: string | undefined): MailProviderValue {
+  if (value === "m365") {
+    return "m365";
+  }
+
+  return "agentmail";
+}

--- a/src/services/mail-provider.ts
+++ b/src/services/mail-provider.ts
@@ -1,0 +1,43 @@
+export interface InboxSubscriptionRequest {
+  mailbox: string;
+  notificationUrl: string;
+  lifecycleNotificationUrl: string;
+  clientState: string;
+}
+
+export interface InboxSubscription {
+  id: string;
+  expirationDateTime: string;
+  resource: string;
+}
+
+export interface AttachmentRequest {
+  mailbox: string;
+  messageId?: string;
+  attachmentId?: string;
+  sharePointSiteId?: string;
+  driveId?: string;
+  itemId?: string;
+}
+
+export interface MailSendRequest {
+  mailbox: string;
+  to: string[];
+  subject: string;
+  htmlBody: string;
+  conversationId?: string;
+}
+
+export interface VerifyWebhookSignatureInput {
+  headers: Headers | Record<string, string | undefined>;
+  clientState?: string;
+  tlsClientCertificate?: string;
+}
+
+export interface MailProvider {
+  subscribeInbox(input: InboxSubscriptionRequest): Promise<InboxSubscription>;
+  fetchAttachment(input: AttachmentRequest): Promise<Buffer>;
+  sendReply(input: MailSendRequest): Promise<void>;
+  sendReport(input: MailSendRequest): Promise<void>;
+  verifyWebhookSignature(input: VerifyWebhookSignatureInput): boolean;
+}

--- a/tests/microsoft365-provider.test.ts
+++ b/tests/microsoft365-provider.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { Microsoft365Provider } from "../src/services/Microsoft365Provider";
+
+function createGraphClientMock() {
+  const routes = new Map<string, { get?: any; post?: any }>();
+
+  return {
+    routes,
+    client: {
+      api(path: string) {
+        return {
+          get: vi.fn(async () => routes.get(path)?.get),
+          post: vi.fn(async (body: unknown) => {
+            const route = routes.get(path);
+            if (typeof route?.post === "function") {
+              return route.post(body);
+            }
+            return route?.post;
+          }),
+        };
+      },
+    },
+  };
+}
+
+describe("Microsoft365Provider", () => {
+  it("maakt inbox-subscription met lifecycleNotificationUrl", async () => {
+    const graph = createGraphClientMock();
+    graph.routes.set("/subscriptions", {
+      post: {
+        id: "sub-123",
+        expirationDateTime: "2026-04-20T00:00:00.000Z",
+        resource: "/users/inbox@example.com/messages",
+      },
+    });
+
+    const provider = new Microsoft365Provider({
+      tenantId: "tenant",
+      clientId: "client",
+      clientSecret: "secret",
+      expectedClientState: "state-123",
+      graphClient: graph.client,
+      requireTlsCertificate: false,
+    });
+
+    const subscription = await provider.subscribeInbox({
+      mailbox: "inbox@example.com",
+      notificationUrl: "https://example.com/webhook",
+      lifecycleNotificationUrl: "https://example.com/lifecycle",
+      clientState: "state-123",
+    });
+
+    expect(subscription.id).toBe("sub-123");
+    expect(subscription.resource).toBe("/users/inbox@example.com/messages");
+  });
+
+  it("haalt Outlook inline attachment op", async () => {
+    const graph = createGraphClientMock();
+    graph.routes.set("/users/mailbox/messages/msg-1/attachments/att-1", {
+      get: {
+        contentBytes: Buffer.from("hallo").toString("base64"),
+      },
+    });
+
+    const provider = new Microsoft365Provider({
+      tenantId: "tenant",
+      clientId: "client",
+      clientSecret: "secret",
+      expectedClientState: "state-123",
+      graphClient: graph.client,
+      requireTlsCertificate: false,
+    });
+
+    const file = await provider.fetchAttachment({
+      mailbox: "mailbox",
+      messageId: "msg-1",
+      attachmentId: "att-1",
+    });
+
+    expect(file.toString()).toBe("hallo");
+  });
+
+  it("haalt SharePoint content op via drives endpoint", async () => {
+    const graph = createGraphClientMock();
+    graph.routes.set("/sites/site-1/drives/drive-1/items/item-1/content", {
+      get: "sharepoint-bestand",
+    });
+
+    const provider = new Microsoft365Provider({
+      tenantId: "tenant",
+      clientId: "client",
+      clientSecret: "secret",
+      expectedClientState: "state-123",
+      graphClient: graph.client,
+      requireTlsCertificate: false,
+    });
+
+    const file = await provider.fetchAttachment({
+      mailbox: "mailbox",
+      sharePointSiteId: "site-1",
+      driveId: "drive-1",
+      itemId: "item-1",
+    });
+
+    expect(file.toString()).toBe("sharepoint-bestand");
+  });
+
+  it("stuurt reply met conversationId header", async () => {
+    const graph = createGraphClientMock();
+    const posts: unknown[] = [];
+    graph.routes.set("/users/inbox@example.com/sendMail", {
+      post: (body: unknown) => {
+        posts.push(body);
+        return {};
+      },
+    });
+
+    const provider = new Microsoft365Provider({
+      tenantId: "tenant",
+      clientId: "client",
+      clientSecret: "secret",
+      expectedClientState: "state-123",
+      graphClient: graph.client,
+      requireTlsCertificate: false,
+    });
+
+    await provider.sendReply({
+      mailbox: "inbox@example.com",
+      to: ["to@example.com"],
+      subject: "Onderwerp",
+      htmlBody: "<p>Hoi</p>",
+      conversationId: "conv-1",
+    });
+
+    expect(posts).toHaveLength(1);
+    const payload = posts[0] as {
+      message: { internetMessageHeaders?: Array<{ name: string; value: string }> };
+    };
+    expect(payload.message.internetMessageHeaders?.[0]).toEqual({
+      name: "x-ms-conversation-id",
+      value: "conv-1",
+    });
+  });
+
+  it("verifieert clientState + TLS certificaat", () => {
+    const provider = new Microsoft365Provider({
+      tenantId: "tenant",
+      clientId: "client",
+      clientSecret: "secret",
+      expectedClientState: "state-123",
+      graphClient: createGraphClientMock().client,
+    });
+
+    const ok = provider.verifyWebhookSignature({
+      headers: { "x-arr-clientcert": "cert" },
+      clientState: "state-123",
+    });
+    const badState = provider.verifyWebhookSignature({
+      headers: { "x-arr-clientcert": "cert" },
+      clientState: "wrong",
+    });
+
+    expect(ok).toBe(true);
+    expect(badState).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation
- Implement Stage 2 of ADR-005 to add a Microsoft 365 mail transport that can replace the existing mail provider without changing higher-level server code.
- Provide Graph-based inbox subscription, attachment retrieval (Outlook + SharePoint), send-mail with conversation threading, and webhook verification to enable a safe burn-in plan for STAR's M365 tenant.
- Keep the implementation testable against a mocked Graph client so integration can be gated on real tenant consent and env vars.

### Description
- Add a `MailProvider` contract in `src/services/mail-provider.ts` defining subscription, attachment fetch, send and webhook verification APIs.
- Implement `Microsoft365Provider` in `src/services/Microsoft365Provider.ts` with Graph subscription creation (includes `lifecycleNotificationUrl`), attachment retrieval for Outlook inline attachments and SharePoint drive content, `sendReply`/`sendReport` via `/users/{mailbox}/sendMail` with `x-ms-conversation-id` header support, and webhook signature checks against `clientState` plus optional TLS cert header validation.
- Provide a lightweight Graph client helper that acquires client-credentials tokens via OAuth token endpoint (fallbackable to an injected mocked `graphClient` for tests) and performs `GET`/`POST` calls to `https://graph.microsoft.com/v1.0`.
- Add `MAIL_PROVIDER` resolution support in `src/services/mail-provider-config.ts` and extend server env parsing in `src/env.ts` with `MAIL_PROVIDER`, `M365_TENANT_ID`, `M365_CLIENT_ID`, `M365_CLIENT_SECRET`, and `M365_WEBHOOK_CLIENT_STATE`.
- Add unit tests in `tests/microsoft365-provider.test.ts` using a mocked Graph client to cover subscription creation, Outlook attachment decoding, SharePoint content retrieval, send-mail threading header, and webhook verification logic.
- Add `docs/M365-setup.md` describing required Azure AD app registration scopes, env configuration, webhook expectations, and a burn-in/rollback plan.

### Testing
- Added unit tests in `tests/microsoft365-provider.test.ts` which exercise subscription creation, attachment fetch paths, send-mail payloads, and webhook verification logic, but running `pnpm test -- tests/microsoft365-provider.test.ts` in this environment failed because the `vitest` binary is not available (`sh: 1: vitest: not found`).
- Ran `pnpm lint` locally in this environment which failed because the `biome` binary is not available (`sh: 1: biome: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2925bbc9883308a0c70d2b32905f5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/210" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
