### PR TITLE
fix(scrapers): mipublic sitemap extractor + graceful detail skip (RJC-213)

### DIFF
--- a/packages/scrapers/src/mipublic.ts
+++ b/packages/scrapers/src/mipublic.ts
@@ -13,7 +13,8 @@ import type {
 } from "./types";
 
 const DEFAULT_MIPUBLIC_ORIGIN = "https://mipublic.nl";
-const DEFAULT_SITEMAP_PATH = "/sitemap_index.xml";
+const DEFAULT_SITEMAP_PATH = "/vacature-sitemap.xml";
+const SITEMAP_INDEX_FALLBACK_PATH = "/sitemap_index.xml";
 const DEFAULT_DETAIL_CONCURRENCY = 4;
 const MAX_DETAIL_CONCURRENCY = 8;
 const MAX_SITEMAP_CHILD_FETCHES = 30;
@@ -121,34 +122,37 @@ export function parseMipublicSitemap(xml: string): ParsedSitemap {
   cutoff.setDate(cutoff.getDate() - SITEMAP_MAX_AGE_DAYS);
 
   const urlBlocks = xml.match(/<url\b[^>]*>[\s\S]*?<\/url>/gi) ?? [];
-  for (const block of urlBlocks) {
-    const locMatch = block.match(/<loc>([^<]+)<\/loc>/i);
-    if (!locMatch) continue;
-    const value = locMatch[1]?.trim();
-    if (!value) continue;
-
-    const lastmod = parseLastmod(block);
-    if (lastmod && lastmod < cutoff) continue;
-
-    try {
-      const parsed = new URL(value);
-      if (isVacatureDetailUrl(parsed)) urls.add(parsed.toString());
-    } catch {
-      continue;
-    }
-  }
-
-  // Fallback for simpler sitemaps that omit <url> wrappers
-  if (urls.size === 0) {
-    for (const match of xml.matchAll(/<loc>([^<]+)<\/loc>/gi)) {
-      const value = match[1]?.trim();
+  if (urlBlocks.length > 0) {
+    for (const block of urlBlocks) {
+      const locMatch = block.match(/<loc>([^<]+)<\/loc>/i);
+      if (!locMatch) continue;
+      const value = locMatch[1]?.trim();
       if (!value) continue;
+
+      const lastmod = parseLastmod(block);
+      if (lastmod && lastmod < cutoff) continue;
+
       try {
         const parsed = new URL(value);
         if (isVacatureDetailUrl(parsed)) urls.add(parsed.toString());
       } catch {
         continue;
       }
+    }
+    return { kind: "urlset", urls: [...urls] };
+  }
+
+  // Fallback for simpler sitemaps that omit <url> wrappers. Only applies when
+  // the document genuinely has no <url> blocks — otherwise stale entries that
+  // were correctly filtered above would sneak back in.
+  for (const match of xml.matchAll(/<loc>([^<]+)<\/loc>/gi)) {
+    const value = match[1]?.trim();
+    if (!value) continue;
+    try {
+      const parsed = new URL(value);
+      if (isVacatureDetailUrl(parsed)) urls.add(parsed.toString());
+    } catch {
+      continue;
     }
   }
 
@@ -312,27 +316,76 @@ function detectMipublicCaptchaBlocker(
   return null;
 }
 
-async function scrapeMipublicListings(
-  config: PlatformRuntimeConfig,
-  options?: { limit?: number },
-): Promise<PlatformScrapeResult> {
-  const resolved = resolveMipublicOptions(config);
+type SitemapDiscoveryResult =
+  | { kind: "captcha"; message: string }
+  | { kind: "ok"; urls: string[]; errors: string[] };
+
+/**
+ * Fetch the configured sitemap and collect vacancy URLs. Falls back to
+ * `/sitemap_index.xml` when the primary sitemap yields 0 URLs — that is the
+ * RJC-213 regression mode where MiPublic's legacy `/vacature-sitemap.xml` has
+ * been frozen in time and current vacancies are only reachable via the index.
+ */
+async function discoverMipublicDetailUrls(
+  resolved: MipublicOptions,
+): Promise<SitemapDiscoveryResult> {
   const sitemapPage = await fetchPublicJobBoardPage(resolved.sitemapUrl);
-  const sitemapCaptchaBlocker = detectMipublicCaptchaBlocker(resolved.sitemapUrl, sitemapPage);
-  if (sitemapCaptchaBlocker) {
-    return {
-      listings: [],
-      errors: [sitemapCaptchaBlocker.message],
-    };
-  }
-  const limit = options?.limit ?? resolved.maxListings;
+  const blocker = detectMipublicCaptchaBlocker(resolved.sitemapUrl, sitemapPage);
+  if (blocker) return { kind: "captcha", message: blocker.message };
+
   const collected = await collectMipublicVacatureUrls(
     sitemapPage.html,
     resolved.sitemapUrl,
     fetchPublicJobBoardPage,
   );
-  const detailUrls = typeof limit === "number" ? collected.urls.slice(0, limit) : collected.urls;
-  const sitemapErrors = [...collected.errors];
+  const errors = [...collected.errors];
+
+  if (collected.urls.length > 0) {
+    return { kind: "ok", urls: collected.urls, errors };
+  }
+
+  // Fallback: if the configured sitemap is the flat `/vacature-sitemap.xml`
+  // and it came up empty, try the Yoast sitemap index. Skip if the caller
+  // already pointed at the index or at a custom sitemap.
+  const fallbackUrl = new URL(SITEMAP_INDEX_FALLBACK_PATH, resolved.sitemapUrl).toString();
+  if (resolved.sitemapUrl === fallbackUrl) {
+    return { kind: "ok", urls: [], errors };
+  }
+
+  try {
+    const indexPage = await fetchPublicJobBoardPage(fallbackUrl);
+    const indexBlocker = detectMipublicCaptchaBlocker(fallbackUrl, indexPage);
+    if (indexBlocker) return { kind: "captcha", message: indexBlocker.message };
+    if (indexPage.status >= 400) {
+      errors.push(`MiPublic sitemap-index ${fallbackUrl} gaf HTTP ${indexPage.status} terug.`);
+      return { kind: "ok", urls: [], errors };
+    }
+    const fallbackCollected = await collectMipublicVacatureUrls(
+      indexPage.html,
+      fallbackUrl,
+      fetchPublicJobBoardPage,
+    );
+    return { kind: "ok", urls: fallbackCollected.urls, errors: [...errors, ...fallbackCollected.errors] };
+  } catch (error) {
+    errors.push(
+      `MiPublic sitemap-index ${fallbackUrl} kon niet worden opgehaald: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return { kind: "ok", urls: [], errors };
+  }
+}
+
+async function scrapeMipublicListings(
+  config: PlatformRuntimeConfig,
+  options?: { limit?: number },
+): Promise<PlatformScrapeResult> {
+  const resolved = resolveMipublicOptions(config);
+  const discovered = await discoverMipublicDetailUrls(resolved);
+  if (discovered.kind === "captcha") {
+    return { listings: [], errors: [discovered.message] };
+  }
+  const limit = options?.limit ?? resolved.maxListings;
+  const detailUrls = typeof limit === "number" ? discovered.urls.slice(0, limit) : discovered.urls;
+  const sitemapErrors = discovered.errors;
 
   if (detailUrls.length === 0) {
     return {
@@ -419,23 +472,17 @@ async function scrapeMipublicListings(
 export const mipublicAdapter: PlatformAdapter = {
   async validate(config: PlatformRuntimeConfig): Promise<PlatformValidationResult> {
     const resolved = resolveMipublicOptions(config);
-    const sitemapPage = await fetchPublicJobBoardPage(resolved.sitemapUrl);
-    const sitemapCaptchaBlocker = detectMipublicCaptchaBlocker(resolved.sitemapUrl, sitemapPage);
-    if (sitemapCaptchaBlocker) {
+    const discovered = await discoverMipublicDetailUrls(resolved);
+    if (discovered.kind === "captcha") {
       return {
         ok: false,
         status: "failed",
         blockerKind: "anti_bot_challenge",
-        message: sitemapCaptchaBlocker.message,
+        message: discovered.message,
         evidence: { sitemapUrl: resolved.sitemapUrl },
       };
     }
-    const collected = await collectMipublicVacatureUrls(
-      sitemapPage.html,
-      resolved.sitemapUrl,
-      fetchPublicJobBoardPage,
-    );
-    const detailUrls = collected.urls;
+    const detailUrls = discovered.urls;
 
     if (detailUrls.length === 0) {
       return {
@@ -444,7 +491,7 @@ export const mipublicAdapter: PlatformAdapter = {
         message: "MiPublic sitemap bevat geen parseerbare vacaturedetailpagina's.",
         evidence: {
           sitemapUrl: resolved.sitemapUrl,
-          sitemapErrors: collected.errors,
+          sitemapErrors: discovered.errors,
         },
       };
     }

--- a/packages/scrapers/src/mipublic.ts
+++ b/packages/scrapers/src/mipublic.ts
@@ -13,9 +13,11 @@ import type {
 } from "./types";
 
 const DEFAULT_MIPUBLIC_ORIGIN = "https://mipublic.nl";
-const DEFAULT_SITEMAP_PATH = "/vacature-sitemap.xml";
+const DEFAULT_SITEMAP_PATH = "/sitemap_index.xml";
 const DEFAULT_DETAIL_CONCURRENCY = 4;
 const MAX_DETAIL_CONCURRENCY = 8;
+const MAX_SITEMAP_CHILD_FETCHES = 30;
+const SITEMAP_CHILD_FETCH_CONCURRENCY = 4;
 
 type MipublicOptions = {
   detailConcurrency: number;
@@ -69,54 +71,152 @@ function resolveMipublicOptions(config: PlatformRuntimeConfig): MipublicOptions 
 
 const SITEMAP_MAX_AGE_DAYS = 90;
 
-function extractSitemapUrls(xml: string): string[] {
+type SitemapChildRef = { url: string; lastmod?: Date };
+
+type ParsedSitemap =
+  | { kind: "index"; children: SitemapChildRef[] }
+  | { kind: "urlset"; urls: string[] };
+
+function isVacatureDetailUrl(url: URL): boolean {
+  return url.hostname === "mipublic.nl" && /^\/vacature\/[^/]+\/?$/.test(url.pathname);
+}
+
+function parseLastmod(block: string): Date | undefined {
+  const match = block.match(/<lastmod>([^<]+)<\/lastmod>/i);
+  if (!match) return undefined;
+  const parsed = new Date(match[1].trim());
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+/**
+ * Parse sitemap XML into either a sitemap index (list of child sitemaps) or a
+ * urlset (list of vacancy URLs). Both shapes are emitted by Yoast SEO on
+ * mipublic.nl — `/sitemap_index.xml` is the index, each `vacature-sitemap*.xml`
+ * is a urlset. Keeping this as a pure function keeps it trivially testable.
+ */
+export function parseMipublicSitemap(xml: string): ParsedSitemap {
+  const isIndex = /<sitemapindex\b/i.test(xml);
+
+  if (isIndex) {
+    const children: SitemapChildRef[] = [];
+    const blocks = xml.match(/<sitemap\b[^>]*>[\s\S]*?<\/sitemap>/gi) ?? [];
+    for (const block of blocks) {
+      const locMatch = block.match(/<loc>([^<]+)<\/loc>/i);
+      if (!locMatch) continue;
+      const value = locMatch[1]?.trim();
+      if (!value) continue;
+      try {
+        const parsed = new URL(value);
+        if (parsed.hostname !== "mipublic.nl") continue;
+        children.push({ url: parsed.toString(), lastmod: parseLastmod(block) });
+      } catch {
+        continue;
+      }
+    }
+    return { kind: "index", children };
+  }
+
   const urls = new Set<string>();
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - SITEMAP_MAX_AGE_DAYS);
 
-  // Parse <url> blocks to check <lastmod> dates when available
-  const urlBlocks = xml.match(/<url>[\s\S]*?<\/url>/gi) ?? [];
+  const urlBlocks = xml.match(/<url\b[^>]*>[\s\S]*?<\/url>/gi) ?? [];
   for (const block of urlBlocks) {
     const locMatch = block.match(/<loc>([^<]+)<\/loc>/i);
     if (!locMatch) continue;
-
     const value = locMatch[1]?.trim();
     if (!value) continue;
 
-    // Skip stale entries based on <lastmod>
-    const lastmodMatch = block.match(/<lastmod>([^<]+)<\/lastmod>/i);
-    if (lastmodMatch) {
-      const lastmod = new Date(lastmodMatch[1].trim());
-      if (!Number.isNaN(lastmod.getTime()) && lastmod < cutoff) continue;
-    }
+    const lastmod = parseLastmod(block);
+    if (lastmod && lastmod < cutoff) continue;
 
     try {
       const parsed = new URL(value);
-      if (parsed.hostname === "mipublic.nl" && /^\/vacature\/[^/]+\/?$/.test(parsed.pathname)) {
-        urls.add(parsed.toString());
-      }
+      if (isVacatureDetailUrl(parsed)) urls.add(parsed.toString());
     } catch {
       continue;
     }
   }
 
-  // Fallback: if no <url> blocks found, parse bare <loc> tags (simpler sitemaps)
+  // Fallback for simpler sitemaps that omit <url> wrappers
   if (urls.size === 0) {
     for (const match of xml.matchAll(/<loc>([^<]+)<\/loc>/gi)) {
       const value = match[1]?.trim();
       if (!value) continue;
       try {
         const parsed = new URL(value);
-        if (parsed.hostname === "mipublic.nl" && /^\/vacature\/[^/]+\/?$/.test(parsed.pathname)) {
-          urls.add(parsed.toString());
-        }
+        if (isVacatureDetailUrl(parsed)) urls.add(parsed.toString());
       } catch {
         continue;
       }
     }
   }
 
-  return [...urls];
+  return { kind: "urlset", urls: [...urls] };
+}
+
+type SitemapFetcher = (url: string) => Promise<{ html: string; status: number; url: string }>;
+
+/**
+ * Fetch a sitemap (or sitemap index) and recursively collect all vacancy URLs.
+ * Child sitemaps are fetched newest-first and capped by MAX_SITEMAP_CHILD_FETCHES
+ * so a future Yoast rollout (20+ sub-sitemaps) cannot explode the request count.
+ */
+export async function collectMipublicVacatureUrls(
+  initialXml: string,
+  initialUrl: string,
+  fetcher: SitemapFetcher,
+): Promise<{ urls: string[]; errors: string[] }> {
+  const parsed = parseMipublicSitemap(initialXml);
+  if (parsed.kind === "urlset") {
+    return { urls: parsed.urls, errors: [] };
+  }
+
+  const errors: string[] = [];
+  const aggregated = new Set<string>();
+
+  const ordered = [...parsed.children].sort((a, b) => {
+    const aTime = a.lastmod?.getTime() ?? 0;
+    const bTime = b.lastmod?.getTime() ?? 0;
+    return bTime - aTime;
+  });
+  const selected = ordered.slice(0, MAX_SITEMAP_CHILD_FETCHES);
+
+  let nextIndex = 0;
+  async function worker() {
+    while (nextIndex < selected.length) {
+      const current = nextIndex;
+      nextIndex += 1;
+      const child = selected[current];
+      if (child.url === initialUrl) continue;
+      try {
+        const page = await fetcher(child.url);
+        if (page.status >= 400) {
+          errors.push(`MiPublic sub-sitemap ${child.url} gaf HTTP ${page.status} terug.`);
+          continue;
+        }
+        const childParsed = parseMipublicSitemap(page.html);
+        if (childParsed.kind === "urlset") {
+          for (const url of childParsed.urls) aggregated.add(url);
+        } else {
+          errors.push(`MiPublic sub-sitemap ${child.url} is onverwacht opnieuw een sitemap-index.`);
+        }
+      } catch (error) {
+        errors.push(
+          `MiPublic sub-sitemap ${child.url} kon niet worden opgehaald: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(SITEMAP_CHILD_FETCH_CONCURRENCY, selected.length) },
+      () => worker(),
+    ),
+  );
+
+  return { urls: [...aggregated], errors };
 }
 
 async function mapWithConcurrency<TInput, TOutput>(
@@ -226,12 +326,21 @@ async function scrapeMipublicListings(
     };
   }
   const limit = options?.limit ?? resolved.maxListings;
-  const detailUrls = extractSitemapUrls(sitemapPage.html).slice(0, limit);
+  const collected = await collectMipublicVacatureUrls(
+    sitemapPage.html,
+    resolved.sitemapUrl,
+    fetchPublicJobBoardPage,
+  );
+  const detailUrls = typeof limit === "number" ? collected.urls.slice(0, limit) : collected.urls;
+  const sitemapErrors = [...collected.errors];
 
   if (detailUrls.length === 0) {
     return {
       listings: [],
-      errors: ["MiPublic sitemap bevat geen parseerbare vacature-URLs."],
+      errors: [
+        "MiPublic sitemap bevat geen parseerbare vacature-URLs.",
+        ...sitemapErrors,
+      ],
     };
   }
 
@@ -272,6 +381,7 @@ async function scrapeMipublicListings(
   });
 
   const listings = results.flatMap((entry) => entry.listings);
+  const realErrorsFromSitemap = sitemapErrors;
   const noDataEntries = results.filter(
     (
       entry,
@@ -282,9 +392,12 @@ async function scrapeMipublicListings(
     } => "isNoData" in entry && entry.isNoData === true,
   );
   const noDataCount = noDataEntries.length;
-  const realErrors = results.flatMap((entry) =>
-    entry.error && !("isNoData" in entry && entry.isNoData) ? [entry.error] : [],
-  );
+  const realErrors = [
+    ...realErrorsFromSitemap,
+    ...results.flatMap((entry) =>
+      entry.error && !("isNoData" in entry && entry.isNoData) ? [entry.error] : [],
+    ),
+  ];
   // Summarise missing-data pages into a single line instead of one per URL
   if (noDataCount > 0) {
     const exampleUrls = noDataEntries
@@ -317,13 +430,22 @@ export const mipublicAdapter: PlatformAdapter = {
         evidence: { sitemapUrl: resolved.sitemapUrl },
       };
     }
-    const detailUrls = extractSitemapUrls(sitemapPage.html);
+    const collected = await collectMipublicVacatureUrls(
+      sitemapPage.html,
+      resolved.sitemapUrl,
+      fetchPublicJobBoardPage,
+    );
+    const detailUrls = collected.urls;
 
     if (detailUrls.length === 0) {
       return {
         ok: false,
         status: "failed",
         message: "MiPublic sitemap bevat geen parseerbare vacaturedetailpagina's.",
+        evidence: {
+          sitemapUrl: resolved.sitemapUrl,
+          sitemapErrors: collected.errors,
+        },
       };
     }
 

--- a/tests/mipublic-scraper.test.ts
+++ b/tests/mipublic-scraper.test.ts
@@ -159,16 +159,69 @@ describe("mipublicAdapter.scrape", () => {
     vi.restoreAllMocks();
   });
 
-  it("continues the scrape when some detail pages lack JobPosting data", async () => {
+  it("falls back to /sitemap_index.xml when the flat /vacature-sitemap.xml is stale (RJC-213)", async () => {
+    const primarySitemapUrl = "https://mipublic.nl/vacature-sitemap.xml";
     const indexUrl = "https://mipublic.nl/sitemap_index.xml";
-    const subSitemapUrl = "https://mipublic.nl/vacature-sitemap.xml";
+    const freshChildUrl = "https://mipublic.nl/vacature-sitemap19.xml";
+
+    // Primary sitemap has only stale entries → yields 0 URLs after the 90-day cutoff.
+    const staleUrlsetXml = buildUrlset([
+      { loc: "https://mipublic.nl/vacature/stale/", lastmod: "2022-01-01T00:00:00+00:00" },
+    ]);
+    const indexXml = buildSitemapIndex([{ loc: freshChildUrl, lastmod: todayIso() }]);
+    const freshUrlsetXml = buildUrlset([
+      { loc: "https://mipublic.nl/vacature/verse-vacature/", lastmod: todayIso() },
+    ]);
+
+    const jobPosting = {
+      "@context": "https://schema.org",
+      "@type": "JobPosting",
+      title: "Beleidsmedewerker",
+      description: "<p>Verse MiPublic-vacature</p>",
+      url: "https://mipublic.nl/vacature/verse-vacature/",
+      identifier: { value: "mipublic-rjc213" },
+      hiringOrganization: { name: "Gemeente Motian" },
+    };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === primarySitemapUrl) return createHtmlResponse({ url, html: staleUrlsetXml });
+      if (url === indexUrl) return createHtmlResponse({ url, html: indexXml });
+      if (url === freshChildUrl) return createHtmlResponse({ url, html: freshUrlsetXml });
+      if (url === "https://mipublic.nl/vacature/verse-vacature/") {
+        return createHtmlResponse({
+          url,
+          html: `<html><head><script type="application/ld+json">${JSON.stringify(jobPosting)}</script></head><body></body></html>`,
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { mipublicAdapter } = await import("../packages/scrapers/src/mipublic");
+    const result = await mipublicAdapter.scrape({
+      baseUrl: "https://mipublic.nl",
+      parameters: {},
+    });
+
+    expect(result.listings).toHaveLength(1);
+    expect(result.listings[0]).toMatchObject({
+      title: "Beleidsmedewerker",
+      externalId: "mipublic-rjc213",
+    });
+    // Primary sitemap was fetched, fallback index + one child sitemap were traversed,
+    // and finally the detail page was fetched — four total network calls.
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("continues the scrape when some detail pages lack JobPosting data", async () => {
+    const primarySitemapUrl = "https://mipublic.nl/vacature-sitemap.xml";
     const jobUrls = [
       "https://mipublic.nl/vacature/job-with-jsonld/",
       "https://mipublic.nl/vacature/job-without-jsonld/",
       "https://mipublic.nl/vacature/job-archived/",
     ];
 
-    const indexXml = buildSitemapIndex([{ loc: subSitemapUrl, lastmod: todayIso() }]);
     const urlsetXml = buildUrlset(jobUrls.map((loc) => ({ loc, lastmod: todayIso() })));
 
     const jobPosting = {
@@ -183,8 +236,7 @@ describe("mipublicAdapter.scrape", () => {
 
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
-      if (url === indexUrl) return createHtmlResponse({ url, html: indexXml });
-      if (url === subSitemapUrl) return createHtmlResponse({ url, html: urlsetXml });
+      if (url === primarySitemapUrl) return createHtmlResponse({ url, html: urlsetXml });
       if (url === jobUrls[0]) {
         return createHtmlResponse({
           url,

--- a/tests/mipublic-scraper.test.ts
+++ b/tests/mipublic-scraper.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  collectMipublicVacatureUrls,
+  parseMipublicSitemap,
+} from "../packages/scrapers/src/mipublic";
+
+function buildUrlset(urls: Array<{ loc: string; lastmod?: string }>): string {
+  const entries = urls
+    .map(
+      ({ loc, lastmod }) =>
+        `<url><loc>${loc}</loc>${lastmod ? `<lastmod>${lastmod}</lastmod>` : ""}</url>`,
+    )
+    .join("");
+  return `<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${entries}</urlset>`;
+}
+
+function buildSitemapIndex(children: Array<{ loc: string; lastmod?: string }>): string {
+  const entries = children
+    .map(
+      ({ loc, lastmod }) =>
+        `<sitemap><loc>${loc}</loc>${lastmod ? `<lastmod>${lastmod}</lastmod>` : ""}</sitemap>`,
+    )
+    .join("");
+  return `<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${entries}</sitemapindex>`;
+}
+
+function todayIso(): string {
+  return new Date().toISOString();
+}
+
+function createHtmlResponse(options: {
+  html: string;
+  status?: number;
+  url: string;
+  headers?: Record<string, string>;
+}): Response {
+  return {
+    status: options.status ?? 200,
+    url: options.url,
+    headers: new Headers(options.headers),
+    text: async () => options.html,
+  } as Response;
+}
+
+describe("parseMipublicSitemap", () => {
+  it("detects a sitemap index and returns its children", () => {
+    const xml = buildSitemapIndex([
+      { loc: "https://mipublic.nl/vacature-sitemap.xml", lastmod: "2025-08-20T19:07:17+00:00" },
+      { loc: "https://mipublic.nl/vacature-sitemap19.xml", lastmod: "2025-03-01T00:00:00+00:00" },
+    ]);
+
+    const parsed = parseMipublicSitemap(xml);
+
+    expect(parsed.kind).toBe("index");
+    if (parsed.kind !== "index") return;
+    expect(parsed.children).toHaveLength(2);
+    expect(parsed.children[0]).toMatchObject({
+      url: "https://mipublic.nl/vacature-sitemap.xml",
+    });
+    expect(parsed.children[0].lastmod).toBeInstanceOf(Date);
+  });
+
+  it("filters urlset entries by the 90-day lastmod cutoff and vacancy path", () => {
+    const xml = buildUrlset([
+      { loc: "https://mipublic.nl/vacature/recent-job/", lastmod: todayIso() },
+      { loc: "https://mipublic.nl/vacature/stale-job/", lastmod: "2022-01-01T00:00:00+00:00" },
+      { loc: "https://mipublic.nl/over-ons/", lastmod: todayIso() },
+    ]);
+
+    const parsed = parseMipublicSitemap(xml);
+
+    expect(parsed.kind).toBe("urlset");
+    if (parsed.kind !== "urlset") return;
+    expect(parsed.urls).toEqual(["https://mipublic.nl/vacature/recent-job/"]);
+  });
+});
+
+describe("collectMipublicVacatureUrls", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("walks a sitemap index and aggregates ≥100 vacancy URLs across children", async () => {
+    const indexUrl = "https://mipublic.nl/sitemap_index.xml";
+    const today = todayIso();
+
+    // Recent sub-sitemap gets the vast majority of URLs — simulates Yoast's
+    // rolling active sitemap on mipublic.nl.
+    const freshChild = "https://mipublic.nl/vacature-sitemap.xml";
+    const staleChild = "https://mipublic.nl/vacature-sitemap2.xml";
+
+    const indexXml = buildSitemapIndex([
+      { loc: freshChild, lastmod: today },
+      { loc: staleChild, lastmod: "2023-11-23T14:44:27+00:00" },
+    ]);
+
+    const freshUrls = Array.from({ length: 120 }, (_, i) => ({
+      loc: `https://mipublic.nl/vacature/fresh-job-${i + 1}/`,
+      lastmod: today,
+    }));
+    const staleUrls = Array.from({ length: 50 }, (_, i) => ({
+      loc: `https://mipublic.nl/vacature/stale-job-${i + 1}/`,
+      lastmod: "2022-01-01T00:00:00+00:00",
+    }));
+
+    const fetcher = vi.fn(async (url: string) => {
+      if (url === freshChild) {
+        return { url, status: 200, html: buildUrlset(freshUrls) };
+      }
+      if (url === staleChild) {
+        return { url, status: 200, html: buildUrlset(staleUrls) };
+      }
+      throw new Error(`Unexpected sub-sitemap fetch: ${url}`);
+    });
+
+    const result = await collectMipublicVacatureUrls(indexXml, indexUrl, fetcher);
+
+    expect(result.urls.length).toBeGreaterThanOrEqual(100);
+    expect(result.urls).toContain("https://mipublic.nl/vacature/fresh-job-1/");
+    expect(result.errors).toEqual([]);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces HTTP errors from sub-sitemaps without collapsing the whole collection", async () => {
+    const indexXml = buildSitemapIndex([
+      { loc: "https://mipublic.nl/vacature-sitemap.xml", lastmod: todayIso() },
+      { loc: "https://mipublic.nl/vacature-sitemap-broken.xml", lastmod: todayIso() },
+    ]);
+
+    const fetcher = vi.fn(async (url: string) => {
+      if (url === "https://mipublic.nl/vacature-sitemap.xml") {
+        return {
+          url,
+          status: 200,
+          html: buildUrlset([
+            { loc: "https://mipublic.nl/vacature/werkende-job/", lastmod: todayIso() },
+          ]),
+        };
+      }
+      return { url, status: 502, html: "Bad Gateway" };
+    });
+
+    const result = await collectMipublicVacatureUrls(
+      indexXml,
+      "https://mipublic.nl/sitemap_index.xml",
+      fetcher,
+    );
+
+    expect(result.urls).toEqual(["https://mipublic.nl/vacature/werkende-job/"]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("HTTP 502");
+  });
+});
+
+describe("mipublicAdapter.scrape", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("continues the scrape when some detail pages lack JobPosting data", async () => {
+    const indexUrl = "https://mipublic.nl/sitemap_index.xml";
+    const subSitemapUrl = "https://mipublic.nl/vacature-sitemap.xml";
+    const jobUrls = [
+      "https://mipublic.nl/vacature/job-with-jsonld/",
+      "https://mipublic.nl/vacature/job-without-jsonld/",
+      "https://mipublic.nl/vacature/job-archived/",
+    ];
+
+    const indexXml = buildSitemapIndex([{ loc: subSitemapUrl, lastmod: todayIso() }]);
+    const urlsetXml = buildUrlset(jobUrls.map((loc) => ({ loc, lastmod: todayIso() })));
+
+    const jobPosting = {
+      "@context": "https://schema.org",
+      "@type": "JobPosting",
+      title: "Senior Adviseur",
+      description: "<p>Motian MiPublic-vacature</p>",
+      url: jobUrls[0],
+      identifier: { value: "mipublic-001" },
+      hiringOrganization: { name: "Gemeente Motian" },
+    };
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === indexUrl) return createHtmlResponse({ url, html: indexXml });
+      if (url === subSitemapUrl) return createHtmlResponse({ url, html: urlsetXml });
+      if (url === jobUrls[0]) {
+        return createHtmlResponse({
+          url,
+          html: `<html><head><script type="application/ld+json">${JSON.stringify(jobPosting)}</script></head><body><h1>Senior Adviseur</h1></body></html>`,
+        });
+      }
+      if (url === jobUrls[1]) {
+        // No JSON-LD, but a usable <h1> for the fallback parser — scrape should continue.
+        return createHtmlResponse({
+          url,
+          html: "<html><head><title>Docent Wiskunde - MiPublic</title></head><body><h1>Docent Wiskunde</h1></body></html>",
+        });
+      }
+      if (url === jobUrls[2]) {
+        // Page exists but has no JobPosting and no meaningful title — counted as skipped.
+        return createHtmlResponse({
+          url,
+          html: "<html><head><title>MiPublic</title></head><body>Deze vacature is niet meer beschikbaar.</body></html>",
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { mipublicAdapter } = await import("../packages/scrapers/src/mipublic");
+
+    const result = await mipublicAdapter.scrape({
+      baseUrl: "https://mipublic.nl",
+      parameters: {},
+    });
+
+    expect(result.listings.length).toBeGreaterThanOrEqual(1);
+    expect(result.listings.some((listing) => listing.title === "Senior Adviseur")).toBe(true);
+    expect(result.listings.some((listing) => listing.title === "Docent Wiskunde")).toBe(true);
+    // Missing-JSON-LD page is summarised into a single line, not a per-URL failure cascade.
+    expect(result.errors?.some((error) => /MiPublic detailpagina/.test(error))).toBe(true);
+    expect(result.errors?.every((error) => !/geen parseerbare vacature-URLs/.test(error))).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
Closes [RJC-213](https://linear.app/ryan-lisse-personal/issue/RJC-213/)

## Summary
- MiPublic now serves a `<sitemapindex>` at `/sitemap_index.xml` that fans out to ~20 `vacature-sitemap*.xml` children. The previous extractor fetched `/vacature-sitemap.xml` directly and then filtered URLs by a 90-day `<lastmod>` cutoff — and all URLs in that specific sub-sitemap pre-date the window, so every run produced `MiPublic sitemap bevat geen parseerbare vacature-URLs` with `jobsFound=0`.
- Switched the default sitemap path to `/sitemap_index.xml`, added a pure `parseMipublicSitemap()` that discriminates index vs urlset, and a `collectMipublicVacatureUrls()` walker that fans out newest-first across child sitemaps (capped at 30, 4-way concurrent).
- Detail pages lacking JSON-LD `JobPosting` data are still summarised into one error line instead of failing the scrape; the new test file locks that behavior in so it doesn't regress.

## Test plan
- [x] `pnpm vitest run tests/mipublic-scraper.test.ts` — 5/5 passing
- [x] Covers sitemap-index traversal with ≥100 aggregated URLs
- [x] Covers HTTP 5xx on a sub-sitemap (surfaces per-child error, does not collapse the run)
- [x] Covers mixed detail pages (one with JSON-LD, one without, one archived) — asserts the scrape continues and the missing-JSON-LD pages are summarised
- [x] `pnpm exec biome check tests/mipublic-scraper.test.ts` clean
- [x] `pnpm exec tsc --noEmit` clean on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
