### PR TITLE
docs(sidebar): codify FilterChecklist vs CompactMultiSelectFilter rule (RJC-227)

### DIFF
--- a/components/sidebar/sidebar-filter-controls.tsx
+++ b/components/sidebar/sidebar-filter-controls.tsx
@@ -19,6 +19,20 @@ import type { FilterOption, ProvinceAnchor } from "./sidebar-types";
 import { DARK_FILTER_SECTION_LABEL_CLASS } from "./sidebar-types";
 import { summarizeSelection } from "./sidebar-utils";
 
+/**
+ * Renders every option as an inline `<input>` + `<label>` checkbox in the SSR HTML.
+ *
+ * **Only use for static lists with N <= 10 items** (e.g., status, contractType).
+ * For unbounded user-data lists (categories, regions, end-clients) prefer
+ * {@link CompactMultiSelectFilter} — its `DropdownMenu` only renders rows on
+ * open, so a 150-item list adds zero bytes to the initial SSR payload.
+ *
+ * Background: the /vacatures Vakgebied filter rendered ~150 categories inline
+ * via this component and shipped a single 57KB chunk (≈22% of the 263KB SSR
+ * HTML), causing a 1.2s avg / 2.2s tail cold load. See commit 4ae7f108
+ * ("perf(vacatures): collapse Vakgebied/Regio filter SSR + bump cache TTL")
+ * and Linear RJC-227 for the codified rule.
+ */
 export function FilterChecklist({
   idPrefix,
   options,


### PR DESCRIPTION
## Summary
- Adds a TSDoc warning above `FilterChecklist` in `components/sidebar/sidebar-filter-controls.tsx` so the next person who reaches for it knows it inlines every option in SSR HTML — fine for static N<=10 lists, dangerous for unbounded user-data lists.
- Points readers at `CompactMultiSelectFilter` (DropdownMenu, only mounts on open) for category/region/end-client style lists, and references commit `4ae7f108` + Linear RJC-227 for the failure mode.
- Docs/comments only — zero runtime impact, no deploy needed.

## Why
`/vacatures` cold load was 1.2s avg / 2.2s tail with 263KB SSR HTML. A single 57KB chunk was the Vakgebied filter SSR-rendering ~150 categories inline through `FilterChecklist`. Swapping to `CompactMultiSelectFilter` (commit 4ae7f108) fixed it. RJC-227 codifies the rule so the regression cannot recur silently.

## Test plan
- [x] `pnpm lint` — clean (Biome, 902 files)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] No code paths touched; comment-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
