### PR TITLE
feat(overzicht): AI-powered trend analysis &amp; opportunity detection

### DIFF
--- a/app/overzicht/page.tsx
+++ b/app/overzicht/page.tsx
@@ -11,17 +11,20 @@ import {
   Kanban,
   MapPin,
   RefreshCw,
+  Sparkles,
   TrendingUp,
   Users,
 } from "lucide-react";
 import nextDynamic from "next/dynamic";
 import Link from "next/link";
 import { type ReactNode, Suspense } from "react";
+import { AiInsightsCard } from "@/components/overview/ai-insights-card";
 import { PipelineHealthCard } from "@/components/overview/pipeline-health-card";
 import { PageHeader } from "@/components/page-header";
 import { KPICard } from "@/components/shared/kpi-card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { getTrendInsights } from "@/src/services/trend-insights";
 
 const KpiTrendChart = nextDynamic(
   () => import("@/components/overview/kpi-trend-chart").then((m) => ({ default: m.KpiTrendChart })),
@@ -152,6 +155,12 @@ async function DashboardContent() {
           href="/interviews"
         />
       </div>
+
+      <DashboardCard title="AI-analyse & kansen" icon={<Sparkles className="h-4 w-4" />}>
+        <Suspense fallback={<AiInsightsSkeleton />}>
+          <AiInsightsSection />
+        </Suspense>
+      </DashboardCard>
 
       <DashboardCard title="Trend (30 dagen)" icon={<TrendingUp className="h-4 w-4" />}>
         <KpiTrendChart data={[]} />
@@ -421,6 +430,25 @@ async function DashboardContent() {
         </DashboardCard>
       </div>
     </>
+  );
+}
+
+async function AiInsightsSection() {
+  const result = await getTrendInsights();
+  return <AiInsightsCard result={result} />;
+}
+
+function AiInsightsSkeleton() {
+  return (
+    <div className="space-y-3">
+      <Skeleton className="h-4 w-2/3" />
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+          <Skeleton key={i} className="h-32 rounded-lg" />
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/components/overview/ai-insights-card.tsx
+++ b/components/overview/ai-insights-card.tsx
@@ -1,0 +1,130 @@
+import { AlertTriangle, ArrowRight, Lightbulb, Sparkles, TrendingUp } from "lucide-react";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import type { TrendInsight, TrendInsightsResult } from "@/src/services/trend-insights";
+
+const TYPE_STYLES: Record<
+  TrendInsight["type"],
+  { badge: string; iconClass: string; Icon: typeof Sparkles; label: string }
+> = {
+  kans: {
+    badge: "border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+    iconClass: "bg-emerald-500/10 text-emerald-600",
+    Icon: Lightbulb,
+    label: "Kans",
+  },
+  trend: {
+    badge: "border-blue-500/20 bg-blue-500/10 text-blue-600 dark:text-blue-400",
+    iconClass: "bg-blue-500/10 text-blue-600",
+    Icon: TrendingUp,
+    label: "Trend",
+  },
+  risico: {
+    badge: "border-red-500/20 bg-red-500/10 text-red-600 dark:text-red-400",
+    iconClass: "bg-red-500/10 text-red-600",
+    Icon: AlertTriangle,
+    label: "Risico",
+  },
+  actie: {
+    badge: "border-amber-500/20 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+    iconClass: "bg-amber-500/10 text-amber-600",
+    Icon: Sparkles,
+    label: "Actie",
+  },
+};
+
+const PRIORITY_STYLES: Record<TrendInsight["priority"], string> = {
+  hoog: "border-red-500/20 bg-red-500/10 text-red-600 dark:text-red-400",
+  gemiddeld: "border-yellow-500/20 bg-yellow-500/10 text-yellow-600 dark:text-yellow-400",
+  laag: "border-border bg-muted text-muted-foreground",
+};
+
+export function AiInsightsCard({ result }: { result: TrendInsightsResult }) {
+  if (result.insights.length === 0) {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm text-muted-foreground">{result.summary}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-sm text-muted-foreground">{result.summary}</p>
+        <Badge
+          variant="outline"
+          className="shrink-0 border-border text-[10px] uppercase tracking-wide text-muted-foreground"
+        >
+          {result.source === "ai" ? "AI-analyse" : "Regel-analyse"}
+        </Badge>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {result.insights.map((insight, index) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: AI-generated list is stable within a render and titles may repeat
+          <InsightTile key={`${insight.type}-${index}-${insight.title}`} insight={insight} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function InsightTile({ insight }: { insight: TrendInsight }) {
+  const typeStyle = TYPE_STYLES[insight.type];
+  const Icon = typeStyle.Icon;
+  const body = (
+    <div className="flex h-full flex-col rounded-lg border border-border bg-background/60 p-3 transition-colors hover:border-primary/30 hover:bg-accent">
+      <div className="flex items-start justify-between gap-3">
+        <div
+          className={`flex h-8 w-8 items-center justify-center rounded-lg ${typeStyle.iconClass}`}
+        >
+          <Icon className="h-4 w-4" />
+        </div>
+        <div className="flex flex-col items-end gap-1">
+          <Badge variant="outline" className={typeStyle.badge}>
+            {typeStyle.label}
+          </Badge>
+          <Badge variant="outline" className={PRIORITY_STYLES[insight.priority]}>
+            {insight.priority === "hoog"
+              ? "Hoog"
+              : insight.priority === "gemiddeld"
+                ? "Medium"
+                : "Laag"}
+          </Badge>
+        </div>
+      </div>
+
+      <h4 className="mt-3 text-sm font-semibold text-foreground">{insight.title}</h4>
+      <p className="mt-1 flex-1 text-xs leading-5 text-muted-foreground">{insight.description}</p>
+
+      {(insight.metricLabel || insight.metricValue) && (
+        <div className="mt-3 flex items-center justify-between rounded-md border border-border bg-muted/40 px-2 py-1.5">
+          <span className="text-[11px] uppercase tracking-wide text-muted-foreground">
+            {insight.metricLabel ?? "Metric"}
+          </span>
+          <span className="text-sm font-semibold text-foreground">
+            {insight.metricValue ?? "—"}
+          </span>
+        </div>
+      )}
+
+      {insight.href && (
+        <div className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-primary">
+          Open
+          <ArrowRight className="h-3 w-3" />
+        </div>
+      )}
+    </div>
+  );
+
+  if (insight.href) {
+    return (
+      <Link href={insight.href} className="h-full">
+        {body}
+      </Link>
+    );
+  }
+
+  return <div className="h-full">{body}</div>;
+}

--- a/src/services/trend-insights.ts
+++ b/src/services/trend-insights.ts
@@ -1,0 +1,587 @@
+import { unstable_cache } from "next/cache";
+import { z } from "zod";
+import { and, db, desc, eq, gte, isNull, lt, ne, sql } from "../db";
+import {
+  applications,
+  candidates,
+  interviews,
+  jobMatches,
+  jobs,
+  scrapeResults,
+} from "../db/schema";
+import { gemini31FlashLite, tracedGenerateObject as generateObject } from "../lib/ai-models";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export type TrendInsightType = "kans" | "trend" | "risico" | "actie";
+export type TrendInsightPriority = "hoog" | "gemiddeld" | "laag";
+
+export type TrendInsight = {
+  type: TrendInsightType;
+  title: string;
+  description: string;
+  priority: TrendInsightPriority;
+  metricLabel?: string;
+  metricValue?: string;
+  href?: string;
+};
+
+export type TrendInsightsResult = {
+  generatedAt: string;
+  source: "ai" | "fallback";
+  summary: string;
+  insights: TrendInsight[];
+};
+
+// ── Metrics ──────────────────────────────────────────────────────────
+
+export type PlatformInflow = {
+  platform: string;
+  lastWeek: number;
+  previousWeek: number;
+  deltaPct: number | null;
+};
+
+export type StageConversion = {
+  fromStage: string;
+  toStage: string;
+  conversionPct: number | null;
+  fromCount: number;
+  toCount: number;
+};
+
+export type TopOpenClient = {
+  client: string;
+  openCount: number;
+};
+
+export type TopOpenTitle = {
+  title: string;
+  openCount: number;
+};
+
+export type TrendMetrics = {
+  window: {
+    now: string;
+    sevenDaysAgo: string;
+    fourteenDaysAgo: string;
+    thirtyDaysAgo: string;
+  };
+  totals: {
+    openJobs: number;
+    activeCandidates: number;
+    applications30d: number;
+    applications7d: number;
+    placements30d: number;
+    matches30d: number;
+  };
+  platformInflow: PlatformInflow[];
+  stageCounts: Record<string, number>;
+  stageConversion: StageConversion[];
+  staleScreenings: number;
+  staleInterviews: number;
+  highScoreUnreviewedMatches: {
+    total: number;
+    averageScore: number | null;
+  };
+  upcomingInterviews7d: number;
+  recentScrapeFailures: number;
+  topOpenClients: TopOpenClient[];
+  topOpenTitles: TopOpenTitle[];
+  newCandidatesWithoutApplication: number;
+  matchScoreTrend: {
+    last7dAvg: number | null;
+    previous7dAvg: number | null;
+    deltaPoints: number | null;
+  };
+};
+
+function daysAgo(n: number): Date {
+  const date = new Date();
+  date.setDate(date.getDate() - n);
+  return date;
+}
+
+function pctChange(current: number, previous: number): number | null {
+  if (previous === 0) return current === 0 ? 0 : null;
+  return Math.round(((current - previous) / previous) * 100);
+}
+
+export async function collectTrendMetrics(database: typeof db = db): Promise<TrendMetrics> {
+  const now = new Date();
+  const sevenDaysAgo = daysAgo(7);
+  const fourteenDaysAgo = daysAgo(14);
+  const thirtyDaysAgo = daysAgo(30);
+  const visible = and(ne(jobs.status, "archived"), isNull(jobs.deletedAt));
+
+  const [
+    openJobsRes,
+    activeCandidatesRes,
+    applications30dRes,
+    applications7dRes,
+    placements30dRes,
+    matches30dRes,
+    platformInflowRaw,
+    stageCountsRaw,
+    stageTransitionsRaw,
+    staleScreeningsRes,
+    staleInterviewsRes,
+    highScoreUnreviewedRes,
+    upcomingInterviews7dRes,
+    recentScrapeFailuresRes,
+    topOpenClientsRaw,
+    topOpenTitlesRaw,
+    newCandidatesNoAppRes,
+    matchScoreLast7Res,
+    matchScorePrev7Res,
+  ] = await Promise.all([
+    database
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(jobs)
+      .where(and(eq(jobs.status, "open"), isNull(jobs.deletedAt))),
+
+    database
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(candidates)
+      .where(and(isNull(candidates.deletedAt), eq(candidates.matchingStatus, "open"))),
+
+    database
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(applications)
+      .where(and(isNull(applications.deletedAt), gte(applications.createdAt, thirtyDaysAgo))),
+
+    database
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(applications)
+      .where(and(isNull(applications.deletedAt), gte(applications.createdAt, sevenDaysAgo))),
+
+    database
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(applications)
+      .where(
+        and(
+          isNull(applications.deletedAt),
+          eq(applications.stage, "hired"),
+          gte(applications.updatedAt, thirtyDaysAgo),
+        ),
+      ),
+
+    database
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(jobMatches)
+      .where(gte(jobMatches.createdAt, thirtyDaysAgo)),
+
+    database
+      .select({
+        platform: jobs.platform,
+        lastWeek: sql<number>`cast(count(*) filter (where ${jobs.scrapedAt} >= ${sevenDaysAgo}) as integer)`,
+        previousWeek: sql<number>`cast(count(*) filter (where ${jobs.scrapedAt} >= ${fourteenDaysAgo} and ${jobs.scrapedAt} < ${sevenDaysAgo}) as integer)`,
+      })
+      .from(jobs)
+      .where(visible)
+      .groupBy(jobs.platform),
+
+    database
+      .select({
+        stage: applications.stage,
+        count: sql<number>`cast(count(*) as integer)`,
+      })
+      .from(applications)
+      .where(isNull(applications.deletedAt))
+      .groupBy(applications.stage),
+
+    database
+      .select({
+        stage: applications.stage,
+        count: sql<number>`cast(count(*) as integer)`,
+      })
+      .from(applications)
+      .where(and(isNull(applications.deletedAt), gte(applications.createdAt, thirtyDaysAgo)))
+      .groupBy(applications.stage),
+
+    database
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(applications)
+      .where(
+        and(
+          isNull(applications.deletedAt),
+          eq(applications.stage, "screening"),
+          lt(applications.updatedAt, fourteenDaysAgo),
+        ),
+      ),
+
+    database
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(applications)
+      .where(
+        and(
+          isNull(applications.deletedAt),
+          eq(applications.stage, "interview"),
+          lt(applications.updatedAt, fourteenDaysAgo),
+        ),
+      ),
+
+    database
+      .select({
+        count: sql<number>`cast(count(*) as integer)`,
+        averageScore: sql<number | null>`avg(${jobMatches.matchScore})`,
+      })
+      .from(jobMatches)
+      .where(and(gte(jobMatches.matchScore, 80), eq(jobMatches.status, "pending"))),
+
+    database
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(interviews)
+      .where(
+        and(
+          isNull(interviews.deletedAt),
+          eq(interviews.status, "scheduled"),
+          gte(interviews.scheduledAt, now),
+          lt(interviews.scheduledAt, daysAgo(-7)),
+        ),
+      ),
+
+    database
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(scrapeResults)
+      .where(
+        and(
+          gte(scrapeResults.runAt, sevenDaysAgo),
+          sql`(${scrapeResults.status} = 'failed' or jsonb_array_length(coalesce(${scrapeResults.errors}, '[]'::jsonb)) > 0)`,
+        ),
+      ),
+
+    database
+      .select({
+        client: sql<string | null>`coalesce(${jobs.endClient}, ${jobs.company})`,
+        openCount: sql<number>`cast(count(*) as integer)`,
+      })
+      .from(jobs)
+      .where(and(eq(jobs.status, "open"), isNull(jobs.deletedAt)))
+      .groupBy(sql`coalesce(${jobs.endClient}, ${jobs.company})`)
+      .orderBy(desc(sql`count(*)`))
+      .limit(5),
+
+    database
+      .select({
+        title: jobs.title,
+        openCount: sql<number>`cast(count(*) as integer)`,
+      })
+      .from(jobs)
+      .where(and(eq(jobs.status, "open"), isNull(jobs.deletedAt)))
+      .groupBy(jobs.title)
+      .orderBy(desc(sql`count(*)`))
+      .limit(5),
+
+    database
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(candidates)
+      .where(
+        and(
+          isNull(candidates.deletedAt),
+          gte(candidates.createdAt, sevenDaysAgo),
+          sql`not exists (select 1 from ${applications} a where a.candidate_id = ${candidates.id} and a.deleted_at is null)`,
+        ),
+      ),
+
+    database
+      .select({ avgScore: sql<number | null>`avg(${jobMatches.matchScore})` })
+      .from(jobMatches)
+      .where(gte(jobMatches.createdAt, sevenDaysAgo)),
+
+    database
+      .select({ avgScore: sql<number | null>`avg(${jobMatches.matchScore})` })
+      .from(jobMatches)
+      .where(
+        and(gte(jobMatches.createdAt, fourteenDaysAgo), lt(jobMatches.createdAt, sevenDaysAgo)),
+      ),
+  ]);
+
+  const stageCounts: Record<string, number> = {};
+  for (const row of stageCountsRaw) stageCounts[row.stage] = row.count;
+
+  const stageTransitions: Record<string, number> = {};
+  for (const row of stageTransitionsRaw) stageTransitions[row.stage] = row.count;
+
+  const stageOrderList = ["new", "screening", "interview", "offer", "hired"] as const;
+  const reachedBy = (stage: (typeof stageOrderList)[number]) => {
+    const startIdx = stageOrderList.indexOf(stage);
+    return stageOrderList.slice(startIdx).reduce((sum, s) => sum + (stageTransitions[s] ?? 0), 0);
+  };
+
+  const stageConversion: StageConversion[] = [
+    ["new", "screening"],
+    ["screening", "interview"],
+    ["interview", "offer"],
+    ["offer", "hired"],
+  ].map(([from, to]) => {
+    const fromCount = reachedBy(from as (typeof stageOrderList)[number]);
+    const toCount = reachedBy(to as (typeof stageOrderList)[number]);
+
+    return {
+      fromStage: from,
+      toStage: to,
+      fromCount,
+      toCount,
+      conversionPct: fromCount === 0 ? null : Math.round((toCount / fromCount) * 100),
+    };
+  });
+
+  const platformInflow: PlatformInflow[] = platformInflowRaw
+    .map((row) => ({
+      platform: row.platform,
+      lastWeek: row.lastWeek ?? 0,
+      previousWeek: row.previousWeek ?? 0,
+      deltaPct: pctChange(row.lastWeek ?? 0, row.previousWeek ?? 0),
+    }))
+    .sort((a, b) => b.lastWeek - a.lastWeek);
+
+  const last7dAvg = matchScoreLast7Res[0]?.avgScore ?? null;
+  const prev7dAvg = matchScorePrev7Res[0]?.avgScore ?? null;
+  const deltaPoints =
+    last7dAvg !== null && prev7dAvg !== null ? Math.round((last7dAvg - prev7dAvg) * 10) / 10 : null;
+
+  return {
+    window: {
+      now: now.toISOString(),
+      sevenDaysAgo: sevenDaysAgo.toISOString(),
+      fourteenDaysAgo: fourteenDaysAgo.toISOString(),
+      thirtyDaysAgo: thirtyDaysAgo.toISOString(),
+    },
+    totals: {
+      openJobs: openJobsRes[0]?.count ?? 0,
+      activeCandidates: activeCandidatesRes[0]?.count ?? 0,
+      applications30d: applications30dRes[0]?.count ?? 0,
+      applications7d: applications7dRes[0]?.count ?? 0,
+      placements30d: placements30dRes[0]?.count ?? 0,
+      matches30d: matches30dRes[0]?.count ?? 0,
+    },
+    platformInflow,
+    stageCounts,
+    stageConversion,
+    staleScreenings: staleScreeningsRes[0]?.count ?? 0,
+    staleInterviews: staleInterviewsRes[0]?.count ?? 0,
+    highScoreUnreviewedMatches: {
+      total: highScoreUnreviewedRes[0]?.count ?? 0,
+      averageScore:
+        highScoreUnreviewedRes[0]?.averageScore != null
+          ? Math.round(Number(highScoreUnreviewedRes[0].averageScore) * 10) / 10
+          : null,
+    },
+    upcomingInterviews7d: upcomingInterviews7dRes[0]?.count ?? 0,
+    recentScrapeFailures: recentScrapeFailuresRes[0]?.count ?? 0,
+    topOpenClients: topOpenClientsRaw
+      .filter((row): row is { client: string; openCount: number } => Boolean(row.client))
+      .map((row) => ({ client: row.client, openCount: row.openCount })),
+    topOpenTitles: topOpenTitlesRaw.map((row) => ({
+      title: row.title,
+      openCount: row.openCount,
+    })),
+    newCandidatesWithoutApplication: newCandidatesNoAppRes[0]?.count ?? 0,
+    matchScoreTrend: {
+      last7dAvg: last7dAvg !== null ? Math.round(last7dAvg * 10) / 10 : null,
+      previous7dAvg: prev7dAvg !== null ? Math.round(prev7dAvg * 10) / 10 : null,
+      deltaPoints,
+    },
+  };
+}
+
+// ── AI generation ────────────────────────────────────────────────────
+
+const insightSchema = z.object({
+  type: z
+    .enum(["kans", "trend", "risico", "actie"])
+    .describe("Classificatie: kans, trend (neutrale observatie), risico, of concrete actie"),
+  title: z.string().min(3).max(80).describe("Korte pakkende titel in het Nederlands"),
+  description: z
+    .string()
+    .min(20)
+    .max(280)
+    .describe("1-2 zinnen uitleg met concrete cijfers, in het Nederlands"),
+  priority: z.enum(["hoog", "gemiddeld", "laag"]),
+  metricLabel: z.string().max(40).optional(),
+  metricValue: z.string().max(40).optional(),
+  href: z
+    .string()
+    .regex(/^\/[a-z0-9/?=&_-]*$/i)
+    .optional()
+    .describe("Optionele deep-link binnen de app, bijv. /pipeline?fase=screening"),
+});
+
+const trendInsightsOutputSchema = z.object({
+  summary: z
+    .string()
+    .min(20)
+    .max(240)
+    .describe("Eén zin samenvatting van de belangrijkste signalen"),
+  insights: z.array(insightSchema).min(3).max(6),
+});
+
+const SYSTEM_PROMPT = `Je bent een recruitment-analist voor Motian, een Nederlands uitzend- en detacheringsplatform. Je krijgt ruwe trenddata en moet 3-6 korte, concrete inzichten formuleren die een recruiter helpen vandaag betere beslissingen te nemen.
+
+Regels:
+- Schrijf alles in helder Nederlands.
+- Baseer elk inzicht op de gegeven cijfers. Geen speculatie of verzonnen data.
+- Zoek expliciet naar:
+  * Kansen: platforms met stijgende instroom, klanten met veel open vacatures, hoogscorende matches die nog niet zijn opgevolgd, nieuwe kandidaten zonder sollicitatie.
+  * Risico's: achterblijvende conversie, lang stilstaande kandidaten in een fase, dalende instroom, scrape-fouten.
+  * Trends: significante stijging of daling week-over-week.
+  * Acties: concrete next steps waar de recruiter vandaag tijd aan moet besteden.
+- Gebruik prioriteit 'hoog' alleen voor signalen die direct omzet- of conversie-impact hebben.
+- Laat inzichten weg als er onvoldoende data is (bijv. totalen op 0). Verzin dan geen insight.
+- Gebruik waar mogelijk href deep-links: /pipeline, /pipeline?fase=new|screening|interview|offer, /kandidaten, /vacatures, /scraper, /interviews.
+- Maak titels kort en actionable ("Hoogscorende matches wachten op review", niet "Er zijn matches").`;
+
+export async function generateTrendInsights(metrics: TrendMetrics): Promise<TrendInsightsResult> {
+  const generatedAt = new Date().toISOString();
+
+  if (metrics.totals.openJobs === 0 && metrics.totals.applications30d === 0) {
+    return {
+      generatedAt,
+      source: "fallback",
+      summary:
+        "Er is nog te weinig data om trends te analyseren. Voeg vacatures en kandidaten toe.",
+      insights: [],
+    };
+  }
+
+  try {
+    const result = await generateObject({
+      model: gemini31FlashLite,
+      schema: trendInsightsOutputSchema,
+      system: SYSTEM_PROMPT,
+      prompt: `Analyseer onderstaande trenddata en genereer 3-6 inzichten voor de recruiter.
+
+${JSON.stringify(metrics, null, 2)}
+
+Focus op concrete opportunities die vandaag actie vragen. Noem in elke description concrete getallen uit de data.`,
+      providerOptions: {
+        google: {
+          structuredOutputs: true,
+        },
+      },
+      abortSignal: AbortSignal.timeout(15_000),
+    });
+
+    return {
+      generatedAt,
+      source: "ai",
+      summary: result.object.summary,
+      insights: result.object.insights,
+    };
+  } catch (error) {
+    console.warn("[trend-insights] AI generation failed, using fallback", error);
+    return {
+      generatedAt,
+      source: "fallback",
+      ...buildFallbackInsights(metrics),
+    };
+  }
+}
+
+export function buildFallbackInsights(
+  metrics: TrendMetrics,
+): Pick<TrendInsightsResult, "summary" | "insights"> {
+  const insights: TrendInsight[] = [];
+
+  if (metrics.highScoreUnreviewedMatches.total > 0) {
+    insights.push({
+      type: "kans",
+      title: "Hoogscorende matches wachten op review",
+      description: `${metrics.highScoreUnreviewedMatches.total} matches met score ≥ 80 staan nog op 'pending'. Beoordeel ze eerst voor het hoogste conversiepotentieel.`,
+      priority: "hoog",
+      metricLabel: "Wachtende matches",
+      metricValue: String(metrics.highScoreUnreviewedMatches.total),
+      href: "/kandidaten",
+    });
+  }
+
+  if (metrics.staleScreenings + metrics.staleInterviews > 0) {
+    insights.push({
+      type: "risico",
+      title: "Pipeline-fases staan te lang stil",
+      description: `${metrics.staleScreenings} kandidaten zitten >14 dagen in screening, ${metrics.staleInterviews} in interview. Plan een vervolgstap of sluit af.`,
+      priority: "gemiddeld",
+      metricLabel: "Lang stilstaand",
+      metricValue: String(metrics.staleScreenings + metrics.staleInterviews),
+      href: "/pipeline?fase=screening&weergave=lijst",
+    });
+  }
+
+  const topGrowth = metrics.platformInflow.find(
+    (row) => row.deltaPct !== null && row.deltaPct >= 25 && row.lastWeek >= 5,
+  );
+  if (topGrowth) {
+    insights.push({
+      type: "trend",
+      title: `Instroom stijgt op ${topGrowth.platform}`,
+      description: `${topGrowth.platform} heeft deze week ${topGrowth.lastWeek} nieuwe vacatures (+${topGrowth.deltaPct}% t.o.v. vorige week). Prioriteer sourcing op dit platform.`,
+      priority: "gemiddeld",
+      metricLabel: topGrowth.platform,
+      metricValue: `+${topGrowth.deltaPct}%`,
+      href: "/vacatures",
+    });
+  }
+
+  if (metrics.newCandidatesWithoutApplication > 0) {
+    insights.push({
+      type: "actie",
+      title: "Nieuwe kandidaten zonder sollicitatie",
+      description: `${metrics.newCandidatesWithoutApplication} kandidaten zijn de laatste 7 dagen toegevoegd maar hebben nog geen match of sollicitatie. Draai auto-matching of koppel handmatig.`,
+      priority: "gemiddeld",
+      metricLabel: "Nieuwe instroom",
+      metricValue: String(metrics.newCandidatesWithoutApplication),
+      href: "/kandidaten",
+    });
+  }
+
+  if (metrics.topOpenClients[0] && metrics.topOpenClients[0].openCount >= 3) {
+    const top = metrics.topOpenClients[0];
+    insights.push({
+      type: "kans",
+      title: `${top.client} heeft ${top.openCount} open vacatures`,
+      description: `${top.client} is momenteel de klant met de meeste openstaande rollen. Focus sourcing op dit account voor maximale hit-rate.`,
+      priority: "gemiddeld",
+      metricLabel: "Open vacatures",
+      metricValue: String(top.openCount),
+      href: "/vacatures",
+    });
+  }
+
+  if (metrics.recentScrapeFailures >= 3) {
+    insights.push({
+      type: "risico",
+      title: "Scrape-storingen lopen op",
+      description: `${metrics.recentScrapeFailures} scrape-runs liepen vast in de laatste 7 dagen. Controleer de bronconfiguratie voordat sourcing gaten laat vallen.`,
+      priority: "hoog",
+      metricLabel: "Fouten (7d)",
+      metricValue: String(metrics.recentScrapeFailures),
+      href: "/scraper",
+    });
+  }
+
+  const summary =
+    insights.length === 0
+      ? "Geen urgente signalen in de laatste 30 dagen."
+      : `${insights.length} signalen uit de trenddata vragen aandacht.`;
+
+  return { summary, insights };
+}
+
+// ── Orchestrator (cached) ────────────────────────────────────────────
+
+async function getTrendInsightsUncached(database: typeof db = db): Promise<TrendInsightsResult> {
+  const metrics = await collectTrendMetrics(database);
+  return generateTrendInsights(metrics);
+}
+
+const getCached = unstable_cache(
+  async () => getTrendInsightsUncached(db),
+  ["trend-insights", "v1"],
+  { revalidate: 15 * 60 },
+);
+
+export async function getTrendInsights(database: typeof db = db): Promise<TrendInsightsResult> {
+  if (database === db) return getCached();
+  return getTrendInsightsUncached(database);
+}

--- a/src/services/trend-insights.ts
+++ b/src/services/trend-insights.ts
@@ -244,12 +244,7 @@ export async function collectTrendMetrics(database: typeof db = db): Promise<Tre
     database
       .select({ count: sql<number>`cast(count(*) as integer)` })
       .from(scrapeResults)
-      .where(
-        and(
-          gte(scrapeResults.runAt, sevenDaysAgo),
-          sql`(${scrapeResults.status} = 'failed' or jsonb_array_length(coalesce(${scrapeResults.errors}, '[]'::jsonb)) > 0)`,
-        ),
-      ),
+      .where(and(gte(scrapeResults.runAt, sevenDaysAgo), eq(scrapeResults.status, "failed"))),
 
     database
       .select({
@@ -274,13 +269,17 @@ export async function collectTrendMetrics(database: typeof db = db): Promise<Tre
       .limit(5),
 
     database
-      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .select({ count: sql<number>`cast(count(distinct ${candidates.id}) as integer)` })
       .from(candidates)
+      .leftJoin(
+        applications,
+        and(eq(applications.candidateId, candidates.id), isNull(applications.deletedAt)),
+      )
       .where(
         and(
           isNull(candidates.deletedAt),
           gte(candidates.createdAt, sevenDaysAgo),
-          sql`not exists (select 1 from ${applications} a where a.candidate_id = ${candidates.id} and a.deleted_at is null)`,
+          isNull(applications.id),
         ),
       ),
 
@@ -570,9 +569,21 @@ export function buildFallbackInsights(
 
 // ── Orchestrator (cached) ────────────────────────────────────────────
 
+const EMPTY_METRICS_RESULT: TrendInsightsResult = {
+  generatedAt: new Date(0).toISOString(),
+  source: "fallback",
+  summary: "Trenddata is tijdelijk niet beschikbaar.",
+  insights: [],
+};
+
 async function getTrendInsightsUncached(database: typeof db = db): Promise<TrendInsightsResult> {
-  const metrics = await collectTrendMetrics(database);
-  return generateTrendInsights(metrics);
+  try {
+    const metrics = await collectTrendMetrics(database);
+    return generateTrendInsights(metrics);
+  } catch (error) {
+    console.warn("[trend-insights] metrics collection failed", error);
+    return { ...EMPTY_METRICS_RESULT, generatedAt: new Date().toISOString() };
+  }
 }
 
 const getCached = unstable_cache(

--- a/tests/trend-insights.test.ts
+++ b/tests/trend-insights.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import { buildFallbackInsights, type TrendMetrics } from "../src/services/trend-insights";
+
+function baseMetrics(overrides: Partial<TrendMetrics> = {}): TrendMetrics {
+  const now = new Date();
+  return {
+    window: {
+      now: now.toISOString(),
+      sevenDaysAgo: now.toISOString(),
+      fourteenDaysAgo: now.toISOString(),
+      thirtyDaysAgo: now.toISOString(),
+    },
+    totals: {
+      openJobs: 120,
+      activeCandidates: 40,
+      applications30d: 50,
+      applications7d: 12,
+      placements30d: 2,
+      matches30d: 80,
+    },
+    platformInflow: [
+      { platform: "striive", lastWeek: 20, previousWeek: 10, deltaPct: 100 },
+      { platform: "magnet.me", lastWeek: 5, previousWeek: 5, deltaPct: 0 },
+    ],
+    stageCounts: { new: 10, screening: 5, interview: 3, offer: 1, hired: 2 },
+    stageConversion: [],
+    staleScreenings: 4,
+    staleInterviews: 2,
+    highScoreUnreviewedMatches: { total: 7, averageScore: 85.3 },
+    upcomingInterviews7d: 3,
+    recentScrapeFailures: 0,
+    topOpenClients: [
+      { client: "ABN AMRO", openCount: 8 },
+      { client: "ING", openCount: 5 },
+    ],
+    topOpenTitles: [{ title: "Senior Data Engineer", openCount: 4 }],
+    newCandidatesWithoutApplication: 6,
+    matchScoreTrend: { last7dAvg: 72.4, previous7dAvg: 68.1, deltaPoints: 4.3 },
+    ...overrides,
+  };
+}
+
+describe("trend-insights fallback", () => {
+  it("surfaces high-score unreviewed matches as a high-priority opportunity", () => {
+    const { insights } = buildFallbackInsights(baseMetrics());
+    const hit = insights.find((i) => i.title.includes("Hoogscorende matches"));
+    expect(hit).toBeDefined();
+    expect(hit?.priority).toBe("hoog");
+    expect(hit?.type).toBe("kans");
+    expect(hit?.metricValue).toBe("7");
+  });
+
+  it("flags stale pipeline stages as risico", () => {
+    const { insights } = buildFallbackInsights(baseMetrics());
+    const stale = insights.find((i) => i.type === "risico" && i.title.includes("stil"));
+    expect(stale).toBeDefined();
+    expect(stale?.description).toContain("4");
+    expect(stale?.description).toContain("2");
+  });
+
+  it("highlights platforms with strong week-over-week growth", () => {
+    const { insights } = buildFallbackInsights(baseMetrics());
+    const growth = insights.find((i) => i.type === "trend");
+    expect(growth).toBeDefined();
+    expect(growth?.title).toContain("striive");
+    expect(growth?.metricValue).toBe("+100%");
+  });
+
+  it("proposes auto-matching for new candidates without applications", () => {
+    const { insights } = buildFallbackInsights(baseMetrics());
+    const action = insights.find((i) => i.type === "actie");
+    expect(action).toBeDefined();
+    expect(action?.title).toContain("Nieuwe kandidaten");
+    expect(action?.href).toBe("/kandidaten");
+  });
+
+  it("highlights top client with multiple open vacancies", () => {
+    const { insights } = buildFallbackInsights(baseMetrics());
+    const client = insights.find((i) => i.type === "kans" && i.title.includes("ABN AMRO"));
+    expect(client).toBeDefined();
+    expect(client?.metricValue).toBe("8");
+  });
+
+  it("adds scrape failure risk when recent failures exceed threshold", () => {
+    const metrics = baseMetrics({ recentScrapeFailures: 5 });
+    const { insights } = buildFallbackInsights(metrics);
+    const risk = insights.find((i) => i.title.includes("Scrape-storingen"));
+    expect(risk).toBeDefined();
+    expect(risk?.priority).toBe("hoog");
+  });
+
+  it("returns an empty insight list and neutral summary when the pipeline is idle", () => {
+    const metrics = baseMetrics({
+      highScoreUnreviewedMatches: { total: 0, averageScore: null },
+      staleScreenings: 0,
+      staleInterviews: 0,
+      platformInflow: [{ platform: "striive", lastWeek: 2, previousWeek: 2, deltaPct: 0 }],
+      newCandidatesWithoutApplication: 0,
+      topOpenClients: [],
+      recentScrapeFailures: 0,
+    });
+
+    const { summary, insights } = buildFallbackInsights(metrics);
+    expect(insights).toHaveLength(0);
+    expect(summary).toMatch(/Geen urgente signalen/i);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a new **"AI-analyse &amp; kansen"** card to the Overzicht page that aggregates trend data and surfaces 3-6 concrete insights for the recruiter (opportunities, trends, risks, actions).
- Introduces `src/services/trend-insights.ts` which collects operational metrics (weekly job inflow per platform, pipeline stage conversion, stale applications, high-score unreviewed matches, top-open clients, scrape failures, match-score trend) and feeds them to Gemini 3.1 Flash Lite via `tracedGenerateObject` with a Zod-validated output.
- Ships a deterministic `buildFallbackInsights` rule-based generator that runs whenever AI generation fails or times out, so the card is always useful.
- Card renders its own `Suspense` boundary so the rest of Overzicht loads immediately; results are cached for 15 minutes via `unstable_cache`.

## Key files

- `src/services/trend-insights.ts` — metrics aggregation + AI + fallback + cached orchestrator
- `components/overview/ai-insights-card.tsx` — presentational `InsightTile` grid with tone-coded type/priority badges and deep-link hrefs
- `app/overzicht/page.tsx` — wires the new card in with a Suspense boundary, between KPIs and the 30-day trend chart
- `tests/trend-insights.test.ts` — 7 unit tests covering the fallback rules

## What the recruiter sees

Insights are classified as `kans`, `trend`, `risico`, or `actie`, each with a priority badge and optional deep-link. Examples the system can surface:

- "Hoogscorende matches wachten op review" (pending matches with score ≥ 80)
- "Instroom stijgt op &lt;platform&gt;" (week-over-week inflow growth)
- "&lt;Klant&gt; heeft N open vacatures" (sourcing focus)
- "Pipeline-fases staan te lang stil" (apps &gt;14 days in screening/interview)
- "Nieuwe kandidaten zonder sollicitatie"
- "Scrape-storingen lopen op"

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test tests/trend-insights.test.ts` — 7/7 pass
- [x] Related tests still green: `tests/overzicht-data.test.ts`, `tests/pipeline-health-overview.test.ts`, `tests/recruiter-insights.test.ts`
- [ ] Manual smoke in browser on `/overzicht` with live data (AI + fallback paths)

https://claude.ai/code/session_012MzghDYYLsZT5feiiJsJa5