### PR TITLE
fix(scrapers/werkzoeken): Browserbase fallback for degraded 200 markup

### DIFF
--- a/packages/scrapers/src/werkzoeken.ts
+++ b/packages/scrapers/src/werkzoeken.ts
@@ -574,7 +574,24 @@ async function scrapeWerkzoekenInternal(
       }
 
       const parsed = parseWerkzoekenListingCards(result.value.html, config.baseUrl);
-      const added = pushNewListings(parsed);
+      let added = pushNewListings(parsed);
+
+      // Intermittent failure mode (RJC-219): the direct fetch returns 200 but
+      // the markup has degraded (stripped data-* attributes or no vacancy
+      // anchors at all). The page usually renders fine seconds later — so
+      // before surfacing `unexpected_markup`, retry the same URL once via
+      // Browserbase (real Chrome) when configured. If Browserbase also
+      // returns zero cards, fall through to the existing error path.
+      if (added === 0 && page === pnrStep && process.env.BROWSERBASE_API_KEY) {
+        try {
+          throwIfAborted(signal);
+          const browserbaseHtml = await fetchViaBrowserbase(url, signal);
+          const reparsed = parseWerkzoekenListingCards(browserbaseHtml, config.baseUrl);
+          added = pushNewListings(reparsed);
+        } catch {
+          // Swallow — we fall through to the unexpected_markup branch below.
+        }
+      }
 
       if (added === 0) {
         if (page > pnrStep) {


### PR DESCRIPTION
## Summary
- Werkzoeken's `?pnr=10` listing page occasionally returns HTTP 200 with degraded markup — zero vacancy anchors parse, and we fail with `blockerKind=unexpected_markup`. The same URL usually works on the next run (500 `<h3>` and 4 JSON-LD blocks present on a live curl).
- Add a single Browserbase (real Chrome) retry when the direct fetch parses zero cards on the first pnr page and `BROWSERBASE_API_KEY` is configured. If Browserbase also yields zero cards, fall through to the existing `unexpected_markup` path.
- Missing `BROWSERBASE_API_KEY` falls through gracefully so CI/tests keep running against the direct-fetch path.
- Mirrors the session-reuse/Chrome-fallback pattern documented for MiPublic (see `docs/solutions/integration-issues/browserbase-session-reuse-siteguard-Scrapers-20260423.md`).

## Test plan
- [x] `pnpm vitest run tests/werkzoeken-scraper.test.ts` — 14/14 passing
- [x] `pnpm exec tsc --noEmit` — clean
- [x] Live smoke `runScrapePipeline('werkzoeken', ...)` — returns `{"jobsNew":7,"duplicates":493,"errors":[]}` (no `unexpected_markup`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
