### PR TITLE
Prevent risk-policy-gate from hanging on empty stdin

### DIFF
--- a/scripts/harness/risk-policy-gate.ts
+++ b/scripts/harness/risk-policy-gate.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { appendFileSync, existsSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { type HarnessConfig, loadHarnessConfig } from "@/src/harness/config";
 
@@ -149,12 +149,7 @@ async function resolveChangedFiles(projectRoot: string): Promise<string[]> {
 
   // Check if stdin has data (non-TTY)
   if (!process.stdin.isTTY) {
-    const stdinData = await new Promise<string>((res) => {
-      let buf = "";
-      process.stdin.setEncoding("utf8");
-      process.stdin.on("data", (chunk) => (buf += chunk));
-      process.stdin.on("end", () => res(buf));
-    });
+    const stdinData = readFileSync(0, "utf8");
     const lines = stdinData
       .split("\n")
       .map((l) => l.trim())


### PR DESCRIPTION
## Summary
- make the harness risk-policy gate non-blocking when stdin is an empty exec/spawn pipe
- preserve existing piped-input behavior used by GitHub workflows
- restore the full local test suite to green after the harness integration timeout regression

## Testing
- pnpm lint
- pnpm test
- pnpm exec tsc --noEmit
- pnpm test tests/harness/integration.test.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/215" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
