### PR TITLE
fix(scrapers): werkzoeken abort propagation + pnr=10 markup (RJC-212)

### DIFF
--- a/packages/scrapers/src/werkzoeken.ts
+++ b/packages/scrapers/src/werkzoeken.ts
@@ -19,7 +19,10 @@ import {
 
 const WERKZOEKEN_FETCH_TIMEOUT_MS = 20_000;
 const WERKZOEKEN_SCRAPE_MAX_DURATION_MS = 240_000;
-const WERKZOEKEN_SCRAPE_MAX_DURATION_MIN_MS = 30_000;
+// Lower bound is intentionally small so tests (and aggressive scheduling)
+// can request short deadlines; the AbortSignal then short-circuits every
+// in-flight fetch instead of waiting for the per-request timeout.
+const WERKZOEKEN_SCRAPE_MAX_DURATION_MIN_MS = 500;
 const WERKZOEKEN_SCRAPE_MAX_DURATION_MAX_MS = 600_000;
 
 function resolveWerkzoekenMaxDurationMs(value: unknown): number {
@@ -60,6 +63,42 @@ type WerkzoekenSession = {
   cookieHeader?: string;
   referer: string;
 };
+
+function combineSignals(
+  perRequestTimeoutMs: number,
+  external?: AbortSignal,
+): AbortSignal {
+  const perRequest = AbortSignal.timeout(perRequestTimeoutMs);
+  if (!external) return perRequest;
+  const anyFn = (AbortSignal as unknown as { any?: (signals: AbortSignal[]) => AbortSignal })
+    .any;
+  if (typeof anyFn === "function") {
+    return anyFn.call(AbortSignal, [perRequest, external]);
+  }
+  // Fallback: manual composition for runtimes without AbortSignal.any
+  const controller = new AbortController();
+  const forwardAbort = (src: AbortSignal) => {
+    if (src.aborted) {
+      controller.abort((src as { reason?: unknown }).reason);
+      return;
+    }
+    src.addEventListener("abort", () => controller.abort((src as { reason?: unknown }).reason), {
+      once: true,
+    });
+  };
+  forwardAbort(perRequest);
+  forwardAbort(external);
+  return controller.signal;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    const reason = (signal as { reason?: unknown }).reason;
+    throw reason instanceof Error
+      ? reason
+      : new Error(typeof reason === "string" ? reason : "Werkzoeken scrape afgebroken");
+  }
+}
 
 function parseSalaryValue(value: string | undefined): number | undefined {
   if (!value) return undefined;
@@ -122,7 +161,7 @@ function extractWerkzoekenCookieHeader(response: Response): string | undefined {
 
 async function fetchWerkzoekenResponse(
   url: string,
-  options?: Partial<WerkzoekenSession>,
+  options?: Partial<WerkzoekenSession> & { signal?: AbortSignal },
 ): Promise<Response> {
   const headers = new Headers(DEFAULT_REQUEST_HEADERS);
   headers.set("Referer", options?.referer ?? DEFAULT_WERKZOEKEN_ORIGIN);
@@ -131,18 +170,21 @@ async function fetchWerkzoekenResponse(
     headers.set("Cookie", options.cookieHeader);
   }
 
+  throwIfAborted(options?.signal);
+
   return fetch(url, {
     headers,
-    signal: AbortSignal.timeout(WERKZOEKEN_FETCH_TIMEOUT_MS),
+    signal: combineSignals(WERKZOEKEN_FETCH_TIMEOUT_MS, options?.signal),
   });
 }
 
 async function bootstrapWerkzoekenSession(
   baseUrl: string,
   sourcePath: string,
+  signal?: AbortSignal,
 ): Promise<WerkzoekenSession> {
   const sourceUrl = resolveWerkzoekenSourceUrl(baseUrl, sourcePath);
-  const response = await fetchWerkzoekenResponse(sourceUrl.toString());
+  const response = await fetchWerkzoekenResponse(sourceUrl.toString(), { signal });
 
   if (response.ok) {
     return {
@@ -262,12 +304,14 @@ export function parseWerkzoekenDetailPage(
   };
 }
 
-async function fetchViaBrowserbase(url: string): Promise<string> {
+async function fetchViaBrowserbase(url: string, signal?: AbortSignal): Promise<string> {
   const apiKey = process.env.BROWSERBASE_API_KEY;
   const projectId = process.env.BROWSERBASE_PROJECT_ID;
   if (!apiKey || !projectId) {
     throw new Error("BROWSERBASE_API_KEY/PROJECT_ID niet geconfigureerd");
   }
+
+  throwIfAborted(signal);
 
   // Dynamic import to avoid bundling puppeteer-core when not used
   const puppeteer = await import("puppeteer-core");
@@ -275,7 +319,15 @@ async function fetchViaBrowserbase(url: string): Promise<string> {
     browserWSEndpoint: `wss://connect.browserbase.com?apiKey=${apiKey}&projectId=${projectId}`,
   });
 
+  const onAbort = () => {
+    // Close the remote browser as soon as the hard deadline fires so the
+    // puppeteer promises reject and the scrape unwinds promptly.
+    browser.close().catch(() => {});
+  };
+  signal?.addEventListener("abort", onAbort, { once: true });
+
   try {
+    throwIfAborted(signal);
     const page = await browser.newPage();
     await page.goto(url, { waitUntil: "networkidle2", timeout: 30_000 });
 
@@ -307,15 +359,18 @@ async function fetchViaBrowserbase(url: string): Promise<string> {
 
     return await page.content();
   } finally {
-    await browser.close();
+    signal?.removeEventListener("abort", onAbort);
+    await browser.close().catch(() => {});
   }
 }
 
-async function fetchViaFirecrawl(url: string): Promise<string> {
+async function fetchViaFirecrawl(url: string, signal?: AbortSignal): Promise<string> {
   const apiKey = process.env.FIRECRAWL_API_KEY;
   if (!apiKey) {
     throw new Error("FIRECRAWL_API_KEY niet geconfigureerd — kan niet terugvallen op Firecrawl");
   }
+
+  throwIfAborted(signal);
 
   const response = await fetch(FIRECRAWL_API_URL, {
     method: "POST",
@@ -324,7 +379,7 @@ async function fetchViaFirecrawl(url: string): Promise<string> {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({ url, formats: ["html"], waitFor: 2000 }),
-    signal: AbortSignal.timeout(30_000),
+    signal: combineSignals(30_000, signal),
   });
 
   if (!response.ok) {
@@ -339,14 +394,21 @@ async function fetchViaFirecrawl(url: string): Promise<string> {
   return body.data.html;
 }
 
-async function fetchHtml(url: string, session?: Partial<WerkzoekenSession>): Promise<string> {
+async function fetchHtml(
+  url: string,
+  session?: Partial<WerkzoekenSession>,
+  signal?: AbortSignal,
+): Promise<string> {
+  throwIfAborted(signal);
+
   // If Firecrawl is available, try direct fetch once then fallback immediately
   // (avoids wasting 8s on retries that will fail on cloud IPs)
   const maxAttempts = process.env.FIRECRAWL_API_KEY ? 1 : FETCH_RETRY_ATTEMPTS;
   let lastStatus = 0;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    const response = await fetchWerkzoekenResponse(url, session);
+    throwIfAborted(signal);
+    const response = await fetchWerkzoekenResponse(url, { ...session, signal });
 
     if (response.ok) {
       return response.text();
@@ -362,13 +424,15 @@ async function fetchHtml(url: string, session?: Partial<WerkzoekenSession>): Pro
     await new Promise((resolve) => setTimeout(resolve, FETCH_RETRY_DELAY_MS * attempt));
   }
 
+  throwIfAborted(signal);
+
   // Fallback chain: Browserbase (real Chrome, residential IP) → Firecrawl (JS rendering proxy)
   if (RETRYABLE_FETCH_STATUSES.has(lastStatus)) {
     if (process.env.BROWSERBASE_API_KEY) {
-      return fetchViaBrowserbase(url);
+      return fetchViaBrowserbase(url, signal);
     }
     if (process.env.FIRECRAWL_API_KEY) {
-      return fetchViaFirecrawl(url);
+      return fetchViaFirecrawl(url, signal);
     }
   }
 
@@ -380,17 +444,19 @@ async function enrichWerkzoekenListings(
   detailConcurrency: number,
   session?: Partial<WerkzoekenSession>,
   limit?: number,
+  signal?: AbortSignal,
 ): Promise<RawScrapedListing[]> {
   const bounded = listings.slice(0, limit ?? listings.length);
   const results: RawScrapedListing[] = [];
 
   for (let index = 0; index < bounded.length; index += detailConcurrency) {
+    throwIfAborted(signal);
     const batch = bounded.slice(index, index + detailConcurrency);
     const enriched = await Promise.all(
       batch.map(async (listing) => {
         const externalUrl = String(listing.externalUrl ?? "");
         try {
-          const detailHtml = await fetchHtml(externalUrl, session);
+          const detailHtml = await fetchHtml(externalUrl, session, signal);
           return {
             ...listing,
             ...parseWerkzoekenDetailPage(detailHtml, externalUrl),
@@ -408,14 +474,16 @@ async function enrichWerkzoekenListings(
 
 async function scrapeWerkzoekenInternal(
   config: PlatformRuntimeConfig,
-  options?: { limit?: number; smoke?: boolean },
+  options?: { limit?: number; smoke?: boolean; signal?: AbortSignal },
 ): Promise<PlatformScrapeResult> {
   const sourcePath = String(config.parameters.sourcePath ?? "/vacatures-voor/techniek/");
   const maxPages = parsePositiveInteger(config.parameters.maxPages, 3);
   const pnrStep = parsePositiveInteger(config.parameters.pnrStep, 10);
   const detailConcurrency = parsePositiveInteger(config.parameters.detailConcurrency, 4);
   const skipDetail = Boolean(config.parameters.skipDetailEnrichment);
-  const session = await bootstrapWerkzoekenSession(config.baseUrl, sourcePath);
+  const signal = options?.signal;
+  throwIfAborted(signal);
+  const session = await bootstrapWerkzoekenSession(config.baseUrl, sourcePath, signal);
 
   // pnr= returns cumulative results (pnr=10 -> 500 results).
   // We use sliding window (fetch pnr=10, 20, 30...) to minimize redundant bandwidth.
@@ -433,9 +501,10 @@ async function scrapeWerkzoekenInternal(
     pageUrls.map(async ({ page, url }) => ({
       page,
       url,
-      html: await fetchHtml(url, session),
+      html: await fetchHtml(url, session, signal),
     })),
   );
+  throwIfAborted(signal);
 
   const directPages = settledPages.map((result, index) => ({
     page: pageUrls[index].page,
@@ -459,8 +528,9 @@ async function scrapeWerkzoekenInternal(
     session.cookieHeader = undefined;
 
     for (const { page, url } of pageUrls) {
+      throwIfAborted(signal);
       try {
-        const browserbaseHtml = await fetchViaBrowserbase(url);
+        const browserbaseHtml = await fetchViaBrowserbase(url, signal);
         const parsed = parseWerkzoekenListingCards(browserbaseHtml, config.baseUrl);
         const added = pushNewListings(parsed);
 
@@ -555,6 +625,7 @@ async function scrapeWerkzoekenInternal(
     detailConcurrency,
     session,
     options?.limit ?? (options?.smoke ? 3 : undefined),
+    signal,
   );
 
   return {
@@ -602,16 +673,29 @@ export const werkzoekenAdapter: PlatformAdapter = {
     options?: { limit?: number; smoke?: boolean },
   ): Promise<PlatformScrapeResult> {
     const maxDurationMs = resolveWerkzoekenMaxDurationMs(config.parameters.maxDurationMs);
+    const controller = new AbortController();
+    const deadlineError = new Error(
+      `Werkzoeken scrape overschreed deadline van ${maxDurationMs}ms`,
+    );
     let timeoutHandle: ReturnType<typeof setNodeTimeout> | undefined;
     const timeoutPromise = new Promise<PlatformScrapeResult>((_, reject) => {
       timeoutHandle = setNodeTimeout(() => {
-        reject(new Error(`Werkzoeken scrape overschreed deadline van ${maxDurationMs}ms`));
+        // Abort all in-flight fetches so the inner scrape actually stops
+        // instead of leaking past the deadline (see RJC-212).
+        controller.abort(deadlineError);
+        reject(deadlineError);
       }, maxDurationMs);
     });
     try {
-      return await Promise.race([scrapeWerkzoekenInternal(config, options), timeoutPromise]);
+      return await Promise.race([
+        scrapeWerkzoekenInternal(config, { ...options, signal: controller.signal }),
+        timeoutPromise,
+      ]);
     } finally {
       if (timeoutHandle) clearNodeTimeout(timeoutHandle);
+      if (!controller.signal.aborted) {
+        controller.abort(new Error("Werkzoeken scrape afgerond"));
+      }
     }
   },
 

--- a/tests/fixtures/werkzoeken-pnr10.html
+++ b/tests/fixtures/werkzoeken-pnr10.html
@@ -1,0 +1,86 @@
+<!--
+  Minimal fixture captured from https://www.werkzoeken.nl/vacatures-voor/techniek/?pnr=10
+  on 2026-04-22. Two cards — representative of the deep-pagination markup that regressed
+  the listing regex before RJC-212: the `<h3>` element renders with attributes
+  (`<h3 data-vx="d">`) and trailing whitespace in the anchor's class attribute.
+-->
+<div class="vacancies-wrapper" itemscope itemtype="https://schema.org/ItemList">
+  <meta itemprop="name" content=" vacatures Techniek">
+  <meta itemprop="numberOfItems" content="66058">
+
+  <div itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+    <meta itemprop="position" content="1">
+    <a  data-position="1"
+        data-page-number="10"
+        data-result-count="500"
+        data-age="7 dagen geleden"
+        data-business="Techniflex"
+        data-business-type="Uitzendbureau"
+        data-contract-type="Loondienst (vast)"
+        data-education="MBO"
+        data-experience="Ervaren,Expert,Starter"
+        data-hours="Fulltime"
+        data-location-label="Zwolle"
+        data-salary-minimal="3200.00"
+        data-salary-maximum="4000.00"
+        id="row_15653251"
+        data-what="Techniek"
+        data-url="https://www.werkzoeken.nl/vacature/15653251-monteur-motoren/"
+        data-vacancyid="15653251"
+        class="vacancy vac  "
+        href="https://www.werkzoeken.nl/vacature/15653251-monteur-motoren/"
+        title="Monteur Motoren | Zwolle | Techniflex">
+        <h3 data-vx="d">
+            Monteur Motoren                    </h3>
+        <div class="location-and-company-name has-logo">
+            <strong>Zwolle</strong>
+            <span class="bullet">&bull;</span> Techniflex
+        </div>
+        <div class="requested-wrapper">
+            <div class="">Fulltime</div>
+            <div class="">MBO</div>
+            <div class="offer" style="background:#FFF5F5">&euro; 3.200 - &euro; 4.000 p/m</div>
+        </div>
+        <span class="meta">7 dagen geleden</span>
+    </a>
+    <span class="favorite pull-right"></span>
+  </div>
+
+  <div itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+    <meta itemprop="position" content="2">
+    <a  data-position="2"
+        data-page-number="10"
+        data-result-count="500"
+        data-age="5 dagen geleden"
+        data-business="Maandag&reg;"
+        data-business-type="Werving en selectie"
+        data-contract-type="Loondienst (vast)"
+        data-education="HBO"
+        data-experience="Ervaren,Expert,Starter"
+        data-hours="Fulltime"
+        data-location-label="Capelle aan den IJssel"
+        data-salary-minimal="4900.00"
+        data-salary-maximum="6300.00"
+        id="row_15666351"
+        data-what="Techniek"
+        data-url="https://www.werkzoeken.nl/vacature/15666351-projectleider-wmo-woningaanpassingen/"
+        data-vacancyid="15666351"
+        class="vacancy vac  "
+        href="https://www.werkzoeken.nl/vacature/15666351-projectleider-wmo-woningaanpassingen/"
+        title="Projectleider Wmo Woningaanpassingen | Capelle aan den IJssel | Maandag&reg;">
+        <h3 data-vx="d">
+            Projectleider Wmo Woningaanpassingen                    </h3>
+        <div class="location-and-company-name has-logo">
+            <strong>Capelle aan den IJssel</strong>
+            <span class="bullet">&bull;</span> Maandag&reg;
+        </div>
+        <div class="requested-wrapper">
+            <div class="">Fulltime</div>
+            <div class="">HBO</div>
+            <div class="offer" style="background:#FFF5F5">&euro; 4.900 - &euro; 6.300 p/m</div>
+        </div>
+        <span class="meta">5 dagen geleden</span>
+    </a>
+    <span class="favorite pull-right"></span>
+  </div>
+</div>

--- a/tests/werkzoeken-scraper.test.ts
+++ b/tests/werkzoeken-scraper.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildWerkzoekenListPageUrl,
@@ -480,6 +482,84 @@ describe("Werkzoeken scraper", () => {
 
     expect(result.errors).toBeUndefined();
     expect(result.listings).toHaveLength(1);
+  });
+
+  it("enforces the hard deadline by aborting hanging fetches (RJC-212 Bug A)", async () => {
+    // Restore real setTimeout so the hard deadline (setNodeTimeout) fires after maxDurationMs.
+    vi.restoreAllMocks();
+
+    const capturedSignals: AbortSignal[] = [];
+
+    globalThis.fetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal as AbortSignal | undefined;
+      if (signal) capturedSignals.push(signal);
+      // Fetch should reject when the AbortSignal fires — that is how real
+      // undici implements aborts. If the signal is not threaded through, the
+      // promise hangs forever and the hard deadline leaks.
+      return new Promise<Response>((_resolve, reject) => {
+        if (signal) {
+          if (signal.aborted) {
+            reject(new DOMException("Aborted", "AbortError"));
+            return;
+          }
+          signal.addEventListener(
+            "abort",
+            () => {
+              reject(new DOMException("Aborted", "AbortError"));
+            },
+            { once: true },
+          );
+        }
+        // Otherwise: never resolve (simulates a hung upstream).
+      });
+    }) as typeof fetch;
+
+    const start = Date.now();
+    let rejected: unknown;
+    await werkzoekenAdapter
+      .scrape(
+        {
+          slug: "werkzoeken",
+          baseUrl: "https://www.werkzoeken.nl",
+          parameters: {
+            sourcePath: "/vacatures-voor/techniek/",
+            maxPages: 10,
+            pnrStep: 10,
+            detailConcurrency: 1,
+            skipDetailEnrichment: true,
+            maxDurationMs: 2000,
+          },
+          auth: {},
+        },
+        { limit: 1 },
+      )
+      .catch((err) => {
+        rejected = err;
+      });
+    const elapsed = Date.now() - start;
+
+    expect(rejected).toBeDefined();
+    expect(elapsed).toBeLessThanOrEqual(3000);
+    expect(capturedSignals.length).toBeGreaterThan(0);
+    // Every fetch must have received a signal that ultimately aborts — proving
+    // the hard deadline's AbortController is threaded through every call.
+    for (const signal of capturedSignals) {
+      expect(signal.aborted).toBe(true);
+    }
+  });
+
+  it("extracts listing cards from deep pnr=10 markup fixture (RJC-212 Bug B)", () => {
+    const fixtureHtml = readFileSync(join(__dirname, "fixtures", "werkzoeken-pnr10.html"), "utf8");
+    const listings = parseWerkzoekenListingCards(fixtureHtml);
+
+    expect(listings.length).toBeGreaterThanOrEqual(1);
+    expect(listings[0]).toMatchObject({
+      externalId: "15653251",
+      title: "Monteur Motoren",
+      company: "Techniflex",
+      location: "Zwolle",
+    });
+    expect(listings.map((l) => l.externalId)).toContain("15666351");
   });
 
   it("deduplicates cumulative pnr responses across pages", async () => {


### PR DESCRIPTION
Closes RJC-212.

## Summary

- **Bug A — hard-timeout leaks.** The top-level `Promise.race` in `werkzoekenAdapter.scrape` rejected after the configured deadline, but the inner `scrapeWerkzoekenInternal` kept running because its AbortSignal was never threaded through `fetch()`. Production rows logged durations up to 6_407_823 ms even though the deadline error fired at 300_000 ms. The adapter now owns an `AbortController`, aborts it from the timeout callback, and plumbs the signal through `bootstrapWerkzoekenSession`, `fetchHtml`, `fetchWerkzoekenResponse`, `fetchViaFirecrawl`, `fetchViaBrowserbase`, and `enrichWerkzoekenListings`. Each call composes the external signal with the per-request `AbortSignal.timeout(...)` via `AbortSignal.any`, so whichever deadline fires first aborts the in-flight request. The Browserbase fallback also closes its remote browser on abort so puppeteer unwinds immediately. The max-duration min clamp was lowered from 30s → 500ms so short deadlines actually take effect.
- **Bug B — pagination markup regression guard.** Captured a fixture from the live `/vacatures-voor/techniek/?pnr=10` page (which renders `<h3 data-vx="d">` and trailing whitespace on `class="vacancy vac  "`) and added a parser test so the listing regex cannot silently regress again on deep pages. The current regex already matches 500/500 cards on the live page; this locks that in.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm vitest run tests/werkzoeken-scraper.test.ts` (14/14 passing, including the two new tests)
  - [x] `enforces the hard deadline by aborting hanging fetches (RJC-212 Bug A)` — mocks fetch to hang unless the signal fires; asserts wall-clock ≤ 3000 ms and every captured signal is aborted.
  - [x] `extracts listing cards from deep pnr=10 markup fixture (RJC-212 Bug B)` — parses the saved fixture and asserts ≥1 card plus known external IDs (`15653251`, `15666351`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/220" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
