### PR TITLE
test(interview-prep): update mock for AI SDK v6 tracedGenerateText

### DIFF
--- a/tests/interview-prep-generator.test.ts
+++ b/tests/interview-prep-generator.test.ts
@@ -2,13 +2,16 @@ import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
-  tracedGenerateObject,
+  tracedGenerateText,
   getJobById,
   getCandidateById,
   getMatchById,
   generateScreeningQuestions,
 } = vi.hoisted(() => ({
-  tracedGenerateObject: vi.fn(),
+  // Migrated from tracedGenerateObject to tracedGenerateText in the AI SDK v6
+  // migration — the source now calls tracedGenerateText with
+  // `output: Output.object({ schema })` and returns `.output` instead of `.object`.
+  tracedGenerateText: vi.fn(),
   getJobById: vi.fn(),
   getCandidateById: vi.fn(),
   getMatchById: vi.fn(),
@@ -17,7 +20,7 @@ const {
 
 vi.mock("../src/lib/ai-models", () => ({
   gemini31FlashLite: "gemini-3.1-flash-lite",
-  tracedGenerateObject,
+  tracedGenerateText,
   embeddingModel: "openai-embedding-model",
 }));
 
@@ -97,7 +100,7 @@ describe("generateInterviewPrep", () => {
       expect(result.recommendedQuestions.length).toBeGreaterThanOrEqual(3);
       expect(result.nextStep).toContain("3-5 verduidelijkende vragen");
     }
-    expect(tracedGenerateObject).not.toHaveBeenCalled();
+    expect(tracedGenerateText).not.toHaveBeenCalled();
   });
 
   it("uses live recruitment context and screening questions when enough detail is available", async () => {
@@ -130,8 +133,8 @@ describe("generateInterviewPrep", () => {
         priority: 0,
       },
     ]);
-    tracedGenerateObject.mockResolvedValue({
-      object: {
+    tracedGenerateText.mockResolvedValue({
+      output: {
         prepSummary: {
           interviewType: "screening",
           interviewGoal: "Toets sourcingdiepgang en stakeholderfit",
@@ -206,7 +209,7 @@ describe("generateInterviewPrep", () => {
     expect(result.status).toBe("ready");
     if (result.status !== "ready") throw new Error("Expected ready status");
     expect(generateScreeningQuestions).toHaveBeenCalledTimes(1);
-    expect(tracedGenerateObject).toHaveBeenCalledTimes(1);
+    expect(tracedGenerateText).toHaveBeenCalledTimes(1);
     expect(result.artifact.writebackPayload.linkedJobId).toBe(
       "11111111-1111-4111-8111-111111111111",
     );


### PR DESCRIPTION
Fixes the Test CI failure introduced by PR #235's v6 migration. The source was migrated but the vitest mock still stubbed the removed `tracedGenerateObject` export, producing `No "tracedGenerateText" export is defined on mock`. This PR swaps the mock name and result shape (`.object` → `.output`) to match the migrated source. 5/5 tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
