### PR TITLE
docs(solutions): 5 learnings from the 2026-04-23 debug session

### DIFF
--- a/docs/solutions/deprecations/ai-sdk-v6-token-field-rename-TokenTracking-20260423.md
+++ b/docs/solutions/deprecations/ai-sdk-v6-token-field-rename-TokenTracking-20260423.md
@@ -1,0 +1,77 @@
+---
+title: AI SDK v6 renamed `promptTokens`/`completionTokens` → `inputTokens`/`outputTokens`
+date: 2026-04-23
+category: deprecations
+module: AI Services
+problem_type: deprecation_migration
+component: service_object
+symptoms:
+  - "chat_sessions.tokens_used stays 0 across 85 sessions over 2 months"
+  - "No tokens recorded for any flow — cost reporting returns $0.00"
+  - "(undefined ?? 0) + (undefined ?? 0) = 0 silently"
+root_cause: wrong_api
+resolution_type: code_fix
+severity: medium
+tags: [ai-sdk, vercel, deprecation, migration, token-tracking, silent-failure]
+---
+
+# AI SDK v6 renamed `promptTokens`/`completionTokens` → `inputTokens`/`outputTokens`
+
+## Problem
+
+Chat session token counters had been stuck at 0 across all 85 sessions for 2+ months. Root cause: the tracking helper at `app/api/chat/_helpers.ts` reads `usage.promptTokens` and `usage.completionTokens`, which are **AI SDK v4** field names. Our repo is on `ai@^6.0.149` where those fields were renamed to `inputTokens` / `outputTokens` / `totalTokens`. The old field names resolve to `undefined`, `(undefined ?? 0) + (undefined ?? 0) = 0`, early-return — nothing is written.
+
+## Symptoms
+
+- `select sum(tokens_used) from chat_sessions where created_at > now() - interval '30 days'` → 0 across 42 sessions
+- No runtime error, no Sentry alert — just zero counters
+- Would have been caught earlier by a cost-tracking dashboard that alerts on "N sessions but $0.00 spent"
+
+## What Didn't Work
+
+- Assuming the usage object still matched v4 shape. The `ai@6` upgrade was done ~2 months ago; the tracking helper wasn't touched at that time.
+- Relying solely on Vercel AI SDK changelogs — the rename is called out in the v5→v6 migration guide but our tracker was written before v5 and never revisited.
+
+## Solution
+
+Read both name shapes so a future SDK bump (or provider that still uses the old names) doesn't silently zero-out the counter again:
+
+```ts
+const usage = (final as {
+  usage?: {
+    // v6 names (preferred)
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    // v4 names (fallback)
+    promptTokens?: number;
+    completionTokens?: number;
+  };
+})?.usage;
+
+if (!usage) return;
+const prompt = usage.inputTokens ?? usage.promptTokens ?? 0;
+const completion = usage.outputTokens ?? usage.completionTokens ?? 0;
+// Prefer the provider-reported total over our sum — providers sometimes
+// report reasoning/thinking tokens separately that the sum would miss.
+const total = usage.totalTokens ?? prompt + completion;
+if (total <= 0) return;
+```
+
+After the fix, PR #227 replaced this narrow chat-only counter with a full `ai_usage` ledger that auto-records every call through `tracedGenerateText/Object/StreamText/Embed/EmbedMany` with per-call cost in USD micros (see `src/services/ai-usage.ts`, `src/lib/ai-pricing.ts`).
+
+## Why This Works
+
+The OR chain lets the helper survive provider-specific or SDK-version-specific field naming without silently going to zero. Preferring `usage.totalTokens` matters because some providers (Google Gemini with "thinking") report reasoning tokens in a separate field that isn't captured by summing input + output.
+
+## Prevention
+
+- **Every AI SDK major-version bump requires a revisit of the usage/tracing path.** Add a grep hit for `promptTokens|completionTokens` to the SDK upgrade checklist.
+- **Tracking code must exercise runtime assertions.** A lint rule or test that verifies `recordAiUsage` actually writes ≥1 row per provider after an upgrade would have caught this on day 1.
+- **`ai_usage` table + `scripts/cost-report.ts`** (PR #227) surfaces "zero tokens recorded" as a visible signal in the monthly cost report. If the report shows `$0.00` for a month with real traffic, that's a canary.
+
+## Related Issues
+
+- PR #227 — the broader ledger that subsumed this narrow fix.
+- `docs/solutions/deprecations/generateobject-to-generatetext-ai-sdk6-20260223.md` — the other v6 migration doc; references the remaining call sites not yet moved to `Output.object({ schema })`.
+- `src/lib/ai-pricing.ts` — the rate-card source used to turn tokens into USD micros.

--- a/docs/solutions/integration-issues/browserbase-session-reuse-siteguard-Scrapers-20260423.md
+++ b/docs/solutions/integration-issues/browserbase-session-reuse-siteguard-Scrapers-20260423.md
@@ -1,0 +1,120 @@
+---
+title: Reuse one Browserbase session to pass SiteGuard across every detail-page fetch
+date: 2026-04-23
+category: integration-issues
+module: Scrapers
+problem_type: integration_issue
+component: background_job
+symptoms:
+  - "MiPublic scrape returns status=failed with 632 'pagina wordt geblokkeerd door een anti-bot challenge' errors"
+  - "Sitemap fetch works but every per-detail fetch 202's on sgcaptcha"
+  - "Deprecated `wss://connect.browserbase.com?apiKey=&projectId=` endpoint returns HTTP 400"
+root_cause: wrong_api
+resolution_type: code_fix
+severity: high
+tags: [scrapers, browserbase, anti-bot, siteguard, mipublic, puppeteer, session-reuse]
+---
+
+# Reuse one Browserbase session to pass SiteGuard across every detail-page fetch
+
+## Problem
+
+MiPublic's site runs SiteGuard anti-bot (HTTP 202 + meta-refresh to `/.well-known/captcha/`). A one-shot Browserbase session per sitemap-fetch got us through the sitemap, but then 632 per-detail fetches went through direct HTTP and every one hit the captcha. Scrape recorded `status=failed`, 0 listings saved.
+
+## Symptoms
+
+- `status=failed`, `errors: ["MiPublic pagina wordt geblokkeerd door een anti-bot challenge: ..."]` × ~630 rows per run
+- `duration=12s` (just enough to fan out 632 direct-fetch attempts)
+- Scraper-dashboard red, circuit breaker trending toward tripped
+
+## What Didn't Work
+
+- Sending captcha-triggering URLs through Firecrawl as a second-tier fallback — Firecrawl hit the same wall and the `FIRECRAWL_API_KEY` was expired anyway.
+- Retrying direct fetches with increased timeouts — SiteGuard doesn't self-resolve in a stateless HTTP call, it needs a real browser context to run the meta-refresh redirect and earn the cookie.
+
+## Solution
+
+Open ONE Browserbase session for the whole scrape and reuse it for every fetch:
+
+```ts
+type BrowserbaseHandle = {
+  fetchText: (url: string) => Promise<string>;
+  close: () => Promise<void>;
+};
+
+async function openBrowserbaseSession(): Promise<BrowserbaseHandle | null> {
+  const apiKey = process.env.BROWSERBASE_API_KEY;
+  const projectId = process.env.BROWSERBASE_PROJECT_ID;
+  if (!apiKey || !projectId) return null;
+
+  // Browserbase deprecated the direct `wss://connect.browserbase.com?apiKey=`
+  // endpoint — it now returns HTTP 400. The new flow is POST /v1/sessions
+  // first, then connect to the signed `connectUrl` from the response.
+  const res = await fetch("https://api.browserbase.com/v1/sessions", {
+    method: "POST",
+    headers: { "X-BB-API-Key": apiKey, "Content-Type": "application/json" },
+    body: JSON.stringify({ projectId }),
+  });
+  const { connectUrl } = (await res.json()) as { connectUrl?: string };
+  if (!connectUrl) return null;
+
+  const puppeteer = await import("puppeteer-core");
+  const browser = await puppeteer.default.connect({ browserWSEndpoint: connectUrl });
+  const page = await browser.newPage();
+  let siteGuardResolved = false;
+
+  return {
+    async fetchText(url: string): Promise<string> {
+      if (!siteGuardResolved) {
+        // First call: navigate via page.goto so SiteGuard self-resolves and
+        // the cookie lands in the browser context.
+        await page.goto(url, { waitUntil: "networkidle2", timeout: 30_000 });
+        const deadline = Date.now() + 25_000;
+        while (Date.now() < deadline) {
+          await new Promise((r) => setTimeout(r, 2_000));
+          const html = await page.content();
+          if (!html.toLowerCase().includes("sgcaptcha")) break;
+        }
+        siteGuardResolved = true;
+      }
+      // Subsequent calls: use an in-page fetch() so we get raw response
+      // bodies (page.content() wraps XML in an HTML document).
+      return await page.evaluate(async (u) => (await fetch(u)).text(), url);
+    },
+    async close(): Promise<void> {
+      await browser.close().catch(() => {});
+    },
+  };
+}
+```
+
+Then thread the handle through the scrape function:
+
+```ts
+async function scrapeMipublicListings(config, options) {
+  const handle = await openBrowserbaseSession().catch(() => null);
+  try {
+    const discovered = await discoverMipublicDetailUrls(resolved, handle);
+    // ... fetch every detail page via handle.fetchText(url) at concurrency 4
+    return { listings, errors };
+  } finally {
+    if (handle) await handle.close().catch(() => {});
+  }
+}
+```
+
+## Why This Works
+
+SiteGuard is cookie-based — once a real Chrome navigation has run the meta-refresh challenge, the resulting cookie unlocks every subsequent request from that same browser context. Reusing one session spreads the ~10s captcha-resolve cost across 630 fetches (≈15ms each) instead of paying it per call, and `page.evaluate(fetch)` returns raw response bodies so the downstream XML/HTML parser doesn't need to unwrap puppeteer's `page.content()` HTML wrapper.
+
+## Prevention
+
+- When an anti-bot challenge blocks a single request, assume cookie-based and try session-reuse before reaching for Browserbase-per-call (which is wasteful) or upgrading to Firecrawl (which is slower and costs more).
+- `page.content()` wraps XML in an HTML document — if downstream needs the raw bytes, use `page.evaluate(async u => (await fetch(u)).text(), url)` instead.
+- Graceful degradation matters: when `BROWSERBASE_API_KEY` / `BROWSERBASE_PROJECT_ID` are missing, fall through to the direct-fetch path so CI/tests still work without the credential.
+
+## Related Issues
+
+- RJC-213 (PR #219) — initial sitemap-extractor fix that discovered sitemap URLs; didn't yet handle detail pages.
+- RJC-216 (PR #226) — this fix.
+- `docs/solutions/integration-issues/playwright-externalized-triggerdev-AutopilotSystem-20260329.md` — a sibling pattern for externalising browser-driven work out of Trigger.dev.

--- a/docs/solutions/integration-issues/drizzle-having-needs-group-by-Trigger-20260423.md
+++ b/docs/solutions/integration-issues/drizzle-having-needs-group-by-Trigger-20260423.md
@@ -1,0 +1,84 @@
+---
+title: Drizzle `.having()` needs `.groupBy()` — row-level predicates belong in `.where()`
+date: 2026-04-23
+category: integration-issues
+module: Database
+problem_type: database_issue
+component: database
+symptoms:
+  - "column \"jobs.id\" must appear in the GROUP BY clause or be used in an aggregate function"
+  - "nightly-maintenance Trigger.dev task FAILED 22 runs in a row"
+  - "query works locally on a small table, crashes in prod"
+root_cause: wrong_api
+resolution_type: code_fix
+severity: medium
+tags: [drizzle, postgres, having, group-by, trigger-dev, subquery]
+---
+
+# Drizzle `.having()` needs `.groupBy()` — row-level predicates belong in `.where()`
+
+## Problem
+
+`trigger/nightly-maintenance.ts` step 3 (proactive sourcing) used `.having(...)` on a non-aggregated select to filter underserved jobs by their match count. The query had no `GROUP BY`, so Postgres rejected it with `column "jobs.id" must appear in the GROUP BY clause or be used in an aggregate function`. The task had been silently failing every night at 02:00 Amsterdam for 22 consecutive nights.
+
+```ts
+// ❌ BROKEN — HAVING without GROUP BY
+.from(jobs)
+.where(and(getVisibleVacancyCondition(), isNotNull(jobs.embedding)))
+.having(
+  sql`coalesce(
+    (select count(*) from job_matches jm where jm.job_id = ${jobs.id} ...), 0
+  ) < 3`,
+)
+```
+
+## Symptoms
+
+- `column "jobs.id" must appear in the GROUP BY clause or be used in an aggregate function`
+- nightly-maintenance dashboard showed FAILED every night, durations all < 50s (aborted at the query step)
+- 22 consecutive failures with zero Sentry alerts (Trigger.dev task-level crashes don't propagate to Sentry without explicit wiring)
+
+## What Didn't Work
+
+- Assuming HAVING was interchangeable with WHERE — it is not. HAVING filters groups produced by GROUP BY (and operates on aggregates); without GROUP BY, every non-aggregated column is illegal.
+
+## Solution
+
+The correlated subquery was always meant to be a row-level predicate (filter rows where "underserved" = `< 3` active matches). It belongs in `WHERE`, not `HAVING`:
+
+```ts
+// ✅ CORRECT — row-level predicate in the WHERE chain
+.from(jobs)
+.where(
+  and(
+    getVisibleVacancyCondition(),
+    isNotNull(jobs.embedding),
+    sql`coalesce(
+      (select count(*) from job_matches jm
+       where jm.job_id = ${jobs.id}
+       and jm.status in ('pending', 'accepted')),
+      0
+    ) < 3`,
+  ),
+)
+.limit(10);
+```
+
+## Why This Works
+
+- WHERE evaluates per-row before grouping. Correlated subqueries that return one scalar per candidate row are per-row predicates.
+- HAVING only makes sense when you're grouping rows into aggregates and want to filter those groups. Intent: "give me groups where SUM(x) > N". Not: "give me rows where subquery(row) < N".
+
+Rule of thumb: if there's no `GROUP BY` in the query, there should be no `.having()`.
+
+## Prevention
+
+- Default to `.where()` for all row-level predicates (including correlated subqueries).
+- Only reach for `.having()` when you actually have a `.groupBy()` and want to filter the resulting groups.
+- PR #228's `trigger-health-check` cron now catches silent cron failures within 24h — ≥3/5 recent failures per task raises a `Sentry.captureException`. This was the second task found silently dead on the same day; the health-check makes future recurrences loud.
+
+## Related Issues
+
+- RJC-229 — the fix (same PR as MiPublic `<5%` no-JSON-LD tolerance).
+- `docs/solutions/integration-issues/drizzle-sql-array-use-inarray-Database-20260423.md` — sibling bug in `agent-orchestrator` found the same day; same class (ORM footgun that only shows up at runtime).
+- PR #228 (`trigger-health-check`) — the observability layer that would have surfaced this within a day of its first failure.

--- a/docs/solutions/integration-issues/drizzle-sql-array-use-inarray-Database-20260423.md
+++ b/docs/solutions/integration-issues/drizzle-sql-array-use-inarray-Database-20260423.md
@@ -1,0 +1,79 @@
+---
+title: Don't pass a JS array to Postgres `= ANY(...)` via Drizzle's `sql` template — use `inArray`
+date: 2026-04-23
+category: integration-issues
+module: Database
+problem_type: database_issue
+component: database
+symptoms:
+  - "op ANY/ALL (array) requires array on right side"
+  - "Trigger.dev scheduled task FAILED every run for weeks with no Sentry alert"
+  - "Drizzle query silently fails on a correlated IN-clause"
+root_cause: wrong_api
+resolution_type: code_fix
+severity: high
+tags: [drizzle, postgres, sql-template, inarray, trigger-dev, silent-failure]
+---
+
+# Don't pass a JS array to Postgres `= ANY(...)` via Drizzle's `sql` template — use `inArray`
+
+## Problem
+
+`trigger/agent-orchestrator.ts` had been crashing on every scheduled run for weeks (every 12h, ~60 failures total) with `error: op ANY/ALL (array) requires array on right side`. The reason: it used a Drizzle `sql` template to inline a JS array directly on the right-hand side of `= ANY(...)`:
+
+```ts
+// ❌ BROKEN — serialises the array as a single text parameter
+sql`${agentEvents.eventType} = ANY(${PROCESSABLE_EVENTS})`
+```
+
+Drizzle's `sql\`...\`` template binds every `${...}` interpolation as a parameterised value. Passing a JS array produces a single bound param of type text, not a Postgres array literal, and Postgres rejects it.
+
+## Symptoms
+
+- `error: op ANY/ALL (array) requires array on right side` on every `schedules.task` invocation
+- `scrape_results`-style ledger (or any wrapping try/catch) didn't fire because the top-level query crashed before the per-event loop
+- Nothing in Sentry — Trigger.dev logs the task failure to its own dashboard but doesn't propagate to Sentry unless the task calls `Sentry.captureException` explicitly
+
+## What Didn't Work
+
+- Staring at the query and assuming Drizzle would JSON-serialise the array (it doesn't — `sql` templates bind every `${}` as a single param).
+- Hoping Sentry would have caught it. Trigger.dev task-level crashes are invisible to Sentry without explicit wiring.
+
+## Solution
+
+Use Drizzle's `inArray` helper, which serialises correctly to `= ANY($1)` with `$1` bound as a Postgres text array:
+
+```ts
+// ✅ CORRECT
+import { and, db, eq, inArray } from "@/src/db";
+
+await db
+  .select()
+  .from(agentEvents)
+  .where(
+    and(
+      eq(agentEvents.status, "pending"),
+      inArray(agentEvents.eventType, PROCESSABLE_EVENTS),
+    ),
+  )
+  .orderBy(agentEvents.createdAt)
+  .limit(20);
+```
+
+Verified with a reproduction script: the `sql` template variant throws synchronously on first execution; the `inArray` variant returns the expected rows.
+
+## Why This Works
+
+Drizzle's `inArray` knows the column's type (`text` here), so it serialises the JS array as the matching Postgres array type (`text[]`). The `sql` template is type-agnostic — every `${}` is a single `$n` parameter — so it can't distinguish "I want this array expanded as `('a','b','c')`" from "I want this array sent as a single value". When in doubt, prefer Drizzle's typed helpers (`inArray`, `notInArray`, `arrayContains`) over hand-rolled `sql` templates.
+
+## Prevention
+
+- Default to `inArray(column, values)` for IN-clauses; only drop to `sql` when you need something `inArray` can't express (e.g. a correlated subquery).
+- Add a `trigger-health-check` cron (PR #228) that fetches the last 5 runs per scheduled task via `runs.list` and `Sentry.captureException`s on ≥3/5 failures. This closes the "Trigger task silently crashes" observability gap for every task, not just this one.
+- Reproduce Postgres-layer bugs locally before shipping them — one `tsx` script that runs the failing query against the real DB would have caught this in <1 minute.
+
+## Related Issues
+
+- RJC-228 — the fix.
+- `docs/solutions/workflow-issues/orchestrator-polling-to-event-driven-AgentSystem-20260329.md` — the event-driven dispatch this task is a fallback for.
+- `docs/solutions/integration-issues/drizzle-having-needs-group-by-Trigger-20260423.md` — sibling bug found the same day in `nightly-maintenance`.

--- a/docs/solutions/workflow-issues/trigger-version-pin-silent-deploy-TriggerDev-20260423.md
+++ b/docs/solutions/workflow-issues/trigger-version-pin-silent-deploy-TriggerDev-20260423.md
@@ -1,0 +1,83 @@
+---
+title: Remove `TRIGGER_VERSION` pin from prod env — it silently overrides deploys
+date: 2026-04-23
+category: workflow-issues
+module: Trigger.dev
+problem_type: workflow_issue
+component: background_job
+symptoms:
+  - "Manual `tasks.trigger()` runs keep hitting an old bundle even after a successful deploy"
+  - "Trigger.dev dashboard shows new deployments but prod runs use an older version"
+  - "Trigger.dev task crashes are invisible to Sentry"
+severity: high
+applies_when:
+  - "A scheduled Trigger.dev task keeps failing after you deployed a fix"
+  - "Scheduled runs pick up new code but API-invoked runs don't"
+  - "You don't remember setting TRIGGER_VERSION but it's in `vercel env ls`"
+tags: [trigger-dev, deploy, observability, sentry, silent-failure]
+---
+
+# Remove `TRIGGER_VERSION` pin from prod env — it silently overrides deploys
+
+## Context
+
+Our Trigger.dev prod env had `TRIGGER_VERSION="20260402.1"` set 21 days before anyone noticed. Scheduled crons run on Trigger.dev's "latest" resolution and picked up each deploy normally. But `tasks.trigger(...)` invocations via the `@trigger.dev/sdk` client (both from our own API routes and from smoke-test scripts) respected the pin and kept running the old bundle. Result: multiple hot-fix deploys over three days appeared to land on Trigger.dev but weren't actually executed by any of the code paths we were debugging with.
+
+Compounding the blindness: Trigger.dev task-level crashes don't propagate to Sentry unless the task explicitly calls `Sentry.captureException`. So the pinned 21-day-old code was crashing on every invocation with no external signal.
+
+## Guidance
+
+- **Don't pin `TRIGGER_VERSION` in any environment unless you're actively A/B-testing a specific bundle.** In steady state, leave it unset so Trigger.dev resolves the latest active deployment. The env var is invisible in code (no import references it, no `.env.example` entry) and will quietly drift.
+- **Every scheduled task must route crashes to Sentry.** Wrap task bodies in a try/catch that calls `Sentry.captureException(err, { tags: { trigger_task: id } })` before re-throwing, OR rely on `trigger-health-check` (`trigger/trigger-health-check.ts` — daily 07:00 Amsterdam) to fire a Sentry event on ≥3/5 recent failures.
+- **When debugging "my fix isn't working in prod", check the pin first.** `grep TRIGGER_VERSION .env.local` or `vercel env ls production | grep TRIGGER` is a 10-second diagnostic. It's the Trigger.dev equivalent of browser cache when debugging a frontend deploy.
+
+## Why This Matters
+
+The pin is a latent deploy bug that scales with the number of `tasks.trigger()` call sites. Our codebase has that call in 5+ places (ad-hoc smoke scripts, API routes that kick off background work, chained task-to-task calls). Each one silently runs a 21-day-old bundle. The impact isn't "some tasks are slow" — it's "your fix never shipped to this invocation path" with no error anywhere.
+
+Combined with the Sentry gap, this class of bug can eat weeks before anyone runs a manual test.
+
+## When to Apply
+
+- Before shipping a Trigger.dev fix to a task that's been failing: verify `TRIGGER_VERSION` is unset in the target env
+- When a task's `runs.list()` shows a mix of "success" scheduled runs and "failed" manual runs
+- When rolling out a new task the first time — confirm it's callable on the latest version, not gated by a pin
+
+## Examples
+
+Diagnostic:
+
+```bash
+# Check the pin
+vercel env ls production | grep TRIGGER_VERSION
+# Or, after `vercel env pull`:
+grep TRIGGER_VERSION .env.local
+```
+
+Fix:
+
+```bash
+vercel env rm TRIGGER_VERSION production --yes
+vercel env pull .env.local --environment=production --yes
+# Re-trigger the task to confirm it now runs the latest bundle:
+pnpm tsx scripts/trigger-test.ts <task-id>
+```
+
+Verify Sentry pathway (each cron task body):
+
+```ts
+run: async () => {
+  try {
+    // ... actual work
+  } catch (err) {
+    Sentry.captureException(err, { tags: { trigger_task: "nightly-maintenance" } });
+    throw err;
+  }
+}
+```
+
+## Related
+
+- `trigger/trigger-health-check.ts` (PR #228) — the catch-all observability layer for this class of silent failure.
+- `docs/solutions/integration-issues/drizzle-sql-array-use-inarray-Database-20260423.md` — one of the fixes whose deploy was masked by the pin.
+- `docs/solutions/integration-issues/drizzle-having-needs-group-by-Trigger-20260423.md` — the other one.


### PR DESCRIPTION
Five `ce:compound` learnings from today's session, all captured using the bug/knowledge track template. Each doc has root cause, fix code, why-it-works, prevention, and related issues.

| File | Type | Severity |
|---|---|---|
| `browserbase-session-reuse-siteguard-Scrapers-20260423.md` | integration_issue | high |
| `drizzle-sql-array-use-inarray-Database-20260423.md` | database_issue | high |
| `drizzle-having-needs-group-by-Trigger-20260423.md` | database_issue | medium |
| `trigger-version-pin-silent-deploy-TriggerDev-20260423.md` | workflow_issue | high |
| `ai-sdk-v6-token-field-rename-TokenTracking-20260423.md` | deprecation_migration | medium |

These are the "why nobody noticed" stories from today's session — all five produced weeks of silent production damage before a human caught them. Shipping them raises the next agent's chance of avoiding the same traps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
