### PR TITLE
docs: compound-refresh + scraper inventory (7 adapters live)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,24 +193,27 @@ pnpm exec tsc --noEmit # MUST verify no new TypeScript errors were introduced
 
 | Area            | File                               | Notes                                                                   |
 | --------------- | ---------------------------------- | ----------------------------------------------------------------------- |
-| DB Schema       | `src/db/schema.ts`                 | 8 tables, pgvector, dual unique indexes on jobs                         |
+| DB Schema       | `packages/db/src/schema.ts` (re-exported via `src/db/schema.ts`) | Jobs, candidates, scrape_results, scraper_configs, chat_sessions, agent_events, autopilot_runs, autopilot_findings, platform_catalog, ai_usage, + more. pgvector, dual unique on jobs |
 | DB Connection   | `src/db/index.ts`                  | Neon serverless driver                                                  |
-| Normalize       | `src/services/normalize.ts`        | Upsert on (platform, externalId), 2nd unique on (platform, externalUrl) |
+| Normalize       | `src/services/normalize.ts`        | Upsert on (platform, externalId), 2nd unique on (platform, externalUrl). Serialised batch inserts — Promise.all caused Neon pool exhaustion (see docs/solutions/best-practices/neon-serverless-driver-vercel-2026-04-10.md) |
 | AI Enrichment   | `src/services/ai-enrichment.ts`    | Gemini 2.5 flash-lite, no retry, 100ms delay                            |
 | Embeddings      | `src/services/embedding.ts`        | text-embedding-3-small, 512 dims, jobs only                             |
 | Scoring         | `src/services/scoring.ts`          | Keyword matching, extracted weight constants                            |
 | GDPR            | `src/services/gdpr.ts`             | Art 15/17 for candidates only                                           |
 | Jobs Service    | `src/services/jobs.ts`             | ILIKE unescaped, hybridSearch with RRF                                  |
 | Candidates      | `src/services/candidates.ts`       | ILIKE unescaped                                                         |
-| Scrape Pipeline | `src/services/scrape-pipeline.ts`  | Hardcoded switch on platform names                                      |
-| Striive Scraper | `src/services/scrapers/striive.ts` | scrapeViaModal is a stub                                                |
+| Scrape Pipeline | `src/services/scrape-pipeline.ts`  | Orchestrator; adapters live in `packages/scrapers/src/`                  |
+| Platform adapters | `packages/scrapers/src/*.ts`     | 7 active adapters: striive, flextender, nationalevacaturebank, opdrachtoverheid, werkzoeken, mipublic, starapple. Registered in `platform-registry.ts`, typed via `PlatformAdapter` in `types.ts` |
+| AI models / tracing | `src/lib/ai-models.ts`         | `tracedGenerateText/Object/StreamText/Embed/EmbedMany` — all auto-record to `ai_usage` (see `src/services/ai-usage.ts`, `src/lib/ai-pricing.ts`) |
 | AI Agent        | `src/ai/agent.ts`                  | System prompt builder, tool registry                                    |
-| AI Tools        | `src/ai/tools/*.ts`                | 7 tools (query, create, trigger, etc.)                                  |
+| AI Tools        | `src/ai/tools/*.ts`                | ~40 tools (query, create, trigger, etc.)                                |
 | Rate Limit      | `src/lib/rate-limit.ts`            | In-memory sliding window                                                |
-| Middleware      | `middleware.ts`                    | Bearer token auth (deprecated in Next.js 16)                            |
+| Routing / Auth  | `proxy.ts`                         | Next.js 16 proxy layer (replaces legacy `middleware.ts`)                |
 | Sidebar         | `components/app-sidebar.tsx`       | Missing Interviews/Messages nav items                                   |
 | Filter UI       | `components/opdrachten-sidebar.tsx`, `components/shared/standard-filter-sidebar.tsx` | Standaard filter-UI voor alle lijstpagina's (zoek, dropdowns, uren, straal, sort, paginatie) |
