### PR TITLE
fix(scrapers+trigger): mipublic fully success + nightly-maintenance SQL bug

### DIFF
--- a/packages/scrapers/src/mipublic.ts
+++ b/packages/scrapers/src/mipublic.ts
@@ -592,16 +592,31 @@ async function scrapeMipublicListings(
       entry.error && !("isNoData" in entry && entry.isNoData) ? [entry.error] : [],
     ),
   ];
-  // Summarise missing-data pages into a single line instead of one per URL
+  // Missing-JSON-LD pages are expected at a small rate — MiPublic sometimes
+  // serves legacy/expired vacancies without structured data. Treat them as
+  // benign skips (don't bump the run to "partial") unless the rate exceeds
+  // 5% of total URLs, which would signal a real parser regression.
+  const totalFetched = detailUrls.length;
+  const noDataRatio = totalFetched > 0 ? noDataCount / totalFetched : 0;
+  const NO_DATA_REGRESSION_THRESHOLD = 0.05;
+
   if (noDataCount > 0) {
     const exampleUrls = noDataEntries
       .map((entry) => entry.error.replace("MiPublic detailpagina bevat geen JobPosting-data: ", ""))
       .slice(0, 3);
-    const exampleSuffix =
-      exampleUrls.length > 0 ? ` (bijv. ${exampleUrls.join(", ")})` : "";
-    realErrors.push(
-      `${noDataCount} MiPublic detailpagina's bevatten geen JobPosting-data${exampleSuffix}`,
-    );
+    const exampleSuffix = exampleUrls.length > 0 ? ` (bijv. ${exampleUrls.join(", ")})` : "";
+    const summary = `${noDataCount} MiPublic detailpagina's bevatten geen JobPosting-data${exampleSuffix}`;
+
+    if (noDataRatio > NO_DATA_REGRESSION_THRESHOLD) {
+      // >5% missing JSON-LD is a real signal — surface it as an error so the
+      // run status becomes "partial" and the observability layer alerts.
+      realErrors.push(
+        `${summary} — rate ${(noDataRatio * 100).toFixed(1)}% exceeds ${(NO_DATA_REGRESSION_THRESHOLD * 100).toFixed(0)}% threshold`,
+      );
+    } else {
+      // Low-rate misses are expected for legacy content. Log but don't fail.
+      console.log(`[mipublic] ${summary} — within tolerance, not bumping to partial`);
+    }
   }
 
     return {

--- a/trigger/nightly-maintenance.ts
+++ b/trigger/nightly-maintenance.ts
@@ -83,14 +83,21 @@ export const nightlyMaintenanceTask = schedules.task({
         ) as integer)`,
       })
       .from(jobs)
-      .where(and(getVisibleVacancyCondition(), isNotNull(jobs.embedding)))
-      .having(
-        sql`coalesce(
-          (select count(*) from job_matches jm
-           where jm.job_id = ${jobs.id}
-           and jm.status in ('pending', 'accepted')),
-          0
-        ) < 3`,
+      .where(
+        and(
+          getVisibleVacancyCondition(),
+          isNotNull(jobs.embedding),
+          // "Underserved" = fewer than 3 active matches. Correlated subquery
+          // goes in WHERE (not HAVING) because this query has no GROUP BY —
+          // HAVING here produced "column jobs.id must appear in the GROUP BY
+          // clause" and crashed every nightly run since April 2.
+          sql`coalesce(
+            (select count(*) from job_matches jm
+             where jm.job_id = ${jobs.id}
+             and jm.status in ('pending', 'accepted')),
+            0
+          ) < 3`,
+        ),
       )
       .limit(10);
 


### PR DESCRIPTION
Two related fixes:

## 1. mipublic: partial → success
mipublic has been landing `partial` on every successful scrape for months because 3 of ~720 detail pages legitimately lack JSON-LD (legacy content in MiPublic's CMS). The no-data count was emitted as a pipeline error → status=partial.

**Fix**: treat <5% missing-JSON-LD as a benign skip (logged, not errored). Above 5% a real error surfaces so we still catch a parser regression.

Live e2e after fix:
```
jobsNew: 40, duplicates: 606, errors: []
```
(vs pre-fix `errors: ["3 MiPublic detailpagina's bevatten geen JobPosting-data …"]`).

## 2. nightly-maintenance: has been silently failing for 22 nights
Same class of bug as PR #228 (agent-orchestrator):

```
column "jobs.id" must appear in the GROUP BY clause or be used in an aggregate function
```

Root cause: step 3 used `.having(...)` on a non-aggregated select. Postgres requires HAVING to pair with GROUP BY. Intent was a row-level predicate → belongs in WHERE.

Reproduced locally (manual `tasks.trigger("nightly-maintenance")` → same error after TRIGGER_VERSION unpin). Fix moves the subquery predicate into the existing `and(...)` WHERE chain.

## Why the same bug twice?
Both slipped through because Trigger.dev task-level crashes don't propagate to Sentry unless explicitly captured. PR #228 already added `trigger-health-check` which would have alerted within 24h of either — this PR locks the door behind the second horse.

## Test plan
- [x] pnpm lint
- [x] pnpm exec tsc --noEmit
- [x] pnpm vitest run tests/mipublic-scraper.test.ts tests/public-job-board-adapters.test.ts — 16/16 passing
- [x] Live mipublic run: `status=success`, errors=[], jobsNew=40
- [ ] Post-merge Trigger.dev deploy → manual trigger `nightly-maintenance` → expect COMPLETED (reproduced locally with new code, blocked only by deployment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/229" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined error reporting for missing job posting data. Scraping runs no longer marked as failed due to minor data gaps (below 5% miss rate).

* **Performance**
  * Optimized database queries for job selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->