### PR TITLE
fix(scrapers): opdrachtoverheid bump per-request to 90s, cap retries at 2 (RJC-214)

### DIFF
--- a/packages/scrapers/src/opdrachtoverheid.ts
+++ b/packages/scrapers/src/opdrachtoverheid.ts
@@ -11,7 +11,7 @@ import {
 const API_BASE = "https://kbenp-match-api.azurewebsites.net";
 const PAGE_SIZE = 1000;
 const MAX_PAGES = 10;
-const REQUEST_TIMEOUT_MS = 60_000;
+const REQUEST_TIMEOUT_MS = 90_000;
 const MAX_ALLOWED_PAGES = 25;
 
 type ScrapeOpdrachtoverheidOptions = {
@@ -121,7 +121,7 @@ export async function scrapeOpdrachtoverheid(
 ): Promise<RawScrapedListing[]> {
   console.log("Opdrachtoverheid scrapen via API");
 
-  const MAX_RETRIES = 2;
+  const MAX_ATTEMPTS = 2;
   const pageSize = toBoundedPositiveInteger(options.pageSize, PAGE_SIZE, 1, PAGE_SIZE);
   const maxPages = options.smoke
     ? 1
@@ -138,7 +138,7 @@ export async function scrapeOpdrachtoverheid(
       : undefined;
   let attempt = 0;
 
-  while (attempt <= MAX_RETRIES) {
+  while (attempt < MAX_ATTEMPTS) {
     try {
       // Paginate through the API to avoid the 1000-result hard cap
       const allTenders: OpdrachtoverheidTender[] = [];
@@ -199,9 +199,9 @@ export async function scrapeOpdrachtoverheid(
       return validListings;
     } catch (err) {
       attempt++;
-      if (attempt > MAX_RETRIES) {
+      if (attempt >= MAX_ATTEMPTS) {
         throw new Error(
-          `Opdrachtoverheid scrape mislukt na ${MAX_RETRIES + 1} pogingen: ${err instanceof Error ? err.message : String(err)}`,
+          `Opdrachtoverheid scrape mislukt na ${MAX_ATTEMPTS} pogingen: ${err instanceof Error ? err.message : String(err)}`,
         );
       } else {
         const delay = 1200 * 2 ** attempt + Math.floor(Math.random() * 500);

--- a/tests/opdrachtoverheid-scraper.test.ts
+++ b/tests/opdrachtoverheid-scraper.test.ts
@@ -10,6 +10,7 @@ describe("Opdrachtoverheid scraper mapping", () => {
   const originalFetch = globalThis.fetch;
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
     globalThis.fetch = originalFetch;
   });
@@ -77,6 +78,72 @@ describe("Opdrachtoverheid scraper mapping", () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(1);
     expect(listings).toHaveLength(1);
     expect(listings[0]?.externalId).toBe("oo-1");
+  });
+
+  it("times out once, retries, and succeeds within the 180s wall-clock budget", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+
+    let callCount = 0;
+
+    globalThis.fetch = vi.fn((_input, init) => {
+      callCount++;
+
+      if (callCount === 1) {
+        return new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal as AbortSignal | undefined;
+
+          // Simulate a hanging request that only fails once the scraper timeout budget is exhausted.
+          setTimeout(() => {
+            reject(
+              signal?.reason instanceof Error
+                ? signal.reason
+                : new Error("The operation was aborted due to timeout"),
+            );
+          }, 90_000);
+        }) as Promise<Response>;
+      }
+
+      return new Promise<Response>((resolve) => {
+        setTimeout(() => {
+          resolve(
+            new Response(
+              JSON.stringify({
+                negometrix_tenders: [
+                  {
+                    tender_name: "Senior Java Developer",
+                    tender_buying_organization: "Gemeente Utrecht",
+                    tender_description: "Beschrijving",
+                    web_key: "oo-retry-success",
+                    opdracht_overheid_url:
+                      "https://www.opdrachtoverheid.nl/opdracht/oo-retry-success",
+                  },
+                ],
+              }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              },
+            ),
+          );
+        }, 50_000);
+      }) as Promise<Response>;
+    }) as typeof fetch;
+
+    const startedAt = Date.now();
+    const scrapePromise = scrapeOpdrachtoverheid({ maxPages: 1 });
+
+    await vi.advanceTimersByTimeAsync(90_000);
+    await vi.advanceTimersByTimeAsync(2_400);
+    await vi.advanceTimersByTimeAsync(50_000);
+
+    const listings = await scrapePromise;
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect(listings).toHaveLength(1);
+    expect(listings[0]?.externalId).toBe("oo-retry-success");
+    expect(elapsedMs).toBeLessThanOrEqual(180_000);
   });
 
   it("passes runtime maxPages and smoke limits through the registered adapter", async () => {


### PR DESCRIPTION
## Summary
- Raise `REQUEST_TIMEOUT_MS` from 60s to 90s to give the slow `kbenp-match-api` backend room to respond.
- Drop retries 3→2 (renamed `MAX_RETRIES`→`MAX_ATTEMPTS`); wall-clock now bounded at ~180s (2 × 90s).
- Add timeout-simulation test in `tests/opdrachtoverheid-scraper.test.ts`.

Refs [RJC-214](https://linear.app/rcjt-studio/issue/RJC-214). Evidence: scrape_results 2026-04-20T09:48:25Z, duration 93,831 ms, `"Opdrachtoverheid scrape mislukt na 3 pogingen: The operation was aborted due to timeout"`.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm vitest run tests/opdrachtoverheid-scraper.test.ts`
- [ ] Next real scrape returns `status=success`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended request timeout to 90 seconds for better handling of slower network conditions.
  * Refined retry logic for more consistent request recovery.

* **Tests**
  * Added test coverage for retry behavior under timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->