### PR TITLE
fix(ui): /dashboard redirect + kandidaat/kandidaten pluralization (autopilot)

### DIFF
--- a/app/kandidaten/page.tsx
+++ b/app/kandidaten/page.tsx
@@ -183,7 +183,9 @@ async function KandidatenContent({ searchParams }: Props) {
 
         {/* Results count */}
         <div className="flex items-center justify-between">
-          <p className="text-sm text-muted-foreground">{totalCount} kandidaten gevonden</p>
+          <p className="text-sm text-muted-foreground">
+            {totalCount} {totalCount === 1 ? "kandidaat" : "kandidaten"} gevonden
+          </p>
           {totalPages > 1 && (
             <p className="text-sm text-muted-foreground">
               Pagina {page} van {totalPages}

--- a/next.config.ts
+++ b/next.config.ts
@@ -33,6 +33,12 @@ const nextConfig: NextConfig = {
         destination: "/vacatures",
         permanent: true,
       },
+      // /dashboard is the common English default; this app's overview lives at /overzicht.
+      {
+        source: "/dashboard",
+        destination: "/overzicht",
+        permanent: true,
+      },
     ];
   },
   turbopack: {


### PR DESCRIPTION
## Summary
Two autopilot findings from run 3ee0845f (22 apr 02:00):

1. **`/dashboard` 404 (critical)** → permanent redirect to `/overzicht` in `next.config.ts`.
2. **"1 kandidaten gevonden" (low, autoFixable)** → conditional `kandidaat` vs `kandidaten` in `app/kandidaten/page.tsx`.

## Left for separate tickets (autopilot findings #4 and #5)
- /chat conversation list stuck on "Laden…" — needs root-cause investigation
- /chat action button text truncated — needs CSS layout review

## Test plan
- [x] pnpm lint
- [x] pnpm exec tsc --noEmit
- [ ] Post-merge: `curl -I https://motian.vercel.app/dashboard` → 308 to /overzicht
- [ ] Next autopilot cycle: both findings no longer surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