-| Vercel Config   | `vercel.json`                      | Cron: scrape 6AM, vacancy-expiry 3AM                                    |
+| Trigger tasks   | `trigger/*.ts`                     | All scheduled cron jobs. `trigger-health-check.ts` (07:00 Amsterdam) alerts via Sentry when any task fails ≥3/5 runs or goes silent — added after the agent-orchestrator / nightly-maintenance silent-failure incidents |
+| Solutions KB    | `docs/solutions/`                  | Documented solutions to past problems (bugs, best practices, workflow patterns), organised by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in documented areas |
+| Vercel Config   | `vercel.json`                      | Cron offloaded to Trigger.dev; see `trigger/*.ts` for the authoritative schedule |
 
 ---
 

--- a/README.en.md
+++ b/README.en.md
@@ -465,13 +465,17 @@ gantt
     axisFormat %H:%M
 
     section Maintenance
-    Data Retention Cleanup    :02:00, 30min
-    Vacancy Expiry Check      :03:00, 15min
+    Nightly Maintenance (retention + vacancy expiry + sourcing)  :02:00, 45min
+    Scraper Health (circuit-breaker reset)                        :06:00, 5min
+    Trigger Health (cron failure detector → Sentry)               :07:00, 10min
 
     section Scraping (every 4 hours)
     Platform Scrape Pipeline  :00:00, 45min
     Platform Scrape Pipeline  :04:00, 45min
     Platform Scrape Pipeline  :08:00, 45min
+
+    section Agents (event-driven with 12h fallback)
+    Agent Orchestrator (fallback)                                 :12:00, 10min
 ```
 
 ---
@@ -553,11 +557,7 @@ motian/
 │   │   ├── schema.ts             # 9 tables with pgvector
 │   │   └── index.ts              # Neon serverless connection
 │   ├── services/
-│   │   ├── scrapers/             # Platform-specific scrapers
-│   │   │   ├── flextender.ts     # AJAX + CSRF token scraping
-│   │   │   ├── striive.ts        # Playwright browser automation
-│   │   │   └── opdrachtoverheid.ts # Public JSON API
-│   │   ├── scrape-pipeline.ts    # Orchestration
+│   │   ├── scrape-pipeline.ts    # Orchestration (platform adapters in packages/scrapers)
 │   │   ├── normalize.ts          # Zod validation + upsert
 │   │   ├── ai-enrichment.ts      # Gemini-powered enrichment
 │   │   ├── embedding.ts          # OpenAI vector generation
@@ -586,11 +586,17 @@ motian/
 
 ## Scrapers
 
-| Platform             | Method                                                             | Auth              | Source                                      |
-| -------------------- | ------------------------------------------------------------------ | ----------------- | ------------------------------------------- |
-| **Flextender**       | AJAX POST with `widget_config` CSRF token + detail page enrichment | None (public)     | `src/services/scrapers/flextender.ts`       |
-| **Striive**          | Playwright browser automation                                      | Login credentials | `src/services/scrapers/striive.ts`          |
-| **Opdrachtoverheid** | Public JSON API with pagination                                    | None (public)     | `src/services/scrapers/opdrachtoverheid.ts` |
+| Platform                   | Method                                                                              | Auth              | Source                                            |
+| -------------------------- | ----------------------------------------------------------------------------------- | ----------------- | ------------------------------------------------- |
+| **Striive**                | Playwright browser automation                                                       | Login credentials | `packages/scrapers/src/striive.ts`                |
+| **Flextender**             | AJAX POST with `widget_config` CSRF token + detail page enrichment                  | None (public)     | `packages/scrapers/src/flextender.ts`             |
+| **Nationale Vacaturebank** | Consent bootstrap (browser) → cheap HTTP harvest                                    | Session cookie    | `packages/scrapers/src/nationalevacaturebank.ts`  |
+| **Opdrachtoverheid**       | Public JSON API with pagination (90s timeout, 2 retries)                            | None (public)     | `packages/scrapers/src/opdrachtoverheid.ts`       |
+| **Werkzoeken**             | SSR vacancy cards + parallel list-page fetches (AbortSignal-plumbed, pnr-paginated) | None (public)     | `packages/scrapers/src/werkzoeken.ts`             |
+| **MiPublic**               | Yoast sitemap + JSON-LD JobPosting, Browserbase session for SiteGuard anti-bot      | None (public)     | `packages/scrapers/src/mipublic.ts`               |
+| **Starapple**              | Yoast `/vacancy-sitemap.xml` + HTML detail extraction (h1 + h3 sections)            | None (public)     | `packages/scrapers/src/starapple.ts`              |
+
+All adapters implement the `PlatformAdapter` interface (`packages/scrapers/src/types.ts`) with `validate`, `scrape`, and `testImport`. Registration lives in `packages/scrapers/src/platform-registry.ts`; a scheduled `scrape-pipeline` task in `trigger/scrape-pipeline.ts` runs all active configs every 4 hours.
 
 ### Scrape Pipeline
 

--- a/README.md
+++ b/README.md
@@ -494,13 +494,17 @@ gantt
     axisFormat %H:%M
 
     section Onderhoud
-    Data Retentie Opschoning      :02:00, 30min
-    Vacature Verloopcontrole      :03:00, 15min
+    Nightly Maintenance (retentie + vacature-verloop + sourcing)  :02:00, 45min
+    Scraper Health (circuit-breaker reset)                         :06:00, 5min
+    Trigger Health (cron failure detector → Sentry)                :07:00, 10min
 
     section Scraping (elke 4 uur)
     Platform Scrape Pipeline      :00:00, 45min
     Platform Scrape Pipeline      :04:00, 45min
     Platform Scrape Pipeline      :08:00, 45min
+
+    section Agents (event-driven met 12h fallback)
+    Agent Orchestrator (fallback)                                  :12:00, 10min
 ```
 
 ---
