### PR TITLE
fix(scrapers): lock in serialized DB batch inserts to avoid Neon pool exhaustion (RJC-215)

### DIFF
--- a/src/services/normalize.ts
+++ b/src/services/normalize.ts
@@ -401,6 +401,7 @@ export async function normalizeAndSaveJobs(
 
   if (itemsToInsert.length > 0) {
     const batches = chunkJobInsertBatches(itemsToInsert, platform);
+    // Intentionally serialized to avoid exhausting Neon pool connections on large scrapes.
     for (const batch of batches) {
       try {
         const result = await db

--- a/tests/scrape-pipeline-concurrency.test.ts
+++ b/tests/scrape-pipeline-concurrency.test.ts
@@ -1,22 +1,28 @@
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("../src/lib/event-bus", () => ({ publish: vi.fn() }));
-vi.mock("../src/services/normalize", () => ({
-  normalizeAndSaveJobs: vi.fn(),
-}));
-vi.mock("../src/services/record-scrape-result", () => ({
-  recordScrapeResult: vi.fn(() => Promise.resolve()),
-}));
-vi.mock("../src/services/scrapers/index", () => ({
-  scrapeFlextender: vi.fn(),
-  scrapeOpdrachtoverheid: vi.fn(),
-  scrapeStriive: vi.fn(),
+const { mockDbInsert, mockSyncJobSkills } = vi.hoisted(() => ({
+  mockDbInsert: vi.fn(),
+  mockSyncJobSkills: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("../src/db", async (importOriginal) => ({
+  ...(await importOriginal()),
+  db: {
+    insert: mockDbInsert,
+  },
+}));
+
+vi.mock("../src/services/esco", () => ({
+  syncJobSkills: mockSyncJobSkills,
+}));
+
+import { normalizeAndSaveJobs } from "../src/services/normalize";
 import {
   getScrapePipelineConcurrency,
   runScrapePipelinesWithConcurrency,
 } from "../src/services/scrape-pipeline";
+
+const BATCH_INSERT_SIZE = 50;
 
 describe("getScrapePipelineConcurrency", () => {
   it("uses the default and clamps env overrides", () => {
@@ -87,5 +93,60 @@ describe("runScrapePipelinesWithConcurrency", () => {
 
     expect(calls).toEqual(["alpha", "beta"]);
     expect(results.every((result) => result.status === "fulfilled")).toBe(true);
+  });
+});
+
+describe("normalizeAndSaveJobs batch inserts", () => {
+  it("executes DB insert batches sequentially without overlap", async () => {
+    const insertWindows: Array<{ start: number; end: number }> = [];
+    let activeInsertCalls = 0;
+    let maxActiveInsertCalls = 0;
+
+    const valuesMock = vi.fn((rows: Array<{ externalId: string }>) => ({
+      onConflictDoUpdate: vi.fn().mockReturnThis(),
+      returning: vi.fn(async () => {
+        const insertWindow = { start: Date.now(), end: 0 };
+        insertWindows.push(insertWindow);
+        activeInsertCalls += 1;
+        maxActiveInsertCalls = Math.max(maxActiveInsertCalls, activeInsertCalls);
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        activeInsertCalls -= 1;
+        insertWindow.end = Date.now();
+        return rows.map((row) => ({
+          id: `job-${row.externalId}`,
+          externalId: row.externalId,
+          isNew: true,
+        }));
+      }),
+    }));
+
+    mockDbInsert.mockImplementation(() => ({
+      values: valuesMock,
+    }));
+
+    const listings = Array.from({ length: 120 }, (_, index) => ({
+      externalId: `ext-${index + 1}`,
+      externalUrl: `https://example.com/jobs/${index + 1}`,
+      title: `Batch job ${index + 1}`,
+      description: "This listing has a sufficiently long description for validation checks.",
+      status: "open",
+    }));
+
+    const result = await normalizeAndSaveJobs("flextender", listings);
+
+    expect(result.errors).toEqual([]);
+    expect(mockDbInsert).toHaveBeenCalledTimes(3);
+    expect(mockSyncJobSkills).toHaveBeenCalledTimes(120);
+    expect(maxActiveInsertCalls).toBe(1);
+    expect(insertWindows).toHaveLength(3);
+
+    for (let index = 1; index < insertWindows.length; index += 1) {
+      expect(insertWindows[index].start).toBeGreaterThanOrEqual(insertWindows[index - 1].end);
+    }
+
+    // Guard against regressions if batch size changes upstream.
+    expect(valuesMock.mock.calls[0]?.[0]).toHaveLength(BATCH_INSERT_SIZE);
   });
 });


### PR DESCRIPTION
## Summary
- Document the sequential-batch invariant inline in `src/services/normalize.ts` where `normalizeAndSaveJobs` dispatches `for..of await db.insert(...)`.
- Add regression test in `tests/scrape-pipeline-concurrency.test.ts` that spies on insert calls and asserts no overlap (`maxActiveInsertCalls === 1`, next batch's start ≥ prior batch's end).

## What this DOES NOT fix (yet)
The investigation found the batch loop was **already sequential** — which means the batch timeouts observed on flextender and nationalevacaturebank (`"DB batch 0-49: Error: Connection terminated due to connection timeout"`) are not caused by parallel batch dispatch. This PR prevents regression into parallelism but a follow-up is needed to find the real pool-contention source (likely concurrent `syncJobSkills` or other DB work running during the scrape).

Refs [RJC-215](https://linear.app/rcjt-studio/issue/RJC-215).

## Test plan
- [x] `pnpm lint`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm vitest run tests/scrape-pipeline-concurrency.test.ts tests/scrape-pipeline-run.test.ts`
- [ ] Follow-up: identify actual source of pool-contention during large scrapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
