### PR TITLE
fix(scrapers): mipublic retry sitemap via Browserbase on anti-bot block

### DIFF
--- a/packages/scrapers/src/mipublic.ts
+++ b/packages/scrapers/src/mipublic.ts
@@ -326,11 +326,61 @@ type SitemapDiscoveryResult =
  * RJC-213 regression mode where MiPublic's legacy `/vacature-sitemap.xml` has
  * been frozen in time and current vacancies are only reachable via the index.
  */
+async function fetchMipublicSitemapViaBrowserbase(url: string): Promise<string | null> {
+  const apiKey = process.env.BROWSERBASE_API_KEY;
+  const projectId = process.env.BROWSERBASE_PROJECT_ID;
+  if (!apiKey || !projectId) return null;
+
+  const puppeteer = await import("puppeteer-core");
+  const browser = await puppeteer.default.connect({
+    browserWSEndpoint: `wss://connect.browserbase.com?apiKey=${apiKey}&projectId=${projectId}`,
+  });
+
+  try {
+    const page = await browser.newPage();
+    await page.goto(url, { waitUntil: "networkidle2", timeout: 30_000 });
+
+    // MiPublic uses SiteGuard anti-bot (202 + meta-refresh). Wait briefly for
+    // the challenge to resolve and the actual XML to render.
+    const maxWaitMs = 15_000;
+    const startTime = Date.now();
+    while (Date.now() - startTime < maxWaitMs) {
+      const content = await page.content();
+      if (!content.toLowerCase().includes("sgcaptcha") && content.includes("<url")) {
+        return content;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1_500));
+    }
+    return await page.content();
+  } finally {
+    await browser.close().catch(() => {});
+  }
+}
+
+async function fetchSitemapWithBrowserbaseFallback(
+  url: string,
+): Promise<{ status: number; html: string; via: "direct" | "browserbase" }> {
+  const direct = await fetchPublicJobBoardPage(url);
+  if (!detectMipublicCaptchaBlocker(url, direct)) {
+    return { status: direct.status, html: direct.html, via: "direct" };
+  }
+
+  const browserbaseHtml = await fetchMipublicSitemapViaBrowserbase(url).catch(() => null);
+  if (browserbaseHtml && !browserbaseHtml.toLowerCase().includes("sgcaptcha")) {
+    return { status: 200, html: browserbaseHtml, via: "browserbase" };
+  }
+
+  return { status: direct.status, html: direct.html, via: "direct" };
+}
+
 async function discoverMipublicDetailUrls(
   resolved: MipublicOptions,
 ): Promise<SitemapDiscoveryResult> {
-  const sitemapPage = await fetchPublicJobBoardPage(resolved.sitemapUrl);
-  const blocker = detectMipublicCaptchaBlocker(resolved.sitemapUrl, sitemapPage);
+  const sitemapPage = await fetchSitemapWithBrowserbaseFallback(resolved.sitemapUrl);
+  const blocker =
+    sitemapPage.via === "direct"
+      ? detectMipublicCaptchaBlocker(resolved.sitemapUrl, sitemapPage)
+      : null;
   if (blocker) return { kind: "captcha", message: blocker.message };
 
   const collected = await collectMipublicVacatureUrls(
@@ -353,8 +403,9 @@ async function discoverMipublicDetailUrls(
   }
 
   try {
-    const indexPage = await fetchPublicJobBoardPage(fallbackUrl);
-    const indexBlocker = detectMipublicCaptchaBlocker(fallbackUrl, indexPage);
+    const indexPage = await fetchSitemapWithBrowserbaseFallback(fallbackUrl);
+    const indexBlocker =
+      indexPage.via === "direct" ? detectMipublicCaptchaBlocker(fallbackUrl, indexPage) : null;
     if (indexBlocker) return { kind: "captcha", message: indexBlocker.message };
     if (indexPage.status >= 400) {
       errors.push(`MiPublic sitemap-index ${fallbackUrl} gaf HTTP ${indexPage.status} terug.`);

--- a/scripts/scraper-diag.ts
+++ b/scripts/scraper-diag.ts
@@ -1,0 +1,110 @@
+import { db, desc, gte } from "../src/db";
+import { scrapeResults, scraperConfigs } from "../src/db/schema";
+
+const SEVEN_DAYS_AGO = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+async function main() {
+  const recent = await db
+    .select({
+      platform: scrapeResults.platform,
+      status: scrapeResults.status,
+      runAt: scrapeResults.runAt,
+      errors: scrapeResults.errors,
+      durationMs: scrapeResults.durationMs,
+      jobsFound: scrapeResults.jobsFound,
+      jobsNew: scrapeResults.jobsNew,
+    })
+    .from(scrapeResults)
+    .where(gte(scrapeResults.runAt, SEVEN_DAYS_AGO))
+    .orderBy(desc(scrapeResults.runAt));
+
+  type Stat = {
+    total: number;
+    ok: number;
+    failed: number;
+    partial: number;
+    lastErr?: string;
+    lastErrAt?: string;
+    lastStatus?: string;
+  };
+  const byPlatform = new Map<string, Stat>();
+  for (const r of recent) {
+    const s: Stat = byPlatform.get(r.platform) ?? { total: 0, ok: 0, failed: 0, partial: 0 };
+    s.total++;
+    if (r.status === "success") s.ok++;
+    else if (r.status === "partial") s.partial++;
+    else s.failed++;
+
+    if (!s.lastStatus) s.lastStatus = r.status;
+
+    if (r.status !== "success" && !s.lastErr) {
+      const errStr = Array.isArray(r.errors)
+        ? JSON.stringify(r.errors).slice(0, 300)
+        : typeof r.errors === "object" && r.errors !== null
+          ? JSON.stringify(r.errors).slice(0, 300)
+          : String(r.errors ?? "");
+      s.lastErr = errStr;
+      s.lastErrAt = r.runAt?.toISOString?.();
+    }
+    byPlatform.set(r.platform, s);
+  }
+
+  console.log("=== PLATFORM STATS (last 7 days) ===");
+  const rows = [...byPlatform.entries()]
+    .map(([platform, s]) => ({
+      platform,
+      total: s.total,
+      ok: s.ok,
+      partial: s.partial,
+      failed: s.failed,
+      okPct: s.total ? Math.round((s.ok / s.total) * 100) : 0,
+      lastErrAt: s.lastErrAt,
+      lastErr: s.lastErr?.slice(0, 160),
+    }))
+    .sort((a, b) => b.failed + b.partial - (a.failed + a.partial));
+  console.table(rows);
+
+  console.log("\n=== 30 MOST RECENT NON-SUCCESS RUNS ===");
+  const failures = recent.filter((r) => r.status !== "success").slice(0, 30);
+  for (const r of failures) {
+    const errStr = Array.isArray(r.errors)
+      ? JSON.stringify(r.errors)
+      : JSON.stringify(r.errors ?? "");
+    console.log(
+      `- [${r.runAt?.toISOString?.()}] ${r.platform} status=${r.status} dur=${r.durationMs}ms found=${r.jobsFound} new=${r.jobsNew} | ${errStr.slice(0, 300)}`,
+    );
+  }
+
+  const configs = await db
+    .select({
+      platform: scraperConfigs.platform,
+      isActive: scraperConfigs.isActive,
+      consecutiveFailures: scraperConfigs.consecutiveFailures,
+      lastRunAt: scraperConfigs.lastRunAt,
+      lastRunStatus: scraperConfigs.lastRunStatus,
+      validationStatus: scraperConfigs.validationStatus,
+      lastValidationError: scraperConfigs.lastValidationError,
+    })
+    .from(scraperConfigs);
+
+  console.log("\n=== CIRCUIT-BREAKER STATE (tripped when consecutiveFailures >= 5) ===");
+  console.table(
+    configs.map((c) => ({
+      platform: c.platform,
+      active: c.isActive,
+      consecFails: c.consecutiveFailures,
+      tripped: (c.consecutiveFailures ?? 0) >= 5,
+      lastRunAt: c.lastRunAt?.toISOString?.(),
+      lastRunStatus: c.lastRunStatus,
+      valStatus: c.validationStatus,
+      valErr: c.lastValidationError?.slice(0, 120),
+    })),
+  );
+
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/scraper-e2e-verify.ts
+++ b/scripts/scraper-e2e-verify.ts
@@ -1,0 +1,103 @@
+import { and, db, desc, eq, gte } from "../src/db";
+import { scrapeResults, scraperConfigs } from "../src/db/schema";
+import { runScrapePipeline } from "../src/services/scrape-pipeline";
+
+const platforms = process.argv.slice(2);
+if (platforms.length === 0) {
+  console.error("usage: tsx scripts/scraper-e2e-verify.ts <platform> [platform...]");
+  process.exit(1);
+}
+
+async function verifyOne(platform: string) {
+  const [config] = await db
+    .select({ baseUrl: scraperConfigs.baseUrl, isActive: scraperConfigs.isActive })
+    .from(scraperConfigs)
+    .where(eq(scraperConfigs.platform, platform))
+    .limit(1);
+
+  if (!config) return { platform, error: "no config in scraper_configs" };
+  if (!config.isActive) return { platform, error: "inactive" };
+
+  const startTs = Date.now();
+  console.log(`  → running ${platform} against ${config.baseUrl}`);
+  try {
+    const result = await runScrapePipeline(platform, config.baseUrl);
+    const wallMs = Date.now() - startTs;
+
+    const [latest] = await db
+      .select({
+        status: scrapeResults.status,
+        durationMs: scrapeResults.durationMs,
+        jobsFound: scrapeResults.jobsFound,
+        jobsNew: scrapeResults.jobsNew,
+        duplicates: scrapeResults.duplicates,
+        errors: scrapeResults.errors,
+        runAt: scrapeResults.runAt,
+      })
+      .from(scrapeResults)
+      .where(
+        and(
+          eq(scrapeResults.platform, platform),
+          gte(scrapeResults.runAt, new Date(startTs - 5000)),
+        ),
+      )
+      .orderBy(desc(scrapeResults.runAt))
+      .limit(1);
+
+    return { platform, wallMs, runResult: result, latest };
+  } catch (err) {
+    return {
+      platform,
+      wallMs: Date.now() - startTs,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+async function main() {
+  console.log(`Running e2e verification for ${platforms.join(", ")}\n`);
+  const all: Awaited<ReturnType<typeof verifyOne>>[] = [];
+  for (const p of platforms) {
+    console.log(`--- ${p} ---`);
+    const r = await verifyOne(p);
+    all.push(r);
+    if ("error" in r && r.error) {
+      console.log(`  ERROR  ${r.error}`);
+    } else if ("runResult" in r) {
+      console.log(
+        `  duration=${((r.wallMs ?? 0) / 1000).toFixed(1)}s  runResult.jobsNew=${r.runResult?.jobsNew}  dup=${r.runResult?.duplicates}  errors=${r.runResult?.errors?.length ?? 0}`,
+      );
+      if (r.latest) {
+        const errs = Array.isArray(r.latest.errors)
+          ? JSON.stringify(r.latest.errors).slice(0, 200)
+          : "";
+        console.log(
+          `  dbrow: status=${r.latest.status}  found=${r.latest.jobsFound}  new=${r.latest.jobsNew}  dup=${r.latest.duplicates}  ${errs}`,
+        );
+      } else {
+        console.log("  dbrow: (none in last 5s — check recordScrapeResult path)");
+      }
+    }
+  }
+
+  console.log("\n=== Summary ===");
+  console.table(
+    all.map((r) => ({
+      platform: r.platform,
+      status: "latest" in r && r.latest ? r.latest.status : "error" in r ? "ERROR" : "?",
+      found: "latest" in r && r.latest ? r.latest.jobsFound : 0,
+      new: "latest" in r && r.latest ? r.latest.jobsNew : 0,
+      durMs: "wallMs" in r ? r.wallMs : 0,
+      err: "error" in r ? r.error : undefined,
+    })),
+  );
+  const anyError = all.some(
+    (r) => ("error" in r && r.error) || ("latest" in r && r.latest?.status === "failed"),
+  );
+  process.exit(anyError ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
MiPublic now serves the SiteGuard anti-bot challenge (HTTP 202 + sgcaptcha markup) on direct fetches of /vacature-sitemap.xml, so even the RJC-213 primary→sitemap_index fallback can't get through. This PR routes the sitemap fetch through the Browserbase puppeteer endpoint (same pattern used in packages/scrapers/src/werkzoeken.ts) when captcha is detected.

## Scope
- Modified: packages/scrapers/src/mipublic.ts — adds fetchMipublicSitemapViaBrowserbase + fetchSitemapWithBrowserbaseFallback. Applied at both the primary sitemap URL and the /sitemap_index.xml fallback.
- Added: scripts/scraper-diag.ts — per-platform scrape_results diagnosis.
- Added: scripts/scraper-e2e-verify.ts — direct adapter invocation harness (used to produce the live evidence here).

## Evidence
Direct e2e run on 2026-04-22 against live mipublic.nl returned: status=failed, 0 found, err 'MiPublic pagina wordt geblokkeerd door een anti-bot challenge: https://mipublic.nl/vacature-sitemap.xml'.

## Test plan
- [x] pnpm vitest run tests/mipublic-scraper.test.ts tests/public-job-board-adapters.test.ts — 16/16 passing.
- [x] pnpm lint
- [x] pnpm exec tsc --noEmit
- [ ] Post-merge live e2e re-run verifies mipublic now returns status=success with jobsFound > 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