@@ -584,11 +588,7 @@ motian/
 │   │   ├── schema.ts             # 9 tabellen met pgvector
 │   │   └── index.ts              # Neon serverless verbinding
 │   ├── services/
-│   │   ├── scrapers/             # Platform-specifieke scrapers
-│   │   │   ├── flextender.ts     # AJAX + CSRF token scraping
-│   │   │   ├── striive.ts        # Playwright browser automatisering
-│   │   │   └── opdrachtoverheid.ts # Publieke JSON API
-│   │   ├── scrape-pipeline.ts    # Orkestratie
+│   │   ├── scrape-pipeline.ts    # Orkestratie (platform-adapters in packages/scrapers)
 │   │   ├── normalize.ts          # Zod validatie + upsert
 │   │   ├── ai-enrichment.ts      # Gemini-aangedreven verrijking
 │   │   ├── embedding.ts          # OpenAI vector generatie
@@ -617,11 +617,17 @@ motian/
 
 ## Scrapers
 
-| Platform             | Methode                                                            | Authenticatie   | Bron                                        |
-| -------------------- | ------------------------------------------------------------------ | --------------- | ------------------------------------------- |
-| **Flextender**       | AJAX POST met `widget_config` CSRF token + detailpagina verrijking | Geen (openbaar) | `src/services/scrapers/flextender.ts`       |
-| **Striive**          | Playwright browser automatisering                                  | Inloggegevens   | `src/services/scrapers/striive.ts`          |
-| **Opdrachtoverheid** | Publieke JSON API met paginering                                   | Geen (openbaar) | `src/services/scrapers/opdrachtoverheid.ts` |
+| Platform                  | Methode                                                                                 | Authenticatie   | Bron                                                |
+| ------------------------- | --------------------------------------------------------------------------------------- | --------------- | --------------------------------------------------- |
+| **Striive**               | Playwright browser automatisering                                                       | Inloggegevens   | `packages/scrapers/src/striive.ts`                  |
+| **Flextender**            | AJAX POST met `widget_config` CSRF token + detailpagina verrijking                      | Geen (openbaar) | `packages/scrapers/src/flextender.ts`               |
+| **Nationale Vacaturebank**| Consent bootstrap (browser) → goedkope HTTP harvest                                     | Sessie-cookie   | `packages/scrapers/src/nationalevacaturebank.ts`    |
+| **Opdrachtoverheid**      | Publieke JSON API met paginering (90s timeout, 2 retries)                               | Geen (openbaar) | `packages/scrapers/src/opdrachtoverheid.ts`         |
+| **Werkzoeken**            | SSR vacaturekaartjes + parallel list-page fetches (AbortSignal geborgd, pnr-pagination) | Geen (openbaar) | `packages/scrapers/src/werkzoeken.ts`               |
+| **MiPublic**              | Yoast sitemap + JSON-LD JobPosting, Browserbase-sessie voor SiteGuard anti-bot          | Geen (openbaar) | `packages/scrapers/src/mipublic.ts`                 |
+| **Starapple**             | Yoast `/vacancy-sitemap.xml` + HTML detail-extractie (h1 + h3 secties)                  | Geen (openbaar) | `packages/scrapers/src/starapple.ts`                |
+
+Alle adapters implementeren de `PlatformAdapter` interface (`packages/scrapers/src/types.ts`) met `validate`, `scrape`, `testImport`. Registratie gebeurt in `packages/scrapers/src/platform-registry.ts`; een scheduled `scrape-pipeline` task in `trigger/scrape-pipeline.ts` draait alle actieve configuraties elke 4 uur.
 
 ### Scrape Pipeline
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,9 +31,13 @@ CV Upload (SSE)      | slack-notification (on-demand)|    | scraper_configs   |
 
 | Platform | Method | File | Status |
 |----------|--------|------|--------|
