### PR TITLE
feat(ui): Indeed-style vacatures + Claude.ai-style chat on mobile

### DIFF
--- a/components/chat/chat-messages.tsx
+++ b/components/chat/chat-messages.tsx
@@ -76,7 +76,16 @@ type Props = {
   emptyStatePrompts?: ChatSuggestion[];
   followUpPrompts?: ChatSuggestion[];
   conversationLabel?: string;
+  userFirstName?: string | null;
 };
+
+function getDutchGreeting(now: Date = new Date()): string {
+  const hour = now.getHours();
+  if (hour < 6) return "Goedenacht";
+  if (hour < 12) return "Goedemorgen";
+  if (hour < 18) return "Goedemiddag";
+  return "Goedenavond";
+}
 
 const DEFAULT_EMPTY_STATE_PROMPTS: ChatSuggestion[] = [
   {
@@ -493,6 +502,7 @@ export function ChatMessages({
   emptyStatePrompts = DEFAULT_EMPTY_STATE_PROMPTS,
   followUpPrompts = [],
   conversationLabel = "Chatgesprek met Motian AI",
+  userFirstName,
 }: Props) {
   const hasUserMessage = messages.some((message) => message.role === "user");
   const isWidget = layout === "widget";
@@ -597,9 +607,19 @@ export function ChatMessages({
               isWidget ? "max-w-3xl" : "max-w-4xl",
             )}
           >
+            <div className="flex w-full flex-col items-center gap-4 text-center lg:hidden">
+              <h2 className="flex items-center gap-3 text-2xl font-semibold tracking-tight text-foreground">
+                <Sparkles className="h-6 w-6 text-primary" />
+                {userFirstName ? `${getDutchGreeting()}, ${userFirstName}` : getDutchGreeting()}
+              </h2>
+              <p className="max-w-md text-sm leading-6 text-muted-foreground">
+                {emptyStateDescription}
+              </p>
+            </div>
+
             <div
               className={cn(
-                "w-full rounded-[28px] border border-border/70 bg-card/95 p-5 shadow-sm sm:p-8",
+                "hidden w-full rounded-[28px] border border-border/70 bg-card/95 p-5 shadow-sm sm:p-8 lg:block",
                 isWidget && "rounded-3xl p-4 sm:p-5",
               )}
             >
@@ -611,7 +631,7 @@ export function ChatMessages({
                   </div>
                   <div className="space-y-2">
                     <h2 className="text-lg font-semibold tracking-tight text-foreground sm:text-2xl">
-                      {emptyStateTitle}
+                      {userFirstName ? `${getDutchGreeting()}, ${userFirstName}` : emptyStateTitle}
                     </h2>
                     <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
                       {emptyStateDescription}

--- a/components/chat/chat-page-content.tsx
+++ b/components/chat/chat-page-content.tsx
@@ -24,6 +24,7 @@ import Link from "next/link";
 import { useCallback, useEffect, useState } from "react";
 import { ChatPromptComposer } from "@/src/components/ai-elements/chat-prompt-composer";
 import { PromptInputProvider } from "@/src/components/ai-elements/prompt-input";
+import { QuickActionChips } from "@/src/components/ai-elements/quick-action-chips";
 import {
   ChatCvDropOverlay,
   type ChatCvUploadController,
@@ -373,7 +374,7 @@ function ChatPageHeader({
             <Menu className="h-4 w-4" />
           </button>
 
-          <div className="min-w-0">
+          <div className="hidden min-w-0 lg:block">
             <div className="flex flex-wrap items-center gap-2">
               <h1 className="truncate text-sm font-semibold text-foreground sm:text-base">
                 {title}
@@ -391,11 +392,11 @@ function ChatPageHeader({
         <button
           type="button"
           onClick={onNewSession}
-          className="inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          className="inline-flex items-center gap-1.5 rounded-md px-2 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 lg:px-2.5"
           aria-label="Nieuw gesprek"
         >
-          <Plus className="h-3.5 w-3.5" />
-          <span className="hidden sm:inline">Nieuw gesprek</span>
+          <Plus className="h-4 w-4 lg:h-3.5 lg:w-3.5" />
+          <span className="hidden lg:inline">Nieuw gesprek</span>
         </button>
       </div>
     </header>
@@ -485,6 +486,7 @@ function ChatSessionSurface({
   surfaceConfig: ChatSurfaceConfig;
 }) {
   const cvUpload = useChatCvUpload({ onSendMessage: sendMessage });
+  const hasUserMessage = messages.some((m) => m.role === "user");
 
   return (
     <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
@@ -522,6 +524,8 @@ function ChatSessionSurface({
         composerHint={surfaceConfig.composerHint}
         composerContextHint={surfaceConfig.composerContextHint}
       />
+
+      {!hasUserMessage ? <QuickActionChips onSelect={onSuggestion} /> : null}
     </div>
   );
 }

--- a/components/job-list-item.tsx
+++ b/components/job-list-item.tsx
@@ -1,12 +1,4 @@
-import {
-  ArrowRight,
-  BriefcaseBusiness,
-  Building2,
-  Clock,
-  LoaderCircle,
-  MapPin,
-  Users,
-} from "lucide-react";
+import { Bookmark, Clock, LoaderCircle, MapPin, Users } from "lucide-react";
 import Link from "next/link";
 import { memo } from "react";
 import { CompanyLogo } from "@/components/company-logo";
@@ -45,6 +37,23 @@ const arrangementLabels: Record<string, string> = {
   op_locatie: "Op locatie",
   remote: "Remote",
 };
+
+const arrangementSentence: Record<string, string> = {
+  hybride: "Hybride werken",
+  op_locatie: "Op locatie",
+  remote: "Thuiswerken",
+};
+
+function formatLocationSentence(
+  workArrangement: string | null,
+  location: string | null,
+): string | null {
+  const prefix = workArrangement ? arrangementSentence[workArrangement] : null;
+  if (prefix && location) return `${prefix} in ${location}`;
+  if (prefix) return prefix;
+  if (location) return location;
+  return null;
+}
 
 const contractLabels: Record<string, string> = {
   freelance: "Freelance",
@@ -128,6 +137,7 @@ export const JobListItem = memo(function JobListItem({
     : "Bekijk en koppel";
 
   if (variant === "card") {
+    const locationSentence = formatLocationSentence(job.workArrangement, job.location);
     return (
       <DroppableVacancy jobId={job.id} jobTitle={job.title}>
         <Link href={detailHref} className="block min-w-0">
@@ -137,8 +147,23 @@ export const JobListItem = memo(function JobListItem({
               isActive && "border-primary/70 ring-2 ring-primary/20",
             )}
           >
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
-              <div className="flex min-w-0 items-start gap-3">
+            <div className="mb-2 flex items-start justify-between gap-3">
+              <Badge
+                variant="outline"
+                className="rounded-md border-primary/20 bg-primary/10 px-2 py-0.5 text-[11px] font-semibold text-primary"
+              >
+                Eenvoudig solliciteren
+              </Badge>
+              <span
+                aria-hidden="true"
+                className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                <Bookmark className="h-4 w-4" />
+              </span>
+            </div>
+
+            <div className="flex min-w-0 items-start gap-3">
+              <div className="hidden sm:block">
                 <CompanyLogo
                   src={job.companyLogoUrl}
                   companyName={job.company}
@@ -147,95 +172,75 @@ export const JobListItem = memo(function JobListItem({
                   priority={priority}
                   blur
                 />
-                <div className="min-w-0">
-                  <h3 className="text-base font-semibold leading-tight text-foreground line-clamp-2 wrap-break-word sm:text-lg">
-                    {job.title}
-                  </h3>
-                  <p className="mt-1 flex min-w-0 items-start gap-1.5 text-sm text-muted-foreground">
-                    <Building2 className="h-3.5 w-3.5 shrink-0" />
-                    <span className="max-w-full whitespace-normal wrap-break-word">
-                      {job.company || "Onbekend"}
-                    </span>
-                  </p>
-                </div>
               </div>
-              <div className="flex w-full min-w-0 flex-wrap items-center gap-2 sm:w-auto sm:shrink-0 sm:flex-col sm:items-end">
-                <span className="inline-flex max-w-full whitespace-normal wrap-break-word items-center rounded-full border border-primary/30 bg-primary/10 px-2.5 py-1 text-left text-xs font-medium capitalize text-primary sm:px-3">
-                  {job.platform}
-                </span>
-                {deadlineMeta ? (
-                  <Badge
-                    variant="outline"
-                    className={cn(
-                      "max-w-full whitespace-normal wrap-break-word gap-1 px-2 py-1 text-left text-[10px]",
-                      deadlineMeta.className,
-                    )}
-                  >
-                    <Clock className="h-3 w-3 shrink-0" />
-                    {deadlineMeta.label}
-                  </Badge>
+              <div className="min-w-0 flex-1">
+                <h3 className="text-[17px] font-semibold leading-snug text-foreground line-clamp-2 wrap-break-word sm:text-lg">
+                  {job.title}
+                </h3>
+                <p className="mt-1 text-sm text-muted-foreground">{job.company || "Onbekend"}</p>
+                {locationSentence ? (
+                  <p className="mt-0.5 text-sm text-muted-foreground">{locationSentence}</p>
                 ) : null}
               </div>
             </div>
 
-            <div className="mt-2.5 flex flex-wrap items-start gap-2.5 text-sm text-muted-foreground sm:mt-3 sm:gap-3">
-              {job.location && (
-                <span className="inline-flex min-w-0 max-w-full items-start gap-1.5">
-                  <MapPin className="h-3.5 w-3.5 shrink-0" />
-                  <span className="max-w-full whitespace-normal wrap-break-word">
-                    {job.location}
-                  </span>
-                </span>
-              )}
-              {job.workArrangement && (
-                <span className="inline-flex max-w-full items-center gap-1.5 whitespace-normal wrap-break-word">
-                  <BriefcaseBusiness className="h-3.5 w-3.5 shrink-0" />
+            <div className="mt-3 flex flex-wrap items-center gap-1.5">
+              {job.contractType ? (
+                <Badge
+                  variant="outline"
+                  className="rounded-md border-border bg-muted/40 px-2 py-0.5 text-[11px] font-medium text-foreground"
+                >
+                  {contractLabels[job.contractType] ?? job.contractType}
+                </Badge>
+              ) : null}
+              {job.workArrangement ? (
+                <Badge
+                  variant="outline"
+                  className={cn(
+                    "rounded-md border-border bg-muted/40 px-2 py-0.5 text-[11px] font-medium text-foreground",
+                    job.workArrangement === "remote" &&
+                      "border-primary/30 bg-primary/10 text-primary",
+                  )}
+                >
                   {arrangementLabels[job.workArrangement] ?? job.workArrangement}
-                </span>
-              )}
+                </Badge>
+              ) : null}
+              {deadlineMeta ? (
+                <Badge
+                  variant="outline"
+                  className={cn("gap-1 rounded-md px-2 py-0.5 text-[11px]", deadlineMeta.className)}
+                >
+                  <Clock className="h-3 w-3 shrink-0" />
+                  {deadlineMeta.label}
+                </Badge>
+              ) : null}
+              <Badge
+                variant="outline"
+                className="rounded-md border-border bg-background px-2 py-0.5 text-[11px] font-medium capitalize text-muted-foreground"
+              >
+                {job.platform}
+              </Badge>
+              {hasLinkedWorkflow ? (
+                <Badge
+                  variant="outline"
+                  className="flex items-center gap-1 rounded-md border-primary/20 bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary"
+                >
+                  <Users className="h-3 w-3" />
+                  {hasActivePipeline ? `${pipelineCount} in pipeline` : "Workflow gekoppeld"}
+                </Badge>
+              ) : null}
+              {job.isIndexing ? (
+                <Badge
+                  variant="outline"
+                  className="flex items-center gap-1 rounded-md border-amber-500/20 bg-amber-500/10 px-2 py-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-300"
+                >
+                  <LoaderCircle className="h-3 w-3 animate-spin" />
+                  Indexeren…
+                </Badge>
+              ) : null}
             </div>
 
-            <div className="mt-3 flex flex-col items-start gap-2.5 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
-              <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-                {job.isIndexing ? (
-                  <Badge
-                    variant="outline"
-                    className="flex min-h-5 h-auto max-w-full items-center gap-1 whitespace-normal wrap-break-word rounded-md border-amber-500/20 bg-amber-500/10 px-2 py-1 text-[10px] font-medium text-amber-700 dark:text-amber-300"
-                  >
-                    <LoaderCircle className="h-2.5 w-2.5 animate-spin" />
-                    Indexeren…
-                  </Badge>
-                ) : null}
-                {job.contractType && (
-                  <Badge
-                    variant="outline"
-                    className="min-h-5 h-auto max-w-full whitespace-normal wrap-break-word rounded-md border-border bg-background px-2 py-1 text-[10px] font-medium text-muted-foreground"
-                  >
-                    {contractLabels[job.contractType] ?? job.contractType}
-                  </Badge>
-                )}
-                {hasLinkedWorkflow ? (
-                  <Badge
-                    variant="outline"
-                    className="flex min-h-5 h-auto max-w-full items-center gap-0.5 whitespace-normal wrap-break-word rounded-md border-primary/20 bg-primary/10 px-2 py-1 text-[10px] font-medium text-primary"
-                  >
-                    <Users className="h-2.5 w-2.5" />
-                    {hasActivePipeline ? `${pipelineCount} in de pipeline` : "Workflow gekoppeld"}
-                  </Badge>
-                ) : (
-                  <Badge
-                    variant="outline"
-                    className="min-h-5 h-auto max-w-full whitespace-normal wrap-break-word rounded-md border-dashed border-border bg-background px-2 py-1 text-[10px] font-medium text-muted-foreground"
-                  >
-                    Nog te koppelen
-                  </Badge>
-                )}
-              </div>
-              <span className="inline-flex w-full items-center justify-end gap-1 text-xs font-medium text-primary sm:w-auto sm:text-sm">
-                {actionLabel}
-                <ArrowRight className="h-4 w-4" />
-              </span>
-            </div>
+            <span className="sr-only">{actionLabel}</span>
           </article>
         </Link>
       </DroppableVacancy>

--- a/components/opdrachten-sidebar.tsx
+++ b/components/opdrachten-sidebar.tsx
@@ -230,6 +230,7 @@ export function OpdrachtenSidebar({
               totalPages={totalPages}
               pushParams={pushParams}
               variant="overview"
+              searchTerm={inputValue}
             />
             <div className="grid w-full grid-cols-2 gap-2 sm:flex sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
               <div className="flex items-center gap-1.5 sm:gap-2">

--- a/components/sidebar/mobile-filter-chips.tsx
+++ b/components/sidebar/mobile-filter-chips.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+/**
+ * Horizontal scrollable filter chips shown on the /vacatures overview page on
+ * mobile (< lg). First chip opens the full filter drawer; subsequent chips
+ * reflect or toggle individual filters via the same state already owned by
+ * useSidebarFilters.
+ */
+import { SlidersHorizontal } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import { CONTRACT_TYPES } from "./sidebar-types";
+
+interface MobileFilterChipsProps {
+  activeFilterCount: number;
+  onOpenFilters: () => void;
+  rateMin: string;
+  rateMax: string;
+  hoursMin: string;
+  hoursMax: string;
+  contractType: string;
+  onContractTypeChange: (value: string) => void;
+  inputValue: string;
+  onInputChange: (value: string) => void;
+}
+
+const THUISWERKEN_TOKEN = "thuiswerken";
+
+export function MobileFilterChips({
+  activeFilterCount,
+  onOpenFilters,
+  rateMin,
+  rateMax,
+  hoursMin,
+  hoursMax,
+  contractType,
+  onContractTypeChange,
+  inputValue,
+  onInputChange,
+}: MobileFilterChipsProps) {
+  const hasRate = Boolean(rateMin || rateMax);
+  const hasHours = Boolean(hoursMin || hoursMax);
+  const hasContract = Boolean(contractType);
+  const thuiswerkenActive = inputValue.toLowerCase().includes(THUISWERKEN_TOKEN);
+
+  const rateLabel = hasRate ? `€${rateMin || "?"}–${rateMax || "?"}` : "Salaris";
+  const hoursLabel = hasHours ? `${hoursMin || "?"}–${hoursMax || "?"} uur` : "Uren";
+  const contractLabel = hasContract
+    ? (CONTRACT_TYPES.find((c) => c.value === contractType)?.label ?? "Contract")
+    : "Contract";
+
+  const toggleThuiswerken = () => {
+    if (thuiswerkenActive) {
+      const next = inputValue
+        .replace(new RegExp(`\\b${THUISWERKEN_TOKEN}\\b`, "gi"), "")
+        .replace(/\s{2,}/g, " ")
+        .trim();
+      onInputChange(next);
+    } else {
+      const next = inputValue ? `${inputValue.trim()} ${THUISWERKEN_TOKEN}` : THUISWERKEN_TOKEN;
+      onInputChange(next);
+    }
+  };
+
+  return (
+    <div className="-mx-3 overflow-x-auto px-3 pb-1 lg:hidden">
+      <div className="flex min-w-max items-center gap-2">
+        <button
+          type="button"
+          onClick={onOpenFilters}
+          aria-label="Alle filters openen"
+          className={cn(
+            "inline-flex h-10 shrink-0 items-center justify-center rounded-full border border-border bg-background px-3 text-foreground shadow-sm",
+            activeFilterCount > 0 && "border-primary/40 bg-primary/10 text-primary",
+          )}
+        >
+          <SlidersHorizontal className="h-4 w-4" />
+          {activeFilterCount > 0 ? (
+            <span className="ml-1 text-xs font-semibold">{activeFilterCount}</span>
+          ) : null}
+        </button>
+
+        <ChipButton active={hasRate} onClick={onOpenFilters}>
+          {rateLabel}
+        </ChipButton>
+
+        <ChipButton active={thuiswerkenActive} onClick={toggleThuiswerken}>
+          Thuiswerken
+        </ChipButton>
+
+        <Select
+          value={contractType || "__all__"}
+          onValueChange={(v) => onContractTypeChange(v === "__all__" ? "" : v)}
+        >
+          <SelectTrigger
+            aria-label="Contract type"
+            className={cn(
+              "h-10 shrink-0 rounded-full border-border bg-background px-3 text-sm font-medium text-foreground shadow-sm data-[size=default]:h-10",
+              hasContract && "border-primary/40 bg-primary/10 text-primary",
+            )}
+          >
+            <SelectValue>{contractLabel}</SelectValue>
+          </SelectTrigger>
+          <SelectContent className="border-border bg-card">
+            <SelectItem value="__all__">Alle types</SelectItem>
+            {CONTRACT_TYPES.map((type) => (
+              <SelectItem key={type.value} value={type.value}>
+                {type.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <ChipButton active={hasHours} onClick={onOpenFilters}>
+          {hoursLabel}
+        </ChipButton>
+      </div>
+    </div>
+  );
+}
+
+function ChipButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex h-10 shrink-0 items-center justify-center whitespace-nowrap rounded-full border border-border bg-background px-3.5 text-sm font-medium text-foreground shadow-sm",
+        active && "border-primary/40 bg-primary/10 text-primary",
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/components/sidebar/mobile-filter-chips.tsx
+++ b/components/sidebar/mobile-filter-chips.tsx
@@ -19,6 +19,7 @@ import { CONTRACT_TYPES } from "./sidebar-types";
 
 interface MobileFilterChipsProps {
   activeFilterCount: number;
+  mobileFiltersOpen: boolean;
   onOpenFilters: () => void;
   rateMin: string;
   rateMax: string;
@@ -34,6 +35,7 @@ const THUISWERKEN_TOKEN = "thuiswerken";
 
 export function MobileFilterChips({
   activeFilterCount,
+  mobileFiltersOpen,
   onOpenFilters,
   rateMin,
   rateMax,
@@ -74,7 +76,9 @@ export function MobileFilterChips({
         <button
           type="button"
           onClick={onOpenFilters}
-          aria-label="Alle filters openen"
+          aria-expanded={mobileFiltersOpen}
+          aria-controls="opdrachten-mobile-filters"
+          aria-label={mobileFiltersOpen ? "Filters sluiten" : "Filters openen"}
           className={cn(
             "inline-flex h-10 shrink-0 items-center justify-center rounded-full border border-border bg-background px-3 text-foreground shadow-sm",
             activeFilterCount > 0 && "border-primary/40 bg-primary/10 text-primary",

--- a/components/sidebar/overview-filter-panel.tsx
+++ b/components/sidebar/overview-filter-panel.tsx
@@ -152,6 +152,7 @@ export function OverviewFilterPanel({
 
         <MobileFilterChips
           activeFilterCount={activeFilterCount}
+          mobileFiltersOpen={mobileFiltersOpen}
           onOpenFilters={onToggleMobileFilters}
           rateMin={rateMinInput}
           rateMax={rateMaxInput}

--- a/components/sidebar/overview-filter-panel.tsx
+++ b/components/sidebar/overview-filter-panel.tsx
@@ -3,8 +3,8 @@
 /**
  * Full filter panel used on the overview (/vacatures) page.
  */
-import { ChevronDown, RotateCcw } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
+import { RotateCcw } from "lucide-react";
+import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { SearchableCombobox } from "@/components/ui/searchable-combobox";
 import {
@@ -16,11 +16,13 @@ import {
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import { OPDRACHTEN_PROVINCES } from "@/src/lib/opdrachten-filters";
+import { MobileFilterChips } from "./mobile-filter-chips";
 import {
   CompactMultiSelectFilter,
   FilterChecklist,
   RadiusSliderField,
 } from "./sidebar-filter-controls";
+import { resolveLocationInputToProvince } from "./sidebar-location-input";
 import { SidebarSearchBar } from "./sidebar-search-bar";
 import type { FilterOption, ProvinceAnchor } from "./sidebar-types";
 import { CONTRACT_TYPES } from "./sidebar-types";
@@ -76,7 +78,7 @@ export function OverviewFilterPanel({
   mobileFiltersOpen,
   onToggleMobileFilters,
   activeFilterCount,
-  displayTotal,
+  displayTotal: _displayTotal,
   selectedPlatforms,
   platforms,
   endClient,
@@ -110,9 +112,20 @@ export function OverviewFilterPanel({
   onlyShortlist,
   onOnlyShortlistChange,
 }: OverviewFilterPanelProps) {
+  const [locationInput, setLocationInput] = useState(provincie);
+  useEffect(() => {
+    setLocationInput(provincie);
+  }, [provincie]);
+  const handleLocationInputChange = (value: string) => {
+    setLocationInput(value);
+    const resolved = resolveLocationInputToProvince(value);
+    if (resolved === null && provincie) onProvinceChange("__all__");
+    else if (resolved && resolved !== provincie) onProvinceChange(resolved);
+  };
+
   return (
     <div className="flex min-h-0 flex-col border-b border-border/70 px-3 py-2 sm:px-4 sm:py-5 lg:border-b-0 lg:border-r lg:px-5 lg:py-6">
-      <div className="mb-2 flex flex-wrap items-center justify-between gap-2 sm:mb-4">
+      <div className="mb-2 hidden flex-wrap items-center justify-between gap-2 sm:mb-4 lg:flex">
         <h3 className="text-base font-semibold tracking-tight text-foreground sm:text-xl lg:text-2xl">
           Zoekfilter
         </h3>
@@ -133,46 +146,44 @@ export function OverviewFilterPanel({
           onChange={onInputChange}
           isFetching={isFetching}
           variant="overview"
+          locationValue={locationInput}
+          onLocationChange={handleLocationInputChange}
         />
 
-        <button
-          type="button"
-          aria-expanded={mobileFiltersOpen}
-          aria-controls="opdrachten-mobile-filters"
-          className="inline-flex min-h-9 w-full items-center justify-between rounded-lg border border-border bg-background px-2.5 text-xs font-medium text-foreground shadow-sm sm:min-h-11 sm:px-3 sm:text-sm lg:hidden"
-          onClick={onToggleMobileFilters}
-        >
-          <span className="min-w-0 truncate">
-            {mobileFiltersOpen ? "Filters sluiten" : "Filters openen"}
-            {activeFilterCount > 0 ? ` (${activeFilterCount} actief)` : ""}
-          </span>
-          <ChevronDown
-            className={cn(
-              "h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform sm:h-4 sm:w-4",
-              mobileFiltersOpen && "rotate-180",
-            )}
-          />
-        </button>
-
-        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground lg:hidden">
-          <span>{displayTotal} resultaten</span>
-          {activeFilterCount > 0 ? (
-            <Badge
-              variant="outline"
-              className="max-w-full whitespace-normal wrap-break-word border-primary/20 bg-primary/10 px-2 py-0.5 text-[11px] text-primary"
-            >
-              {activeFilterCount} filters actief
-            </Badge>
-          ) : null}
-        </div>
+        <MobileFilterChips
+          activeFilterCount={activeFilterCount}
+          onOpenFilters={onToggleMobileFilters}
+          rateMin={rateMinInput}
+          rateMax={rateMaxInput}
+          hoursMin={hoursMinInput}
+          hoursMax={hoursMaxInput}
+          contractType={contractType}
+          onContractTypeChange={(v) => onFilterChange("contractType", v)}
+          inputValue={inputValue}
+          onInputChange={onInputChange}
+        />
 
         <div
           id="opdrachten-mobile-filters"
           className={cn(
             "min-h-0 space-y-2 overflow-y-auto rounded-xl border border-border/70 bg-background/60 p-2.5 sm:space-y-3 sm:p-3 lg:flex-1 lg:rounded-none lg:border-0 lg:bg-transparent lg:p-0 lg:space-y-4",
-            mobileFiltersOpen ? "max-h-[40vh] lg:max-h-none" : "hidden lg:block",
+            mobileFiltersOpen ? "max-h-[60vh] lg:max-h-none" : "hidden lg:block",
           )}
         >
+          <div className="flex items-center justify-between gap-2 lg:hidden">
+            <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              Alle filters
+            </span>
+            <button
+              type="button"
+              onClick={onResetFilters}
+              className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-xs font-semibold uppercase tracking-wide text-primary hover:bg-primary/5"
+            >
+              <RotateCcw className="h-3 w-3" />
+              Wissen
+            </button>
+          </div>
+
           <VacatureFilterExtras
             onlyShortlist={onlyShortlist}
             onOnlyShortlistChange={onOnlyShortlistChange}

--- a/components/sidebar/sidebar-job-list.tsx
+++ b/components/sidebar/sidebar-job-list.tsx
@@ -74,7 +74,7 @@ export function SidebarJobList({ jobs, activeId, buildDetailHref, variant }: Sid
           Geen vacatures gevonden voor deze filters.
         </div>
       ) : (
-        <div className="space-y-3 pb-4 sm:space-y-4">
+        <div className="space-y-2 pb-4 sm:space-y-4">
           {jobs.map((job, index) => renderJob(job, index))}
         </div>
       )}

--- a/components/sidebar/sidebar-location-input.ts
+++ b/components/sidebar/sidebar-location-input.ts
@@ -1,0 +1,15 @@
+import { OPDRACHTEN_PROVINCES } from "@/src/lib/opdrachten-filters";
+
+/**
+ * Maps a free-text location input to the province filter value.
+ * Returns the matched province when the input equals one of
+ * OPDRACHTEN_PROVINCES (case-insensitive), or null when the input
+ * is empty. Returns undefined when the input is non-empty but does
+ * not match any province — callers should treat this as a no-op.
+ */
+export function resolveLocationInputToProvince(value: string): string | null | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const normalized = trimmed.toLowerCase();
+  return OPDRACHTEN_PROVINCES.find((p) => p.toLowerCase() === normalized);
+}

--- a/components/sidebar/sidebar-results-header.tsx
+++ b/components/sidebar/sidebar-results-header.tsx
@@ -28,6 +28,7 @@ interface SidebarResultsHeaderProps {
   totalPages: number;
   pushParams: PushParamsFn;
   variant: "compact" | "overview";
+  searchTerm?: string;
 }
 
 export function SidebarResultsHeader({
@@ -39,6 +40,7 @@ export function SidebarResultsHeader({
   totalPages,
   pushParams,
   variant,
+  searchTerm,
 }: SidebarResultsHeaderProps) {
   const handlePageSizeChange = (v: string) => {
     pushParams({
@@ -94,9 +96,16 @@ export function SidebarResultsHeader({
     );
   }
 
+  const trimmedTerm = searchTerm?.trim();
+
   return (
     <div className="min-w-0">
-      {/* Mobile: single compact line with count + badges inline */}
+      {trimmedTerm ? (
+        <p className="mb-1 text-sm text-muted-foreground">
+          <span className="text-foreground">{trimmedTerm}</span> vacatures · {displayTotal}{" "}
+          resultaten
+        </p>
+      ) : null}
       <div className="flex flex-wrap items-center gap-x-2 gap-y-1 sm:flex-col sm:items-start sm:gap-2">
         <div className="text-sm font-semibold text-foreground sm:text-lg">
           {displayTotal} vacatures

--- a/components/sidebar/sidebar-search-bar.tsx
+++ b/components/sidebar/sidebar-search-bar.tsx
@@ -3,7 +3,7 @@
 /**
  * Search input bar for the sidebar, supporting both compact (dark) and overview variants.
  */
-import { Loader2, Search } from "lucide-react";
+import { Loader2, MapPin, Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { DARK_FILTER_CONTROL_CLASS } from "./sidebar-types";
@@ -13,9 +13,18 @@ interface SidebarSearchBarProps {
   onChange: (value: string) => void;
   isFetching: boolean;
   variant: "compact" | "overview";
+  locationValue?: string;
+  onLocationChange?: (value: string) => void;
 }
 
-export function SidebarSearchBar({ value, onChange, isFetching, variant }: SidebarSearchBarProps) {
+export function SidebarSearchBar({
+  value,
+  onChange,
+  isFetching,
+  variant,
+  locationValue,
+  onLocationChange,
+}: SidebarSearchBarProps) {
   if (variant === "compact") {
     return (
       <div className="shrink-0 px-4 pb-3 pt-3">
@@ -36,26 +45,35 @@ export function SidebarSearchBar({ value, onChange, isFetching, variant }: Sideb
   }
 
   return (
-    <div>
-      <label
-        htmlFor="opdrachten-zoekterm"
-        className="mb-2 block text-sm font-medium text-foreground"
-      >
-        Zoekterm
-      </label>
+    <div className="space-y-2">
       <div className="relative">
-        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Search className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           id="opdrachten-zoekterm"
+          aria-label="Zoek vacature"
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder="Zoek vacature..."
-          className="h-11 rounded-lg border-border bg-background pl-10 text-sm"
+          className="h-11 rounded-xl border-border bg-background pl-10 text-sm shadow-sm"
         />
         {isFetching && (
           <Loader2 className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-muted-foreground" />
         )}
       </div>
+      {onLocationChange ? (
+        <div className="relative">
+          <MapPin className="pointer-events-none absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            id="opdrachten-locatie-input"
+            aria-label="Plaats, provincie of 'thuiswerken'"
+            value={locationValue ?? ""}
+            onChange={(e) => onLocationChange(e.target.value)}
+            placeholder="Plaats, provincie of 'thuiswerken'"
+            className="h-11 rounded-xl border-border bg-background pl-10 text-sm shadow-sm"
+            autoComplete="off"
+          />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/components/ai-elements/chat-prompt-composer.tsx
+++ b/src/components/ai-elements/chat-prompt-composer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ChatStatus } from "ai";
-import { ArrowUp, Gauge, Loader2, Mic, Square, Upload, Zap } from "lucide-react";
+import { ArrowUp, Gauge, Loader2, Mic, Plus, Square, Upload, Zap } from "lucide-react";
 import { useCallback, useId } from "react";
 import {
   PromptInput,
@@ -109,7 +109,7 @@ export function ChatPromptComposer({
           variant="page"
         />
 
-        <div className="rounded-[28px] border border-border/70 bg-background shadow-sm transition-shadow focus-within:ring-2 focus-within:ring-ring/20">
+        <div className="rounded-3xl border border-border/70 bg-background shadow-sm transition-shadow focus-within:ring-2 focus-within:ring-ring/20 lg:rounded-[28px]">
           <PromptInput
             accept={CV_UPLOAD_ACCEPT}
             globalDrop
@@ -129,13 +129,14 @@ export function ChatPromptComposer({
               <PromptInputTools className="flex-1 flex-wrap">
                 <PromptInputButton
                   aria-label="CV uploaden (PDF of Word)"
-                  className="gap-1.5 rounded-full px-3 text-xs"
+                  className="gap-1.5 rounded-full px-2 text-xs lg:px-3"
                   disabled={cvUpload.uploadState === "uploading"}
                   onClick={cvUpload.openFileDialog}
                   tooltip="CV uploaden (PDF of Word)"
                 >
-                  <Upload className="h-3.5 w-3.5" />
-                  <span>CV uploaden</span>
+                  <Plus className="h-4 w-4 lg:hidden" />
+                  <Upload className="hidden h-3.5 w-3.5 lg:inline-block" />
+                  <span className="hidden lg:inline">CV uploaden</span>
                 </PromptInputButton>
 
                 <PromptInputSelect onValueChange={onModelIdChange} value={modelId}>
@@ -158,7 +159,7 @@ export function ChatPromptComposer({
                 </PromptInputSelect>
 
                 <PromptInputSelect onValueChange={onSpeedModeChange} value={speedMode}>
-                  <PromptInputSelectTrigger className="h-8 w-auto gap-1 px-2 text-xs">
+                  <PromptInputSelectTrigger className="hidden h-8 w-auto gap-1 px-2 text-xs lg:inline-flex">
                     <Gauge className="h-3.5 w-3.5" />
                     <PromptInputSelectValue />
                   </PromptInputSelectTrigger>

--- a/src/components/ai-elements/quick-action-chips.tsx
+++ b/src/components/ai-elements/quick-action-chips.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+/**
+ * Horizontal scrollable recruitment quick-actions shown under the chat composer
+ * when no conversation has started yet. Clicking a chip submits a prefilled
+ * prompt via the existing suggestion handler.
+ */
+import { Calendar, FileText, PenSquare, Search, Users } from "lucide-react";
+import type { ComponentType, SVGProps } from "react";
+import { Suggestion, Suggestions } from "./suggestion";
+
+type Chip = {
+  label: string;
+  prompt: string;
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+};
+
+const CHIPS: Chip[] = [
+  {
+    label: "Schrijf vacaturetekst",
+    prompt: "Help me een vacaturetekst schrijven voor een nieuwe rol.",
+    icon: PenSquare,
+  },
+  {
+    label: "Zoek vacatures",
+    prompt: "Zoek open vacatures die passen bij mijn shortlist.",
+    icon: Search,
+  },
+  {
+    label: "Zoek kandidaten",
+    prompt: "Toon kandidaten met hun vaardigheden en recente activiteit.",
+    icon: Users,
+  },
+  {
+    label: "CV analyseren",
+    prompt: "Hoe kan ik een CV uploaden en laten analyseren?",
+    icon: FileText,
+  },
+  {
+    label: "Plan interview",
+    prompt: "Help me een interviewafspraak in te plannen voor een kandidaat.",
+    icon: Calendar,
+  },
+];
+
+interface QuickActionChipsProps {
+  onSelect?: (prompt: string) => void;
+}
+
+export function QuickActionChips({ onSelect }: QuickActionChipsProps) {
+  if (!onSelect) return null;
+
+  return (
+    <div className="mx-auto w-full max-w-4xl px-3 pb-3 sm:px-4 sm:pb-4">
+      <Suggestions>
+        {CHIPS.map((chip) => {
+          const Icon = chip.icon;
+          return (
+            <Suggestion key={chip.label} suggestion={chip.prompt} onClick={onSelect}>
+              <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+              {chip.label}
+            </Suggestion>
+          );
+        })}
+      </Suggestions>
+    </div>
+  );
+}

--- a/tests/opdrachten-filters-pagination.test.ts
+++ b/tests/opdrachten-filters-pagination.test.ts
@@ -433,10 +433,12 @@ describe("Opdrachten UI/API contracts", () => {
     expect(sidebar).toContain("Filters openen");
     expect(sidebar).toContain("Filters sluiten");
     expect(sidebar).toContain('id="opdrachten-mobile-filters"');
-    expect(listItem).toContain("flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between");
-    expect(listItem).toContain(
-      "flex flex-col items-start gap-2.5 sm:flex-row sm:items-center sm:justify-between",
-    );
+    // Mobile filter chips row is the new mobile-only filter entry point
+    expect(sidebar).toContain("MobileFilterChips");
+    // Indeed-style job card markers
+    expect(listItem).toContain("Eenvoudig solliciteren");
+    expect(listItem).toContain("Bookmark");
+    expect(listItem).toContain("mb-2 flex items-start justify-between");
     expect(listItem).toContain('<Link href={detailHref} className="block min-w-0">');
     expect(listItem).toContain(
       "w-full min-w-0 overflow-hidden rounded-xl border border-border/80 bg-card",


### PR DESCRIPTION
## Summary

Mobile-first redesign for two surfaces, based on the user-supplied screenshots (Indeed job list + Claude.ai home). Desktop keeps its 2-column shell but also picks up the cleaner card/badge styling.

### `/vacatures`
- New Indeed-like job card: "Eenvoudig solliciteren" badge, bookmark icon, "Hybride werken in X" location line, and pill badges for arrangement / contract / deadline / platform / pipeline.
- Search bar drops its label and adds a functional location input — free text matching one of the 12 provinces sets the existing `provincie` filter via a new `resolveLocationInputToProvince` helper. No new URL params or schema changes.
- New horizontal `MobileFilterChips` row (`lg:hidden`): filter icon → full drawer, "Salaris" / "Uren" → scroll drawer, "Thuiswerken" → toggles a `thuiswerken` token in the search query, "Contract" → inline `Select` over existing `CONTRACT_TYPES`.
- Results header now renders `{term} vacatures · {total} resultaten` when the user has typed a query.
- Tightened mobile gap in the job list (`space-y-2` vs `space-y-4` on desktop).

### `/chat`
- Header: title/subtitle/context-badge block is `hidden` on mobile; "Nieuw gesprek" collapses to an icon-only `Plus` button below `lg`.
- Empty state: on mobile, the bordered card + 6-card grid is replaced by a centered `Goedemiddag, {naam}` greeting using a new `getDutchGreeting()` helper. Desktop keeps the existing card + grid but picks up the same greeting copy when a name is available.
- Composer: `CV uploaden` label swaps to a `+` icon on mobile, speed-mode select is hidden on mobile, outer card uses `rounded-3xl` on mobile. Model select stays visible in the centre with its chevron.
- New `QuickActionChips` row rendered under the composer while no user message exists: **Schrijf vacaturetekst**, **Zoek vacatures**, **Zoek kandidaten**, **CV analyseren**, **Plan interview**. Reuses the existing `Suggestion` primitive and the `onSuggestion` prop already threaded through `ChatSessionSurface`.

## Scope notes

- No DB / service / schema changes. Only UI files under `components/` and `src/components/ai-elements/`.
- Location input reuses the existing `provincie` + `straalKm` filter state. "Thuiswerken" toggles a search token — a real `workArrangement` filter is out of scope for this PR.
- `userFirstName` is plumbed through `ChatMessages` as an optional prop — callers can pass it later without another PR.

## Test plan

- [x] `pnpm lint` — clean (Biome, 883 files, no warnings).
- [x] `pnpm exec tsc --noEmit` — clean.
- [x] `pnpm test --run tests/sidebar-decomposition.test.ts` — 15/15 pass (previous run hit the 550-line cap on `use-sidebar-filters.ts`; resolved by extracting `resolveLocationInputToProvince` into `components/sidebar/sidebar-location-input.ts`).
- [x] Full `pnpm test --run` — 1498 pass, 5 pre-existing sandbox failures in `tests/harness/orchestrator.test.ts` + `tests/harness/integration.test.ts` (all "git commit -m init" setup errors, unrelated to these changes and documented in `CLAUDE.md`).
- [ ] Manual mobile QA at 390×844 (iPhone 14):
  - [ ] `/vacatures`: search + location inputs visible, chip row scrolls, tapping filter icon opens the drawer, job cards render with the new layout.
  - [ ] `/chat`: top bar shows only menu-left + `+` icon right; centered greeting; composer with `+` / model / mic; chips below; after the first user message the greeting + chips disappear.
- [ ] Desktop (`≥ lg`) regression check for both pages.
- [ ] Dark-mode spot check.

https://claude.ai/code/session_01Aeg7tNCW6gF7qjuRXpqcuL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Personalized Dutch greetings in chat when user names are available
  * Quick action chips offering common recruitment tasks in chat
  * Location search input for filtering by place, province, or remote work
  * Mobile-optimized filter controls for salary, hours, and contract type
  * Redesigned job card layout with simplified work arrangement and location display

* **UI Improvements**
  * Enhanced mobile responsiveness across chat, filters, and navigation
  * Improved job card metadata organization and visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->