### PR TITLE
test: remove pre-existing-failures note (RJC-225)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,10 +43,9 @@ pnpm voice-agent:dev      # LiveKit voice agent (dev)
 pnpm harness:pre-pr       # lint + tsc + test + risk policy gate
 ```
 
-`pnpm lint` currently passes cleanly. `pnpm test` still has known pre-existing failures in
-`tests/autopilot-run-detail-evidence.test.ts`, `tests/opdrachten-filters-pagination.test.ts`,
-and `tests/harness/integration.test.ts`. Do not assume your changes caused them without
-reproducing, and do not "fix" them by reverting unrelated abstractions.
+`pnpm lint` and `pnpm test` should both pass cleanly. If you see failures, reproduce
+them on a clean checkout before assuming your changes caused them, and do not "fix"
+them by reverting unrelated abstractions.
 
 ## Architecture (big picture)
 


### PR DESCRIPTION
## Summary

Three tests previously documented as pre-existing failures all pass now. Removed the stale note from CLAUDE.md.

## Verification

- tests/autopilot-run-detail-evidence.test.ts ✓
- tests/opdrachten-filters-pagination.test.ts ✓ (fixed by RJC-222 contract updates earlier today, commit 7c23cea8)
- tests/harness/integration.test.ts ✓
- Full suite: **1559/1559 passing** locally

## Test plan
- [x] pnpm test → exit 0
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ryanlisse/motian/pull/241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