-| Striive | Playwright browser automation with login | `src/services/scrapers/striive.ts` | Active |
-| Flextender | AJAX POST with `widget_config` CSRF token | `src/services/scrapers/flextender.ts` | Active |
-| Opdrachtoverheid | Public JSON API with paginated fetch | `src/services/scrapers/opdrachtoverheid.ts` | Active |
+| Striive | Playwright browser automation with login | `packages/scrapers/src/striive.ts` | Active |
+| Flextender | AJAX POST with `widget_config` CSRF token | `packages/scrapers/src/flextender.ts` | Active |
+| Nationale Vacaturebank | Consent bootstrap (browser) → cheap HTTP harvest | `packages/scrapers/src/nationalevacaturebank.ts` | Active |
+| Opdrachtoverheid | Public JSON API with paginated fetch (90s timeout, 2 retries) | `packages/scrapers/src/opdrachtoverheid.ts` | Active |
+| Werkzoeken | SSR cards + parallel page fetches with plumbed AbortSignal | `packages/scrapers/src/werkzoeken.ts` | Active |
+| MiPublic | Yoast sitemap + JSON-LD, Browserbase session for SiteGuard anti-bot | `packages/scrapers/src/mipublic.ts` | Active |
+| Starapple | Yoast `/vacancy-sitemap.xml` + HTML detail extraction | `packages/scrapers/src/starapple.ts` | Active |
 | Indeed | — | — | Planned |
 | LinkedIn | — | — | Planned |
 

--- a/docs/solutions/deprecations/generateobject-to-generatetext-ai-sdk6-20260223.md
+++ b/docs/solutions/deprecations/generateobject-to-generatetext-ai-sdk6-20260223.md
@@ -82,6 +82,25 @@ Biome's `noNonNullAssertion` rule disallows `output!`. Use `output as Type` inst
 | `tests/requirement-extraction.test.ts` | Updated string assertions |
 | `tests/structured-matching.test.ts` | Updated string assertions |
 
+## Current migration status (2026-04-23)
+
+Codebase-wide scan shows the migration is ~78% complete. Services using
+the v6 `Output.object({ schema })` pattern now include
+`ai-enrichment`, `analyze-evidence`, `requirement-extraction`,
+`platform-analyzer`, `structured-matching`, `match-judge`, and
+`platform-strategy-verifier`.
+
+Two call sites still use the legacy `tracedGenerateObject` wrapper
+(which forwards to v5 `ai.generateObject`):
+
+- `src/services/trend-insights.ts:448`
+- `src/services/interview-prep-generator.ts:217`
+
+`src/lib/ai-models.ts` still exports `tracedGenerateObject` as a
+convenience wrapper, which is fine while those two call sites remain.
+When both are migrated, the wrapper can be removed along with this
+deprecation doc.
+
 ## Prevention
 
 Pin AI SDK major version in `package.json` and review migration guides before upgrading. The SDK provides Codemod transformations for automated migration.

