### PR TITLE
fix(perf): speed up fetchDedupedJobsPageFast and stop Neon connection drops (RJC-217)

### DIFF
--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -130,6 +130,10 @@ function createNeonDatabaseClient(): DatabaseClient {
     connectionString: url,
     max: 5,
     connectionTimeoutMillis: 5_000,
+    // Recycle idle sockets before Neon's server-side reaper silently closes
+    // them. Without this, a hot pool connection that has been idle for 60s+
+    // raises "Connection terminated unexpectedly" on the next SSR acquire.
+    idleTimeoutMillis: 30_000,
   });
 
   poolRef = pool;

--- a/src/services/jobs/dedupe-ranks.ts
+++ b/src/services/jobs/dedupe-ranks.ts
@@ -3,7 +3,11 @@ import { jobDedupeRanks, jobs } from "../../db/schema";
 import { getVisibleVacancyCondition } from "./filters";
 
 const STALE_THRESHOLD_MS = 30 * 60 * 1000; // 30 minutes
-const FRESHNESS_CACHE_TTL_MS = 5_000;
+// Freshness only needs to be re-checked when it has a real chance of having
+// flipped stale→fresh (that only happens after a refresh runs, which we
+// invalidate the cache for explicitly). One minute is plenty; the previous
+// 5s value caused every parallel SSR render to hit the DB.
+const FRESHNESS_CACHE_TTL_MS = 60_000;
 const DEDUPE_REFRESH_DEBOUNCE_MS = 5_000;
 
 let cachedFreshness: {
@@ -121,10 +125,14 @@ export async function getDedupeRanksFreshness(): Promise<{
     return cachedFreshness.value;
   }
 
+  // `refreshDedupeRanks` writes the same `computedAt` to every row in one
+  // atomic INSERT … ON CONFLICT, so any single row carries the current
+  // snapshot timestamp. Using `ORDER BY computed_at DESC LIMIT 1` forces a
+  // full sort over ~50k rows (no index on `computed_at`) and was the main
+  // source of the 3s listJobsPage slowdown that dropped Neon connections.
   const rows = await db
     .select({ computedAt: jobDedupeRanks.computedAt })
     .from(jobDedupeRanks)
-    .orderBy(sql`${jobDedupeRanks.computedAt} DESC`)
     .limit(1);
 
   const computedAt = rows[0]?.computedAt ?? null;


### PR DESCRIPTION
Linear: [RJC-217](https://linear.app/ryanlisse/issue/RJC-217)

## Summary

- `listJobsPage` was clocking ~3s with `dedupePageMs=3034ms` for a 12-row sidebar page (34× longer than hydrate), and every SSR render dropped a Neon connection with `Connection terminated unexpectedly`.
- Two independent root causes; both fixed. No schema/migration changes.

## What was wrong

### 1. Full-table scan in the freshness check

`getDedupeRanksFreshness()` ran

```sql
SELECT computed_at FROM job_dedupe_ranks ORDER BY computed_at DESC LIMIT 1
```

but migration `0022_job_dedupe_ranks.sql` only indexes `job_id` (PK), `dedupe_rank`, and `dedupe_group`. There is **no index on `computed_at`**, so Postgres full-scans the heap on every freshness check. With the cache TTL at only 5s, parallel SSR (sidebar + main grid both calling `listJobsPage`) repeatedly paid that scan.

`refreshDedupeRanks` writes the **same** `computed_at` to every row in one atomic `INSERT … ON CONFLICT`, so any row carries the current snapshot timestamp — a plain `LIMIT 1` without `ORDER BY` is correct and cheap.

### 2. Neon pool didn't recycle idle connections

`packages/db/src/index.ts` configured `connectionTimeoutMillis` but no `idleTimeoutMillis`. Neon's server-side idle reaper closes the WebSocket, and the next acquire inside a 3s-long SSR render raises `Connection terminated unexpectedly`.

## Changes

- **`src/services/jobs/dedupe-ranks.ts`**
  - Drop the `ORDER BY computed_at DESC` on the freshness query (now `LIMIT 1` against the heap).
  - Bump `FRESHNESS_CACHE_TTL_MS` from 5s → 60s. `refreshDedupeRanks` already invalidates the cache explicitly, so this only reduces DB round-trips under burst load.
- **`packages/db/src/index.ts`**
  - Add `idleTimeoutMillis: 30_000` so the pool recycles idle WebSockets before Neon does.

## Test plan

- [x] `pnpm lint` passes (Biome, 894 files, no issues).
- [x] `pnpm exec tsc --noEmit` passes.
- [x] `pnpm vitest run tests/jobs-deduplication*.test.ts tests/jobs-page-service.test.ts tests/dedupe-ranks.test.ts tests/dedupe-fast-path-stale.test.ts` — **24/24 passing**.
- [ ] Verify on the Vercel preview that `/vacatures` sidebar hydrates without the `Connection terminated unexpectedly` error and that `listJobsPage` slow-query log drops well under the SLO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
