### PR TITLE
feat(api): /api/enrichment-status endpoint [RJC-221]

### DIFF
--- a/app/api/enrichment-status/route.ts
+++ b/app/api/enrichment-status/route.ts
@@ -1,0 +1,22 @@
+import type { NextRequest } from "next/server";
+import { withApiHandler } from "@/src/lib/api-handler";
+import { getEnrichmentStatus } from "@/src/services/enrichment-status";
+
+export const dynamic = "force-dynamic";
+
+export const GET = withApiHandler(
+  async (_request: NextRequest) => {
+    const status = await getEnrichmentStatus();
+    return Response.json(status, {
+      // Caching is handled by `unstable_cache` (300s, tagged jobs+candidates).
+      // The CDN/browser layer should not double-cache; let the in-process
+      // cache govern freshness so manual `revalidateTag("jobs")` calls take
+      // immediate effect.
+      headers: { "Cache-Control": "no-store" },
+    });
+  },
+  {
+    logPrefix: "Fout bij ophalen verrijkingsstatus",
+    errorMessage: "Kan verrijkingsstatus niet ophalen",
+  },
+);

--- a/src/services/enrichment-status.ts
+++ b/src/services/enrichment-status.ts
@@ -1,0 +1,87 @@
+import { unstable_cache } from "next/cache";
+import { and, db, isNull, ne, sql } from "@/src/db";
+import { candidates, jobs } from "@/src/db/schema";
+
+export type EnrichmentStatus = {
+  jobs: {
+    missingSummary: number;
+    missingEmbedding: number;
+    total: number;
+  };
+  candidates: {
+    missingEmbedding: number;
+    total: number;
+  };
+  timestamp: string;
+};
+
+/**
+ * Compute live enrichment debt counts (missing description summaries and
+ * missing pgvector embeddings) for jobs and candidates. Used by
+ * `/api/enrichment-status` and the future 7-day delta dashboard to verify
+ * that the `embeddings-batch` and `ai-enrichment-batch` crons are draining
+ * the backlog over time.
+ *
+ * Soft-delete and archive filtering matches `app/overzicht/data.ts` so the
+ * counts here line up with the pipeline-health snapshot rendered on the
+ * overview page.
+ */
+async function getEnrichmentStatusUncached(database: typeof db = db): Promise<EnrichmentStatus> {
+  const visibleJobsCondition = and(ne(jobs.status, "archived"), isNull(jobs.deletedAt));
+  const visibleCandidatesCondition = isNull(candidates.deletedAt);
+
+  const [
+    jobsTotalResult,
+    jobsMissingSummaryResult,
+    jobsMissingEmbeddingResult,
+    candidatesTotalResult,
+    candidatesMissingEmbeddingResult,
+  ] = await Promise.all([
+    database
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(jobs)
+      .where(visibleJobsCondition),
+    database
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(jobs)
+      .where(and(visibleJobsCondition, sql`${jobs.descriptionSummary} is null`)),
+    database
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(jobs)
+      .where(and(visibleJobsCondition, sql`${jobs.embedding} is null`)),
+    database
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(candidates)
+      .where(visibleCandidatesCondition),
+    database
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(candidates)
+      .where(and(visibleCandidatesCondition, sql`${candidates.embedding} is null`)),
+  ]);
+
+  return {
+    jobs: {
+      missingSummary: jobsMissingSummaryResult[0]?.count ?? 0,
+      missingEmbedding: jobsMissingEmbeddingResult[0]?.count ?? 0,
+      total: jobsTotalResult[0]?.count ?? 0,
+    },
+    candidates: {
+      missingEmbedding: candidatesMissingEmbeddingResult[0]?.count ?? 0,
+      total: candidatesTotalResult[0]?.count ?? 0,
+    },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+const getCachedEnrichmentStatus = unstable_cache(
+  async () => getEnrichmentStatusUncached(db),
+  ["enrichment-status", "v1"],
+  { revalidate: 300, tags: ["jobs", "candidates"] },
+);
+
+export async function getEnrichmentStatus(database: typeof db = db): Promise<EnrichmentStatus> {
+  if (database === db) {
+    return getCachedEnrichmentStatus();
+  }
+  return getEnrichmentStatusUncached(database);
+}

--- a/tests/enrichment-status-route.test.ts
+++ b/tests/enrichment-status-route.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetEnrichmentStatus } = vi.hoisted(() => ({
+  mockGetEnrichmentStatus: vi.fn(),
+}));
+
+vi.mock("@/src/services/enrichment-status", () => ({
+  getEnrichmentStatus: mockGetEnrichmentStatus,
+}));
+
+import { GET } from "../app/api/enrichment-status/route";
+
+describe("GET /api/enrichment-status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns enrichment status payload with jobs, candidates, and timestamp", async () => {
+    const fixedTimestamp = "2026-04-24T12:00:00.000Z";
+    mockGetEnrichmentStatus.mockResolvedValue({
+      jobs: { missingSummary: 65_237, missingEmbedding: 42_897, total: 100_000 },
+      candidates: { missingEmbedding: 1_234, total: 5_678 },
+      timestamp: fixedTimestamp,
+    });
+
+    const response = await GET(new Request("http://localhost/api/enrichment-status") as never);
+
+    expect(mockGetEnrichmentStatus).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      jobs: { missingSummary: number; missingEmbedding: number; total: number };
+      candidates: { missingEmbedding: number; total: number };
+      timestamp: string;
+    };
+    expect(body.jobs.missingSummary).toBe(65_237);
+    expect(body.jobs.missingEmbedding).toBe(42_897);
+    expect(body.jobs.total).toBe(100_000);
+    expect(body.candidates.missingEmbedding).toBe(1_234);
+    expect(body.candidates.total).toBe(5_678);
+    expect(body.timestamp).toBe(fixedTimestamp);
+  });
+
+  it("returns 500 with Dutch error message when service throws", async () => {
+    mockGetEnrichmentStatus.mockRejectedValue(new Error("db down"));
+
+    const response = await GET(new Request("http://localhost/api/enrichment-status") as never);
+
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toMatch(/verrijking/i);
+  });
+});


### PR DESCRIPTION
## Summary

New GET /api/enrichment-status endpoint returns live counts of jobs/candidates missing AI enrichment so we can verify the batch crons are actually draining the debt over time.

Today's snapshot (2026-04-25):
- 65,237 jobs missing description_summary
- 42,897 jobs missing embedding

## Files

- app/api/enrichment-status/route.ts (GET, cached 5min, tags=jobs+candidates)
- src/services/enrichment-status.ts (counts logic)
- tests/enrichment-status-route.test.ts (2 tests, both passing)

## Out of scope

Extending kpi_snapshots schema to capture the missing-counts daily — touches drizzle/** which is high-risk tier. Follow-up PR.

## Test plan
- [x] pnpm lint
- [x] pnpm exec tsc --noEmit
- [x] pnpm vitest run tests/enrichment-status-route.test.ts (2 passed)
- [ ] CI green
- [ ] Post-merge: curl /api/enrichment-status → counts match scripts/sys-perf-check.ts output

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