--- a/docs/solutions/performance-issues/full-stack-performance-audit-20260414.md
+++ b/docs/solutions/performance-issues/full-stack-performance-audit-20260414.md
@@ -14,6 +14,19 @@ tags: [performance, trigger-dev, search, database, react, audit, optimization]
 
 # Full-Stack Performance Audit — Motian Recruitment Platform
 
+## See also (implementation docs)
+
+This audit is the diagnostic layer. The concrete fixes it informs live in
+dedicated docs — prefer those for the "how" and use this one for the "why":
+
+- `docs/solutions/performance-issues/scraper-dashboard-cold-start-17s-to-1s-2026-04-16.md`
+  — implementation of the dashboard cold-start fix (PR #196 / RJC-153).
+- `docs/solutions/best-practices/neon-serverless-driver-vercel-2026-04-10.md`
+  — the Neon pool config (`max: 1`, `DATABASE_URL_UNPOOLED`) referenced
+  throughout this audit.
+- `docs/solutions/performance-issues/vercel-fluid-compute-spike-Pipeline-20260329.md`
+  — rate-limiting and ISR tuning called out in sections 3 and 8 below.
+
 ## Executive Summary
 
 Comprehensive audit of the Motian recruitment platform across four layers: Trigger.dev


### PR DESCRIPTION
## ce:compound-refresh report

**Scope**: all 13 docs under `docs/solutions/` + a broader sweep of READMEs, `docs/architecture.md`, and the Key Files table in `AGENTS.md` (requested: "update alle readme's en docs and diagrams").

### Solutions KB audit (13 docs)
| Outcome | Count | Files |
|---|---|---|
| **Keep** | 10 | scraper-analytics-schedule-optimization, orchestrator-polling-to-event-driven, middleware-vs-proxy-nextjs16, voice-agent-tool-parity-migration, scraper-dashboard-cold-start-17s-to-1s, vercel-fluid-compute-spike, agent-ui-parity-kandidaten, sentry-pii-scrubber-gdpr, neon-serverless-driver-vercel, nextjs-revalidate-api-routes-vs-pages |
| **Update** | 2 | generateobject-to-generatetext-ai-sdk6 (migration status block added), full-stack-performance-audit (See also header) |
| **Consolidate / Replace / Delete** | 0 | — |

### Broader docs refresh
- README.md + README.en.md Scrapers table: 3 rows → **7 rows** (adds nationalevacaturebank, werkzoeken, mipublic, starapple; fixes paths to `packages/scrapers/src/`)
- README.md + README.en.md Cron gantt diagrams: added nightly-maintenance + scraper-health-check + **trigger-health-check** (new in #228) + agent-orchestrator fallback
- README.md + README.en.md project structure tree: stopped pointing at the long-gone `src/services/scrapers/` directory
- `docs/architecture.md` Scrapers table: same expansion, 3 → 7 rows with correct paths
- `AGENTS.md` Key Files table: repointed paths, added `proxy.ts` (replaces `middleware.ts`), added `ai-usage` / `ai-pricing` / `trigger-health-check` rows, added `docs/solutions/` discoverability row (Phase 5 check)

## Follow-up not in this PR
- New `ce:compound` learnings to capture this session's bugs: Browserbase session-reuse for SiteGuard, Drizzle `sql\`= ANY(\${array})\`` pitfall, HAVING-without-GROUP-BY, TRIGGER_VERSION silent-deploy pin, SDK v6 `inputTokens`/`outputTokens` rename.
- Deeper AGENTS.md refresh beyond Key Files (scope kept narrow).

## Test plan
- [x] pnpm lint (biome clean)
- [ ] Mermaid diagrams render correctly on GitHub preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/231" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to reflect restructured scraper organization and expanded platform support.
  * Enhanced cron and maintenance task scheduling documentation with new health-check and alerting capabilities.
  * Added migration tracking documentation for ongoing platform updates.
  * Improved knowledge base cross-referencing for performance optimization guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->