### PR TITLE
fix(scrapers): mipublic sessions API + drop broken opdrachtoverheid logos

### DIFF
--- a/packages/scrapers/src/mipublic.ts
+++ b/packages/scrapers/src/mipublic.ts
@@ -326,32 +326,59 @@ type SitemapDiscoveryResult =
  * RJC-213 regression mode where MiPublic's legacy `/vacature-sitemap.xml` has
  * been frozen in time and current vacancies are only reachable via the index.
  */
+async function createBrowserbaseSession(
+  apiKey: string,
+  projectId: string,
+): Promise<string | null> {
+  try {
+    const response = await fetch("https://api.browserbase.com/v1/sessions", {
+      method: "POST",
+      headers: {
+        "X-BB-API-Key": apiKey,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ projectId }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!response.ok) return null;
+    const body = (await response.json()) as { connectUrl?: string };
+    return body.connectUrl ?? null;
+  } catch {
+    return null;
+  }
+}
+
 async function fetchMipublicSitemapViaBrowserbase(url: string): Promise<string | null> {
   const apiKey = process.env.BROWSERBASE_API_KEY;
   const projectId = process.env.BROWSERBASE_PROJECT_ID;
   if (!apiKey || !projectId) return null;
 
+  const connectUrl = await createBrowserbaseSession(apiKey, projectId);
+  if (!connectUrl) return null;
+
   const puppeteer = await import("puppeteer-core");
-  const browser = await puppeteer.default.connect({
-    browserWSEndpoint: `wss://connect.browserbase.com?apiKey=${apiKey}&projectId=${projectId}`,
-  });
+  const browser = await puppeteer.default.connect({ browserWSEndpoint: connectUrl });
 
   try {
     const page = await browser.newPage();
     await page.goto(url, { waitUntil: "networkidle2", timeout: 30_000 });
 
-    // MiPublic uses SiteGuard anti-bot (202 + meta-refresh). Wait briefly for
-    // the challenge to resolve and the actual XML to render.
-    const maxWaitMs = 15_000;
+    // MiPublic uses SiteGuard anti-bot (HTTP 202 + meta-refresh to
+    // /.well-known/captcha/). Poll until the challenge self-resolves; the
+    // browser then holds the SiteGuard cookie so an in-page fetch() returns
+    // the raw XML (puppeteer's page.content() wraps XML in an HTML document).
+    const maxWaitMs = 25_000;
     const startTime = Date.now();
     while (Date.now() - startTime < maxWaitMs) {
-      const content = await page.content();
-      if (!content.toLowerCase().includes("sgcaptcha") && content.includes("<url")) {
-        return content;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 1_500));
+      await new Promise((resolve) => setTimeout(resolve, 2_000));
+      const html = await page.content();
+      if (!html.toLowerCase().includes("sgcaptcha")) break;
     }
-    return await page.content();
+
+    return await page.evaluate(async (u) => {
+      const res = await fetch(u);
+      return await res.text();
+    }, url);
   } finally {
     await browser.close().catch(() => {});
   }

--- a/packages/scrapers/src/opdrachtoverheid.ts
+++ b/packages/scrapers/src/opdrachtoverheid.ts
@@ -318,9 +318,13 @@ export function mapOpdrachtoverheidTenderToListing(t: OpdrachtoverheidTender): R
     latitude: loc.latitude ? parseFloat(loc.latitude) : undefined,
     longitude: loc.longitude ? parseFloat(loc.longitude) : undefined,
     postcode: loc.postcode ?? undefined,
-    companyLogoUrl: loc.avatar
-      ? `https://kbenp-match-api.azurewebsites.net/images/${loc.avatar}`
-      : undefined,
+    // Skip the avatar if it lacks a valid file extension — the upstream API
+    // sometimes returns `blob_XXX.` (trailing dot, no extension) which 404s on
+    // the Azure CDN and shows as a broken image in the UI.
+    companyLogoUrl:
+      loc.avatar && /\.(png|jpe?g|gif|svg|webp)$/i.test(loc.avatar)
+        ? `https://kbenp-match-api.azurewebsites.net/images/${loc.avatar}`
+        : undefined,
     sourceUrl: t.tender_url ?? undefined,
     sourcePlatform: t.tender_source ?? undefined,
     durationMonths: computeDurationMonths(t.tender_start_date, t.tender_end_date),


### PR DESCRIPTION
## Summary
Two follow-ups discovered during live e2e verification:

### 1. mipublic — Browserbase sessions API (follow-up to PR #221)
The direct `wss://connect.browserbase.com?apiKey=&projectId=` WebSocket is deprecated (returns 400). New flow: POST `/v1/sessions` then connect to the signed `connectUrl` returned by that call. Also switched from `page.content()` (wraps XML in HTML) to `page.evaluate(fetch)` so the downstream XML parser gets raw bytes via the SiteGuard-unlocked cookie jar.

Result: sitemap fetch now works (~12s, 632 URLs discovered). Detail-page fetches still hit SiteGuard — separate follow-up ticket needed.

### 2. opdrachtoverheid — broken logo URLs
API returns `loc.avatar = "blob_XXX."` (trailing dot, no extension). Resulting URLs 404 on the Azure CDN, flooding the browser console with `image:1 Failed to load resource: 404` on the vacatures list page. Validates `loc.avatar` has a valid image extension before storing; falls back to the `<Building2>` icon in `<CompanyLogo>` when the URL is absent.

Also: one-shot DB cleanup via tsx script nulled **9,547** already-stored broken URLs (not in the commit since it's a migration, not repeatable code).

## Test plan
- [x] pnpm lint
- [x] pnpm exec tsc --noEmit
- [ ] Visual check: no more `image:1 404` floods in devtools console on /vacatures.
- [ ] Next opdrachtoverheid scrape: confirm no new rows stored with trailing-dot URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed company logo URLs to validate image file extensions, preventing broken links from appearing in results.

* **Improvements**
  * Enhanced sitemap discovery with improved anti-bot detection handling and more reliable content extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->