### PR TITLE
fix(chat): conversation list invalidation + action button overflow

### DIFF
--- a/components/chat/chat-history-sidebar.tsx
+++ b/components/chat/chat-history-sidebar.tsx
@@ -63,21 +63,16 @@ export function ChatHistorySidebar({
       }
     } catch (err) {
       console.error("[ChatHistorySidebar] Fetch sessions failed:", err);
+    } finally {
+      // Always clear the loading state so the sidebar never gets stuck on
+      // "Laden..." — even if this effect is superseded by a refreshToken bump
+      // mid-fetch (setting state on a stale attempt is harmless here).
+      setLoading(false);
     }
   }, [refreshToken]);
 
   useEffect(() => {
-    let cancelled = false;
-
-    void fetchSessions().finally(() => {
-      if (!cancelled) {
-        setLoading(false);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
+    void fetchSessions();
   }, [fetchSessions]);
 
   useEffect(() => {

--- a/components/chat/genui/action-primitives.tsx
+++ b/components/chat/genui/action-primitives.tsx
@@ -51,7 +51,8 @@ export function ActionButton({
   disabled?: boolean;
 }) {
   const base = cn(
-    "inline-flex items-center justify-center gap-2 transition-colors",
+    "inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap transition-colors",
+    "[&_svg]:shrink-0",
     genuiTouchTargetClassName,
   );
   const variants = {
@@ -67,7 +68,7 @@ export function ActionButton({
       className={cn(base, variants[variant], "disabled:opacity-50")}
     >
       <Icon className="h-4 w-4" />
-      {label}
+      <span>{label}</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
Fixes two chat UI findings from autopilot run `3ee0845f`.

### Finding 1 — `/chat` sidebar stuck on "Laden..." (medium)
The `ChatHistorySidebar` could get stuck on the "Laden..." state because the loading flag was only cleared when the `cancelled` guard in the effect cleanup allowed it. If `refreshToken` bumped mid-fetch (exactly what happens when the client detects a new conversation after the `submitted → streaming → ready` status transition), the pending fetch's `.finally()` would see `cancelled === true` and skip `setLoading(false)`. Fix: move `setLoading(false)` into `fetchSessions`' own `finally` so each fetch attempt always clears the flag, regardless of whether the triggering effect has been superseded.

### Finding 2 — action button label clipped (low)
The `ActionButton` primitive used by GenUI action bars (`A2UIActionBar` and friends) lacked `whitespace-nowrap` / `shrink-0` and rendered its label as a bare text node. Inside parents that use `flex flex-wrap` with `gap`, the label could wrap or be clipped visually. Fix: add `whitespace-nowrap`, `shrink-0`, and `[&_svg]:shrink-0`, and wrap the label in a `<span>` so flex layout treats the icon + label as one non-shrinking block.

## Test plan
- [x] `pnpm lint` — Biome, no issues.
- [x] `pnpm exec tsc --noEmit` — clean.
- [x] `/chat` loaded in dev server, sidebar populated correctly (no stuck "Laden..." state).
- [ ] Manual: send a new message in a fresh session and confirm it appears in "Gesprekken" without refresh.
- [ ] Manual: trigger a GenUI tool whose action bar has long Dutch labels (e.g. "Nog niet beschikbaar") and confirm no clipping.

Autopilot run: `3ee0845f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with the chat history loading indicator that could become stuck on screen in certain timing scenarios, preventing the loading state from properly clearing.

* **UI Improvements**
  * Enhanced action button styling to prevent text from wrapping, maintain consistent button spacing, and ensure all nested icons remain properly sized and aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->